### PR TITLE
[Frontend][Bug][2/2] Data Entry Form: Disaggregations Bug For Multi-System Agencies

### DIFF
--- a/publisher/src/components/Forms/TabbedDisaggregations.tsx
+++ b/publisher/src/components/Forms/TabbedDisaggregations.tsx
@@ -34,19 +34,10 @@ import {
 
 export const TabbedDisaggregations: React.FC<{
   metric: MetricType;
-  reportMetrics: MetricType[];
   reportID: number;
-  currentIndex: number;
   disabled?: boolean;
   updateFieldDescription: (title?: string, description?: string) => void;
-}> = ({
-  metric,
-  reportMetrics,
-  reportID,
-  currentIndex,
-  disabled,
-  updateFieldDescription,
-}) => {
+}> = ({ metric, reportID, disabled, updateFieldDescription }) => {
   const [activeDisaggregation, setActiveDisaggregation] = useState<{
     [metricKey: string]: {
       disaggregationKey: string;
@@ -99,21 +90,21 @@ export const TabbedDisaggregations: React.FC<{
     let inputFoundInUpdate = false;
     let inputFoundFromLastSave = false;
 
-    reportMetrics[currentIndex]?.disaggregations[
-      disaggregationIndex
-    ]?.dimensions?.forEach((dimension) => {
-      const updatedDimensionValue =
-        formStore.disaggregations[reportID]?.[metric.key]?.[
-          disaggregationKey
-        ]?.[dimension.key]?.value;
+    metric?.disaggregations[disaggregationIndex]?.dimensions?.forEach(
+      (dimension) => {
+        const updatedDimensionValue =
+          formStore.disaggregations[reportID]?.[metric.key]?.[
+            disaggregationKey
+          ]?.[dimension.key]?.value;
 
-      if (
-        dimension.value &&
-        !inputFoundFromLastSave &&
-        updatedDimensionValue !== ""
-      )
-        inputFoundFromLastSave = true;
-    });
+        if (
+          dimension.value &&
+          !inputFoundFromLastSave &&
+          updatedDimensionValue !== ""
+        )
+          inputFoundFromLastSave = true;
+      }
+    );
 
     if (
       formStore.disaggregations[reportID]?.[metric.key]?.[disaggregationKey]
@@ -225,7 +216,7 @@ export const TabbedDisaggregations: React.FC<{
       </TabsRow>
 
       <TabDisplay>
-        {reportMetrics[currentIndex].disaggregations[
+        {metric.disaggregations[
           activeDisaggregation[metric.key]?.disaggregationIndex || 0
         ]?.dimensions.map((dimension, dimensionIndex) => {
           const activeDisaggregationOrZerothIndex =

--- a/publisher/src/components/Reports/DataEntryForm.tsx
+++ b/publisher/src/components/Reports/DataEntryForm.tsx
@@ -309,8 +309,6 @@ const DataEntryForm: React.FC<{
                         {metric.disaggregations.length > 0 && (
                           <TabbedDisaggregations
                             reportID={reportID}
-                            currentIndex={index}
-                            reportMetrics={reportMetrics}
                             metric={metric}
                             updateFieldDescription={updateFieldDescription}
                             disabled={isPublished || hasVersionConflict}


### PR DESCRIPTION
## Description of the change

This removes all `index` and `reportMetric[index]` references to a metric within the `TabbedDisaggregations` component. Prior to organizing metrics by system, the disaggregation tabs referenced a metric by its index for speedy access. Since that is no longer necessary, we can pass the current `metric` directly to the `TabbedDisaggregations` component to render the appropriate disaggregation tabs for each metric.

## Related issues

Closes #15207

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
