### PR TITLE
[Frontend] Data Upload: Error/Warning Page

### DIFF
--- a/publisher/src/components/DataUpload/DataUpload.styles.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.styles.tsx
@@ -34,7 +34,8 @@ const ROW_HEIGHT = 42;
 export const DataUploadContainer = styled.div`
   width: 100%;
   height: 100%;
-  position: absolute;
+  position: fixed;
+  overflow-y: scroll;
   top: 0;
   z-index: 5;
   background: ${palette.solid.white};
@@ -149,6 +150,30 @@ export const ButtonWrapper = styled.div`
   flex-wrap: wrap;
   gap: 10px;
   margin: 13px 0;
+`;
+
+export const UploadErrorButtonWrapper = styled(ButtonWrapper)`
+  width: 100%;
+  justify-content: space-between;
+
+  div:not(:last-child) {
+    background: transparent;
+    border: 1px solid ${palette.highlight.grey4};
+    border-radius: 4px;
+
+    &:hover {
+      background: ${palette.highlight.grey2};
+    }
+  }
+
+  div:last-child {
+    background: ${palette.solid.blue};
+    color: ${palette.solid.white};
+
+    &:hover {
+      opacity: 0.9;
+    }
+  }
 `;
 
 export type ButtonTypes =

--- a/publisher/src/components/DataUpload/DataUpload.styles.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.styles.tsx
@@ -380,10 +380,6 @@ export const UserPromptWrapper = styled.div`
 
 export const UserPromptTitle = styled.div`
   ${typography.sizeCSS.title};
-
-  span {
-    color: ${palette.solid.red};
-  }
 `;
 
 export const UserPromptDescription = styled.div`

--- a/publisher/src/components/DataUpload/DataUpload.styles.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.styles.tsx
@@ -521,3 +521,11 @@ export const ExtendedLabelCell = styled(LabelCell)`
     flex: 4 1 auto;
   }
 `;
+
+export const RedText = styled.span`
+  color: ${palette.solid.red};
+`;
+
+export const OrangeText = styled.span`
+  color: ${palette.solid.orange};
+`;

--- a/publisher/src/components/DataUpload/DataUpload.styles.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.styles.tsx
@@ -406,8 +406,19 @@ export const UserPromptError = styled.div`
 
 export const MetricTitle = styled.div`
   ${typography.sizeCSS.large};
+  display: flex;
+  align-items: center;
   border-top: 1px solid ${palette.highlight.grey4};
   padding: 16px 0;
+
+  span {
+    ${typography.sizeCSS.normal};
+    color: ${palette.highlight.grey9};
+    padding: 2px 10px;
+    border: 1px solid ${palette.highlight.grey5};
+    border-radius: 2px;
+    margin-left: 10px;
+  }
 `;
 
 export const ErrorIconWrapper = styled.div`

--- a/publisher/src/components/DataUpload/DataUpload.styles.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.styles.tsx
@@ -355,6 +355,10 @@ export const UserPromptWrapper = styled.div`
 
 export const UserPromptTitle = styled.div`
   ${typography.sizeCSS.title};
+
+  span {
+    color: ${palette.solid.red};
+  }
 `;
 
 export const UserPromptDescription = styled.div`

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -115,9 +115,9 @@ export const DataUpload: React.FC = observer(() => {
         return showToast("Failed to upload. Please try again.", false, "red");
       }
 
-      /** Handle Pre-Ingest Errors and Metric Errors */
+      /** Errors and/or Warnings Encountered During Upload -- Show Interstitial instead of Confirmation Page */
       const data = await response?.json();
-      const errors = handleUploadErrors(
+      const errors = processUploadErrors(
         data.metrics,
         data.upload_errors?.length ? data.upload_errors : undefined
       );
@@ -132,7 +132,6 @@ export const DataUpload: React.FC = observer(() => {
 
       /** Successful Upload - Proceed To Confirmation Page */
       /** (TODO(#15195): Placeholder - toast will be removed and this should navigate to the confirmation component */
-
       showToast(
         "File uploaded successfully and is pending processing by a Justice Counts administrator.",
         true,
@@ -143,7 +142,7 @@ export const DataUpload: React.FC = observer(() => {
     }
   };
 
-  const handleUploadErrors = (
+  const processUploadErrors = (
     metrics: {
       datapoints: [];
       display_name: string;

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -204,7 +204,7 @@ export const DataUpload: React.FC = observer(() => {
 
   const renderCurrentUploadStep = (): JSX.Element => {
     /**
-     * There are ~3 steps in the upload phase before reaching the metrics confirmation page.
+     * There are ~4 steps in the upload phase before reaching the metrics confirmation page.
      *
      * Step 1: Upload File
      * Trigger: no selected file and no upload error(s)/warnings(s) present in server response
@@ -212,8 +212,13 @@ export const DataUpload: React.FC = observer(() => {
      * Step 2: System Selection (only for agencies with multiple systems)
      * Trigger: file selected AND no system selected
      *
+     * Once a file and system have been selected, a loading page renders that will resolve into Step 3 or Step 4.
+     *
      * Step 3: Upload Errors/Warnings
      * Trigger: upload error(s)/warnings(s) present in server response
+     *
+     * Step 4: Navigate to Confirmation Page
+     * Trigger: file selected AND system selected AND no errors
      */
 
     if (selectedFile && !selectedSystem) {

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -16,39 +16,23 @@
 // =============================================================================
 
 import { observer } from "mobx-react-lite";
-import React, { Fragment, useState } from "react";
+import React, { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { AgencySystems } from "../../shared/types";
 import { useStore } from "../../stores";
-import { removeSnakeCase } from "../../utils";
-import { ReactComponent as ErrorIcon } from "../assets/error-icon.svg";
 import logoImg from "../assets/jc-logo-vector.png";
-import { ReactComponent as WarningIcon } from "../assets/warning-icon.svg";
 import { Logo, LogoContainer } from "../Header";
 import { Loading } from "../Loading";
 import { showToast } from "../Toast";
 import {
   Button,
-  ButtonWrapper,
   DataUploadContainer,
   DataUploadHeader,
-  ErrorAdditionalInfo,
-  ErrorIconWrapper,
-  ErrorMessageDescription,
-  ErrorMessageTitle,
-  ErrorMessageWrapper,
-  FileName,
-  MetricTitle,
   SystemSelection,
   UploadFile,
-  UserPromptContainer,
-  UserPromptDescription,
-  UserPromptError,
-  UserPromptErrorContainer,
-  UserPromptTitle,
-  UserPromptWrapper,
 } from ".";
+import { UploadErrorsWarnings } from "./UploadErrorsWarnings";
 
 export type UploadedFileStatus = "UPLOADED" | "INGESTED" | "ERRORED";
 
@@ -105,7 +89,6 @@ export const DataUpload: React.FC = observer(() => {
     ) || [];
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [uploadError, setUploadError] = useState<boolean>(false);
   const [errorsAndWarnings, setErrorsAndWarnings] =
     useState<ErrorsAndWarnings>();
   const [selectedFile, setSelectedFile] = useState<File>();
@@ -150,14 +133,15 @@ export const DataUpload: React.FC = observer(() => {
     }
   };
 
+  // eslint-disable @typescript-eslint/no-explicit-any
   const handleUploadErrors = (metrics: any) => {
     const errors = metrics.reduce(
-      (acc, metric) => [...acc, ...metric.sheets],
+      (acc: any, metric: any) => [...acc, ...metric.sheets],
       []
     );
     const errorCount = errors.reduce(
-      (acc, sheet) => {
-        sheet.messages.forEach((msg) => {
+      (acc: any, sheet: any) => {
+        sheet.messages.forEach((msg: any) => {
           if (msg.type === "ERROR") acc.errorCount += 1;
           if (msg.type === "WARNING") acc.warningCount += 1;
         });
@@ -215,72 +199,12 @@ export const DataUpload: React.FC = observer(() => {
 
     /** Upload Error/Warnings Step */
     if (errorsAndWarnings?.errorCount) {
-      const systemFileName =
-        selectedSystem && systemToTemplateSpreadsheetFileName[selectedSystem];
-
       return (
-        <UserPromptContainer>
-          <UserPromptWrapper>
-            <UserPromptTitle>
-              Uh oh, we found <span>{errorsAndWarnings?.errorCount}</span>{" "}
-              errors.
-            </UserPromptTitle>
-            <UserPromptDescription>
-              We ran into a few discrepancies between the uploaded data and the
-              Justice Counts format for the{" "}
-              <span>
-                <a
-                  href={`./assets/${systemFileName}`}
-                  download={systemFileName}
-                >
-                  {selectedSystem &&
-                    removeSnakeCase(selectedSystem).toLowerCase()}
-                </a>
-              </span>{" "}
-              system. To continue, please resolve the errors in your file and
-              reupload.
-            </UserPromptDescription>
-
-            <ButtonWrapper>
-              <Button
-                type="blue"
-                onClick={() => setErrorsAndWarnings(undefined)}
-              >
-                New Upload
-              </Button>
-            </ButtonWrapper>
-
-            <UserPromptErrorContainer>
-              {errorsAndWarnings?.errors.map((sheet: any) => (
-                <UserPromptError key={sheet.display_name}>
-                  <MetricTitle>{sheet.display_name}</MetricTitle>
-
-                  {sheet.messages?.map((message: any) => (
-                    <Fragment key={message.title + message.description}>
-                      <ErrorIconWrapper>
-                        {message.type === "ERROR" ? (
-                          <ErrorIcon />
-                        ) : (
-                          <WarningIcon />
-                        )}
-
-                        <ErrorMessageWrapper>
-                          <ErrorMessageTitle>{message.title}</ErrorMessageTitle>
-                          <ErrorMessageDescription>
-                            {message.subtitle}
-                          </ErrorMessageDescription>
-                        </ErrorMessageWrapper>
-                      </ErrorIconWrapper>
-                      <ErrorAdditionalInfo>
-                        {message.description}
-                      </ErrorAdditionalInfo>
-                    </Fragment>
-                  ))}
-                </UserPromptError>
-              ))}
-            </UserPromptErrorContainer>
-          </UserPromptWrapper>
-        </UserPromptContainer>
+        <UploadErrorsWarnings
+          errorsAndWarnings={errorsAndWarnings}
+          setErrorsAndWarnings={setErrorsAndWarnings}
+          selectedSystem={selectedSystem}
+        />
       );
     }
 

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -154,7 +154,7 @@ export const DataUpload: React.FC = observer(() => {
                     "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
                     "subtitle": "race/ethnicity",
                     "title": "Missing Column",
-                    "type": "WARNING"
+                    "type": "ERROR"
                   }
                 ],
                 "sheet_name": "arrests_by_race"

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -116,92 +116,95 @@ export const DataUpload: React.FC = observer(() => {
       }
 
       const data = await response?.json();
-      const mockData = JSON.parse(`{
-        "metrics": [
-          {
-            "datapoints": [],
-            "display_name": "Total Arrests",
-            "key": "LAW_ENFORCEMENT_ARRESTS_global/gender/restricted,global/race_and_ethnicity,metric/law_enforcement/reported_crime/type",
-            "sheets": [
-              {
-                "display_name": "Arrests",
-                "messages": [
-                  {
-                    "description": "There should only be a single row containing data for arrests in 6/2021.",
-                    "subtitle": "6/2021",
-                    "title": "Too Many Rows",
-                    "type": "WARNING"
-                  }
-                ],
-                "sheet_name": "arrests"
-              },
-              {
-                "display_name": "Arrests By Race",
-                "messages": [
-                  {
-                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
-                    "subtitle": "race/ethnicity",
-                    "title": "Missing Column",
-                    "type": "WARNING"
-                  },
-                  {
-                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
-                    "subtitle": "race/ethnicity",
-                    "title": "Missing Column",
-                    "type": "WARNING"
-                  },
-                  {
-                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
-                    "subtitle": "race/ethnicity",
-                    "title": "Missing Column",
-                    "type": "ERROR"
-                  }
-                ],
-                "sheet_name": "arrests_by_race"
-              }
-            ]
-          },
-          {
-            "datapoints": [],
-            "display_name": "Different Metric",
-            "key": "LAW_ENFORCEMENT_ARRESTS_global/gender/restricted,global/race_and_ethnicity,metric/law_enforcement/reported_crime/type",
-            "sheets": [
-              {
-                "display_name": "Different Metric Arrests",
-                "messages": [
-                  {
-                    "description": "There should only be a single row containing data for arrests in 6/2021.",
-                    "subtitle": "6/2021",
-                    "title": "Too Many Rows",
-                    "type": "ERROR"
-                  }
-                ],
-                "sheet_name": "arrests"
-              },
-              {
-                "display_name": "Different Metric Arrests By Race",
-                "messages": [
-                  {
-                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
-                    "subtitle": "race/ethnicity",
-                    "title": "Missing Column",
-                    "type": "WARNING"
-                  },
-                  {
-                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
-                    "subtitle": "race/ethnicity",
-                    "title": "Missing Column",
-                    "type": "WARNING"
-                  }
-                ],
-                "sheet_name": "arrests_by_race"
-              }
-            ]
-          }
-        ],
-        "upload_errors": []
-      }`);
-      const sheetErrors = handleUploadErrors(mockData.metrics);
+      // const mockData = JSON.parse(`{
+      //   "metrics": [
+      //     {
+      //       "datapoints": [],
+      //       "display_name": "Total Arrests",
+      //       "key": "LAW_ENFORCEMENT_ARRESTS_global/gender/restricted,global/race_and_ethnicity,metric/law_enforcement/reported_crime/type",
+      //       "sheets": [
+      //         {
+      //           "display_name": "Arrests",
+      //           "messages": [
+      //             {
+      //               "description": "There should only be a single row containing data for arrests in 6/2021.",
+      //               "subtitle": "6/2021",
+      //               "title": "Too Many Rows",
+      //               "type": "WARNING"
+      //             }
+      //           ],
+      //           "sheet_name": "arrests"
+      //         },
+      //         {
+      //           "display_name": "Arrests By Race",
+      //           "messages": [
+      //             {
+      //               "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
+      //               "subtitle": "race/ethnicity",
+      //               "title": "Missing Column",
+      //               "type": "WARNING"
+      //             },
+      //             {
+      //               "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
+      //               "subtitle": "race/ethnicity",
+      //               "title": "Missing Column",
+      //               "type": "WARNING"
+      //             },
+      //             {
+      //               "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
+      //               "subtitle": "race/ethnicity",
+      //               "title": "Missing Column",
+      //               "type": "ERROR"
+      //             }
+      //           ],
+      //           "sheet_name": "arrests_by_race"
+      //         }
+      //       ]
+      //     },
+      //     {
+      //       "datapoints": [],
+      //       "display_name": "Different Metric",
+      //       "key": "LAW_ENFORCEMENT_ARRESTS_global/gender/restricted,global/race_and_ethnicity,metric/law_enforcement/reported_crime/type",
+      //       "sheets": [
+      //         {
+      //           "display_name": "Different Metric Arrests",
+      //           "messages": [
+      //             {
+      //               "description": "There should only be a single row containing data for arrests in 6/2021.",
+      //               "subtitle": "6/2021",
+      //               "title": "Too Many Rows",
+      //               "type": "ERROR"
+      //             }
+      //           ],
+      //           "sheet_name": "arrests"
+      //         },
+      //         {
+      //           "display_name": "Different Metric Arrests By Race",
+      //           "messages": [
+      //             {
+      //               "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
+      //               "subtitle": "race/ethnicity",
+      //               "title": "Missing Column",
+      //               "type": "WARNING"
+      //             },
+      //             {
+      //               "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
+      //               "subtitle": "race/ethnicity",
+      //               "title": "Missing Column",
+      //               "type": "WARNING"
+      //             }
+      //           ],
+      //           "sheet_name": "arrests_by_race"
+      //         }
+      //       ]
+      //     }
+      //   ],
+      //   "upload_errors": []
+      // }`);
+      const sheetErrors = handleUploadErrors(
+        data.metrics,
+        data.upload_errors.length ? data.upload_errors : undefined
+      );
       setErrorsAndWarnings(sheetErrors);
       setIsLoading(false);
 
@@ -219,7 +222,15 @@ export const DataUpload: React.FC = observer(() => {
   };
 
   // eslint-disable @typescript-eslint/no-explicit-any
-  const handleUploadErrors = (metrics: any) => {
+  const handleUploadErrors = (metrics: any, uploadErrors?: any) => {
+    if (uploadErrors) {
+      return {
+        errorCount: uploadErrors.length,
+        warningCount: 0,
+        errors: uploadErrors,
+      };
+    }
+
     const errors = metrics.reduce(
       (acc: any, metric: any) => [...acc, ...metric.sheets],
       []
@@ -292,7 +303,6 @@ export const DataUpload: React.FC = observer(() => {
       return (
         <UploadErrorsWarnings
           errorsAndWarnings={errorsAndWarnings}
-          setErrorsAndWarnings={setErrorsAndWarnings}
           selectedSystem={selectedSystem}
           resetToNewUpload={resetToNewUpload}
         />

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -55,7 +55,7 @@ export type UploadedFile = {
 export type ErrorsAndWarnings = {
   errorCount: number;
   warningCount: number;
-  errors: {}[];
+  errors: Record<string, unknown>[];
 };
 
 /**
@@ -282,7 +282,7 @@ export const DataUpload: React.FC = observer(() => {
     }
 
     /** Upload Error/Warnings Step */
-    if (errorsAndWarnings?.errorCount || errorsAndWarnings?.warningCount) {
+    if (errorsAndWarnings?.errors.length) {
       return (
         <UploadErrorsWarnings
           errorsAndWarnings={errorsAndWarnings}

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -52,10 +52,28 @@ export type UploadedFile = {
   status: UploadedFileStatus | null;
 };
 
-export type ErrorsAndWarnings = {
+export type ErrorWarningMessage = {
+  title: string;
+  subtitle: string;
+  description: string;
+  type: "ERROR" | "WARNING";
+};
+
+export type MetricErrors = {
+  display_name: string;
+  sheet_name: string;
+  messages: ErrorWarningMessage[];
+};
+
+export type MetricErrorsWarnings = {
   errorCount: number;
   warningCount: number;
-  errors: Record<string, unknown>[];
+  metricErrors: MetricErrors[];
+};
+
+export type PreIngestErrors = {
+  errorCount: number;
+  messages: ErrorWarningMessage[];
 };
 
 /**
@@ -89,8 +107,9 @@ export const DataUpload: React.FC = observer(() => {
     ) || [];
 
   const [isLoading, setIsLoading] = useState<boolean>(false);
-  const [errorsAndWarnings, setErrorsAndWarnings] =
-    useState<ErrorsAndWarnings>();
+  const [errorsAndWarnings, setErrorsAndWarnings] = useState<
+    MetricErrorsWarnings | PreIngestErrors
+  >();
   const [selectedFile, setSelectedFile] = useState<File>();
   const [selectedSystem, setSelectedSystem] = useState<
     AgencySystems | undefined
@@ -116,101 +135,109 @@ export const DataUpload: React.FC = observer(() => {
       }
 
       const data = await response?.json();
-      // const mockData = JSON.parse(`{
-      //   "metrics": [
-      //     {
-      //       "datapoints": [],
-      //       "display_name": "Total Arrests",
-      //       "key": "LAW_ENFORCEMENT_ARRESTS_global/gender/restricted,global/race_and_ethnicity,metric/law_enforcement/reported_crime/type",
-      //       "sheets": [
-      //         {
-      //           "display_name": "Arrests",
-      //           "messages": [
-      //             {
-      //               "description": "There should only be a single row containing data for arrests in 6/2021.",
-      //               "subtitle": "6/2021",
-      //               "title": "Too Many Rows",
-      //               "type": "WARNING"
-      //             }
-      //           ],
-      //           "sheet_name": "arrests"
-      //         },
-      //         {
-      //           "display_name": "Arrests By Race",
-      //           "messages": [
-      //             {
-      //               "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
-      //               "subtitle": "race/ethnicity",
-      //               "title": "Missing Column",
-      //               "type": "WARNING"
-      //             },
-      //             {
-      //               "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
-      //               "subtitle": "race/ethnicity",
-      //               "title": "Missing Column",
-      //               "type": "WARNING"
-      //             },
-      //             {
-      //               "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
-      //               "subtitle": "race/ethnicity",
-      //               "title": "Missing Column",
-      //               "type": "ERROR"
-      //             }
-      //           ],
-      //           "sheet_name": "arrests_by_race"
-      //         }
-      //       ]
-      //     },
-      //     {
-      //       "datapoints": [],
-      //       "display_name": "Different Metric",
-      //       "key": "LAW_ENFORCEMENT_ARRESTS_global/gender/restricted,global/race_and_ethnicity,metric/law_enforcement/reported_crime/type",
-      //       "sheets": [
-      //         {
-      //           "display_name": "Different Metric Arrests",
-      //           "messages": [
-      //             {
-      //               "description": "There should only be a single row containing data for arrests in 6/2021.",
-      //               "subtitle": "6/2021",
-      //               "title": "Too Many Rows",
-      //               "type": "ERROR"
-      //             }
-      //           ],
-      //           "sheet_name": "arrests"
-      //         },
-      //         {
-      //           "display_name": "Different Metric Arrests By Race",
-      //           "messages": [
-      //             {
-      //               "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
-      //               "subtitle": "race/ethnicity",
-      //               "title": "Missing Column",
-      //               "type": "WARNING"
-      //             },
-      //             {
-      //               "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
-      //               "subtitle": "race/ethnicity",
-      //               "title": "Missing Column",
-      //               "type": "WARNING"
-      //             }
-      //           ],
-      //           "sheet_name": "arrests_by_race"
-      //         }
-      //       ]
-      //     }
-      //   ],
-      //   "upload_errors": []
-      // }`);
-      const sheetErrors = handleUploadErrors(
+      const mockData = JSON.parse(`{
+        "metrics": [
+          {
+            "datapoints": [],
+            "display_name": "Total Arrests",
+            "key": "LAW_ENFORCEMENT_ARRESTS_global/gender/restricted,global/race_and_ethnicity,metric/law_enforcement/reported_crime/type",
+            "sheets": [
+              {
+                "display_name": "Arrests",
+                "messages": [
+                  {
+                    "description": "There should only be a single row containing data for arrests in 6/2021.",
+                    "subtitle": "6/2021",
+                    "title": "Too Many Rows",
+                    "type": "WARNING"
+                  }
+                ],
+                "sheet_name": "arrests"
+              },
+              {
+                "display_name": "Arrests By Race",
+                "messages": [
+                  {
+                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
+                    "subtitle": "race/ethnicity",
+                    "title": "Missing Column",
+                    "type": "WARNING"
+                  },
+                  {
+                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
+                    "subtitle": "race/ethnicity",
+                    "title": "Missing Column",
+                    "type": "WARNING"
+                  },
+                  {
+                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
+                    "subtitle": "race/ethnicity",
+                    "title": "Missing Column",
+                    "type": "WARNING"
+                  }
+                ],
+                "sheet_name": "arrests_by_race"
+              }
+            ]
+          },
+          {
+            "datapoints": [],
+            "display_name": "Different Metric",
+            "key": "LAW_ENFORCEMENT_ARRESTS_global/gender/restricted,global/race_and_ethnicity,metric/law_enforcement/reported_crime/type",
+            "sheets": [
+              {
+                "display_name": "Different Metric Arrests",
+                "messages": [
+                  {
+                    "description": "There should only be a single row containing data for arrests in 6/2021.",
+                    "subtitle": "6/2021",
+                    "title": "Too Many Rows",
+                    "type": "WARNING"
+                  }
+                ],
+                "sheet_name": "arrests"
+              },
+              {
+                "display_name": "Different Metric Arrests By Race",
+                "messages": [
+                  {
+                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
+                    "subtitle": "race/ethnicity",
+                    "title": "Missing Column",
+                    "type": "WARNING"
+                  },
+                  {
+                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
+                    "subtitle": "race/ethnicity",
+                    "title": "Missing Column",
+                    "type": "WARNING"
+                  }
+                ],
+                "sheet_name": "arrests_by_race"
+              }
+            ]
+          }
+        ],
+        "upload_errors": []
+      }`);
+
+      /** Handle Pre-Ingest Errors and Metric Errors */
+      const errors = handleUploadErrors(
         data.metrics,
-        data.upload_errors.length ? data.upload_errors : undefined
+        data.upload_errors?.length ? data.upload_errors : undefined
       );
-      setErrorsAndWarnings(sheetErrors);
       setIsLoading(false);
 
-      if (sheetErrors.errors.length) return;
+      if (
+        errors.errorCount ||
+        ("warningCount" in errors && errors.warningCount)
+      ) {
+        return setErrorsAndWarnings(errors);
+      }
 
+      /** Successful Upload - Proceed To Confirmation Page */
       /** (TODO(#15195): Placeholder - toast will be removed and this should navigate to the confirmation component */
+
       showToast(
         "File uploaded successfully and is pending processing by a Justice Counts administrator.",
         true,
@@ -221,23 +248,30 @@ export const DataUpload: React.FC = observer(() => {
     }
   };
 
-  // eslint-disable @typescript-eslint/no-explicit-any
-  const handleUploadErrors = (metrics: any, uploadErrors?: any) => {
-    if (uploadErrors) {
+  const handleUploadErrors = (
+    metrics: {
+      datapoints: [];
+      display_name: string;
+      key: string;
+      sheets: MetricErrors[];
+      upload_errors: PreIngestErrors["messages"];
+    }[],
+    preIngestErrorMessages?: PreIngestErrors["messages"]
+  ): MetricErrorsWarnings | PreIngestErrors => {
+    if (preIngestErrorMessages) {
       return {
-        errorCount: uploadErrors.length,
-        warningCount: 0,
-        errors: uploadErrors,
+        errorCount: preIngestErrorMessages.length,
+        messages: preIngestErrorMessages,
       };
     }
 
-    const errors = metrics.reduce(
-      (acc: any, metric: any) => [...acc, ...metric.sheets],
-      []
+    const metricErrors = metrics.reduce(
+      (acc, metric) => [...acc, ...metric.sheets],
+      [] as MetricErrors[]
     );
-    const errorCount = errors.reduce(
-      (acc: any, sheet: any) => {
-        sheet.messages.forEach((msg: any) => {
+    const errorWarningCount = metricErrors.reduce(
+      (acc, sheet) => {
+        sheet.messages.forEach((msg) => {
           if (msg.type === "ERROR") acc.errorCount += 1;
           if (msg.type === "WARNING") acc.warningCount += 1;
         });
@@ -249,7 +283,7 @@ export const DataUpload: React.FC = observer(() => {
       }
     );
 
-    return { errors, ...errorCount };
+    return { metricErrors, ...errorWarningCount };
   };
 
   const handleSystemSelection = (file: File, system: AgencySystems) => {
@@ -299,7 +333,7 @@ export const DataUpload: React.FC = observer(() => {
     }
 
     /** Upload Error/Warnings Step */
-    if (errorsAndWarnings?.errors.length) {
+    if (errorsAndWarnings) {
       return (
         <UploadErrorsWarnings
           errorsAndWarnings={errorsAndWarnings}
@@ -322,19 +356,13 @@ export const DataUpload: React.FC = observer(() => {
 
   return (
     <DataUploadContainer>
-      <DataUploadHeader
-        transparent={!selectedFile && !errorsAndWarnings?.errors.length}
-      >
+      <DataUploadHeader transparent={!selectedFile && !errorsAndWarnings}>
         <LogoContainer onClick={() => navigate("/")}>
           <Logo src={logoImg} alt="" />
         </LogoContainer>
 
         <Button
-          type={
-            selectedFile || errorsAndWarnings?.errors.length
-              ? "red"
-              : "light-border"
-          }
+          type={selectedFile || errorsAndWarnings ? "red" : "light-border"}
           onClick={() => navigate(-1)}
         >
           Cancel

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -32,7 +32,12 @@ import {
   SystemSelection,
   UploadFile,
 } from ".";
-import { UploadErrorsWarnings } from "./UploadErrorsWarnings";
+import {
+  MetricErrors,
+  MetricErrorsWarnings,
+  PreIngestErrors,
+  UploadErrorsWarnings,
+} from "./UploadErrorsWarnings";
 
 export type UploadedFileStatus = "UPLOADED" | "INGESTED" | "ERRORED";
 
@@ -50,30 +55,6 @@ export type UploadedFile = {
   uploaded_by: string;
   system: AgencySystems;
   status: UploadedFileStatus | null;
-};
-
-export type ErrorWarningMessage = {
-  title: string;
-  subtitle: string;
-  description: string;
-  type: "ERROR" | "WARNING";
-};
-
-export type MetricErrors = {
-  display_name: string;
-  sheet_name: string;
-  messages: ErrorWarningMessage[];
-};
-
-export type MetricErrorsWarnings = {
-  errorCount: number;
-  warningCount: number;
-  metricErrors: MetricErrors[];
-};
-
-export type PreIngestErrors = {
-  errorCount: number;
-  messages: ErrorWarningMessage[];
 };
 
 /**
@@ -134,94 +115,8 @@ export const DataUpload: React.FC = observer(() => {
         return showToast("Failed to upload. Please try again.", false, "red");
       }
 
-      const data = await response?.json();
-      const mockData = JSON.parse(`{
-        "metrics": [
-          {
-            "datapoints": [],
-            "display_name": "Total Arrests",
-            "key": "LAW_ENFORCEMENT_ARRESTS_global/gender/restricted,global/race_and_ethnicity,metric/law_enforcement/reported_crime/type",
-            "sheets": [
-              {
-                "display_name": "Arrests",
-                "messages": [
-                  {
-                    "description": "There should only be a single row containing data for arrests in 6/2021.",
-                    "subtitle": "6/2021",
-                    "title": "Too Many Rows",
-                    "type": "WARNING"
-                  }
-                ],
-                "sheet_name": "arrests"
-              },
-              {
-                "display_name": "Arrests By Race",
-                "messages": [
-                  {
-                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
-                    "subtitle": "race/ethnicity",
-                    "title": "Missing Column",
-                    "type": "WARNING"
-                  },
-                  {
-                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
-                    "subtitle": "race/ethnicity",
-                    "title": "Missing Column",
-                    "type": "WARNING"
-                  },
-                  {
-                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
-                    "subtitle": "race/ethnicity",
-                    "title": "Missing Column",
-                    "type": "WARNING"
-                  }
-                ],
-                "sheet_name": "arrests_by_race"
-              }
-            ]
-          },
-          {
-            "datapoints": [],
-            "display_name": "Different Metric",
-            "key": "LAW_ENFORCEMENT_ARRESTS_global/gender/restricted,global/race_and_ethnicity,metric/law_enforcement/reported_crime/type",
-            "sheets": [
-              {
-                "display_name": "Different Metric Arrests",
-                "messages": [
-                  {
-                    "description": "There should only be a single row containing data for arrests in 6/2021.",
-                    "subtitle": "6/2021",
-                    "title": "Too Many Rows",
-                    "type": "WARNING"
-                  }
-                ],
-                "sheet_name": "arrests"
-              },
-              {
-                "display_name": "Different Metric Arrests By Race",
-                "messages": [
-                  {
-                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
-                    "subtitle": "race/ethnicity",
-                    "title": "Missing Column",
-                    "type": "WARNING"
-                  },
-                  {
-                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
-                    "subtitle": "race/ethnicity",
-                    "title": "Missing Column",
-                    "type": "WARNING"
-                  }
-                ],
-                "sheet_name": "arrests_by_race"
-              }
-            ]
-          }
-        ],
-        "upload_errors": []
-      }`);
-
       /** Handle Pre-Ingest Errors and Metric Errors */
+      const data = await response?.json();
       const errors = handleUploadErrors(
         data.metrics,
         data.upload_errors?.length ? data.upload_errors : undefined

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -248,6 +248,12 @@ export const DataUpload: React.FC = observer(() => {
     setSelectedFile(undefined);
   };
 
+  const resetToNewUpload = () => {
+    setErrorsAndWarnings(undefined);
+    setSelectedFile(undefined);
+    setSelectedSystem(userSystems.length === 1 ? userSystems[0] : undefined);
+  };
+
   if (isLoading) {
     return (
       <DataUploadContainer>
@@ -288,6 +294,7 @@ export const DataUpload: React.FC = observer(() => {
           errorsAndWarnings={errorsAndWarnings}
           setErrorsAndWarnings={setErrorsAndWarnings}
           selectedSystem={selectedSystem}
+          resetToNewUpload={resetToNewUpload}
         />
       );
     }

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -173,8 +173,7 @@ export const DataUpload: React.FC = observer(() => {
 
   const renderCurrentUploadStep = (): JSX.Element => {
     /**
-     * There are ~3 steps in the upload phase before
-     * reaching the metrics confirmation page.
+     * There are ~3 steps in the upload phase before reaching the metrics confirmation page.
      *
      * Step 1: Upload File
      * Trigger: no selected file and no upload error(s)/warnings(s) present in server response

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -116,11 +116,96 @@ export const DataUpload: React.FC = observer(() => {
       }
 
       const data = await response?.json();
-      const errors = handleUploadErrors(data.metrics);
-      setErrorsAndWarnings(errors);
+      const mockData = JSON.parse(`{
+        "metrics": [
+          {
+            "datapoints": [],
+            "display_name": "Total Arrests",
+            "key": "LAW_ENFORCEMENT_ARRESTS_global/gender/restricted,global/race_and_ethnicity,metric/law_enforcement/reported_crime/type",
+            "sheets": [
+              {
+                "display_name": "Arrests",
+                "messages": [
+                  {
+                    "description": "There should only be a single row containing data for arrests in 6/2021.",
+                    "subtitle": "6/2021",
+                    "title": "Too Many Rows",
+                    "type": "WARNING"
+                  }
+                ],
+                "sheet_name": "arrests"
+              },
+              {
+                "display_name": "Arrests By Race",
+                "messages": [
+                  {
+                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
+                    "subtitle": "race/ethnicity",
+                    "title": "Missing Column",
+                    "type": "WARNING"
+                  },
+                  {
+                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
+                    "subtitle": "race/ethnicity",
+                    "title": "Missing Column",
+                    "type": "WARNING"
+                  },
+                  {
+                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
+                    "subtitle": "race/ethnicity",
+                    "title": "Missing Column",
+                    "type": "WARNING"
+                  }
+                ],
+                "sheet_name": "arrests_by_race"
+              }
+            ]
+          },
+          {
+            "datapoints": [],
+            "display_name": "Different Metric",
+            "key": "LAW_ENFORCEMENT_ARRESTS_global/gender/restricted,global/race_and_ethnicity,metric/law_enforcement/reported_crime/type",
+            "sheets": [
+              {
+                "display_name": "Different Metric Arrests",
+                "messages": [
+                  {
+                    "description": "There should only be a single row containing data for arrests in 6/2021.",
+                    "subtitle": "6/2021",
+                    "title": "Too Many Rows",
+                    "type": "ERROR"
+                  }
+                ],
+                "sheet_name": "arrests"
+              },
+              {
+                "display_name": "Different Metric Arrests By Race",
+                "messages": [
+                  {
+                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
+                    "subtitle": "race/ethnicity",
+                    "title": "Missing Column",
+                    "type": "WARNING"
+                  },
+                  {
+                    "description": "We expected the following column race/ethnicity to be found in the sheet arrests_by_race. Only the following rows were found in the sheet: ['year', 'month', 'value'].",
+                    "subtitle": "race/ethnicity",
+                    "title": "Missing Column",
+                    "type": "WARNING"
+                  }
+                ],
+                "sheet_name": "arrests_by_race"
+              }
+            ]
+          }
+        ],
+        "upload_errors": []
+      }`);
+      const sheetErrors = handleUploadErrors(mockData.metrics);
+      setErrorsAndWarnings(sheetErrors);
       setIsLoading(false);
 
-      if (errors.errorCount) return;
+      if (sheetErrors.errors.length) return;
 
       /** (TODO(#15195): Placeholder - toast will be removed and this should navigate to the confirmation component */
       showToast(
@@ -197,7 +282,7 @@ export const DataUpload: React.FC = observer(() => {
     }
 
     /** Upload Error/Warnings Step */
-    if (errorsAndWarnings?.errorCount) {
+    if (errorsAndWarnings?.errorCount || errorsAndWarnings?.warningCount) {
       return (
         <UploadErrorsWarnings
           errorsAndWarnings={errorsAndWarnings}
@@ -220,13 +305,19 @@ export const DataUpload: React.FC = observer(() => {
 
   return (
     <DataUploadContainer>
-      <DataUploadHeader transparent={!selectedFile}>
+      <DataUploadHeader
+        transparent={!selectedFile && !errorsAndWarnings?.errors.length}
+      >
         <LogoContainer onClick={() => navigate("/")}>
           <Logo src={logoImg} alt="" />
         </LogoContainer>
 
         <Button
-          type={selectedFile ? "red" : "light-border"}
+          type={
+            selectedFile || errorsAndWarnings?.errors.length
+              ? "red"
+              : "light-border"
+          }
           onClick={() => navigate(-1)}
         >
           Cancel

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -126,20 +126,18 @@ export const DataUpload: React.FC = observer(() => {
       formData.append("agency_id", userStore.currentAgencyId.toString());
 
       const response = await reportStore.uploadExcelSpreadsheet(formData);
-      setIsLoading(false);
 
       if (response instanceof Error) {
-        setUploadError(true);
+        setIsLoading(false);
         return showToast("Failed to upload. Please try again.", false, "red");
       }
 
       const data = await response?.json();
       const errors = handleUploadErrors(data.metrics);
       setErrorsAndWarnings(errors);
+      setIsLoading(false);
 
-      if (errors.errorCount) return setUploadError(true);
-
-      setUploadError(false);
+      if (errors.errorCount) return;
 
       /** (TODO(#15195): Placeholder - toast will be removed and this should navigate to the confirmation component */
       showToast(
@@ -216,7 +214,7 @@ export const DataUpload: React.FC = observer(() => {
     }
 
     /** Upload Error/Warnings Step */
-    if (uploadError) {
+    if (errorsAndWarnings?.errorCount) {
       const systemFileName =
         selectedSystem && systemToTemplateSpreadsheetFileName[selectedSystem];
 
@@ -244,7 +242,10 @@ export const DataUpload: React.FC = observer(() => {
             </UserPromptDescription>
 
             <ButtonWrapper>
-              <Button type="blue" onClick={() => setUploadError(false)}>
+              <Button
+                type="blue"
+                onClick={() => setErrorsAndWarnings(undefined)}
+              >
                 New Upload
               </Button>
             </ButtonWrapper>

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -126,13 +126,14 @@ export const DataUpload: React.FC = observer(() => {
       }
 
       setUploadError(false);
+
+      /** (TODO(#15195): Placeholder - toast will be removed and this should navigate to the confirmation component */
       showToast(
         "File uploaded successfully and is pending processing by a Justice Counts administrator.",
         true,
         undefined,
         3500
       );
-      /** Placeholder - this should navigate to the confirmation component */
       navigate("/");
     }
   };
@@ -153,7 +154,21 @@ export const DataUpload: React.FC = observer(() => {
   }
 
   const renderCurrentUploadStep = (): JSX.Element => {
-    if (selectedFile) {
+    /**
+     * There are ~3 steps in the upload phase before
+     * reaching the metrics confirmation page.
+     *
+     * Step 1: Upload File
+     * Trigger: no selected file and no upload error(s)/warnings(s) present in server response
+     *
+     * Step 2: System Selection (only for agencies with multiple systems)
+     * Trigger: file selected AND no system selected
+     *
+     * Step 3: Upload Errors/Warnings
+     * Trigger: upload error(s)/warnings(s) present in server response
+     */
+
+    if (selectedFile && !selectedSystem) {
       /** System Selection Step (for multi-system users) */
       return (
         <SystemSelection

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -139,7 +139,7 @@ export const DataUpload: React.FC = observer(() => {
         undefined,
         3500
       );
-      // navigate("/");
+      navigate("/");
     }
   };
 

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -143,10 +143,19 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
             </UserPromptTitle>
             <UserPromptDescription>
               We ran into a few discrepancies between the uploaded data and the
-              Justice Counts format for the X system, but we did our best to
-              resolve them. Please review the warnings and determine if it is
-              safe to proceed. If not, resolve the warnings in your file and
-              reupload.
+              Justice Counts format for the{" "}
+              <span>
+                <a
+                  href={`./assets/${systemFileName}`}
+                  download={systemFileName}
+                >
+                  {selectedSystem &&
+                    removeSnakeCase(selectedSystem).toLowerCase()}
+                </a>
+              </span>{" "}
+              system, but we did our best to resolve them. Please review the
+              warnings and determine if it is safe to proceed. If not, resolve
+              the warnings in your file and reupload.
             </UserPromptDescription>
           </>
         ) : (

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -74,8 +74,8 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
         ) : (
           <>
             <UserPromptTitle>
-              Uh oh, we found <span>{errorsAndWarnings?.errorCount}</span>{" "}
-              errors.
+              Uh oh, we found <span>{errorsAndWarnings?.errorCount}</span> error
+              {errorsAndWarnings?.errorCount > 1 ? "s" : ""}.
             </UserPromptTitle>
             <UserPromptDescription>
               We ran into a few discrepancies between the uploaded data and the

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -46,11 +46,13 @@ type UploadErrorsWarningsProps = {
     value: React.SetStateAction<ErrorsAndWarnings | undefined>
   ) => void;
   selectedSystem: string | undefined;
+  resetToNewUpload: () => void;
 };
 export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
   errorsAndWarnings,
   setErrorsAndWarnings,
   selectedSystem,
+  resetToNewUpload,
 }) => {
   const navigate = useNavigate();
   const systemFileName =
@@ -96,9 +98,7 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
         )}
 
         <UploadErrorButtonWrapper>
-          <Button onClick={() => setErrorsAndWarnings(undefined)}>
-            New Upload
-          </Button>
+          <Button onClick={resetToNewUpload}>New Upload</Button>
 
           {/* (TODO(#15195): Placeholder - this should navigate to the confirmation component */}
           {hasWarningsOnly && (

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -42,15 +42,11 @@ import {
 
 type UploadErrorsWarningsProps = {
   errorsAndWarnings: ErrorsAndWarnings;
-  setErrorsAndWarnings: (
-    value: React.SetStateAction<ErrorsAndWarnings | undefined>
-  ) => void;
   selectedSystem: string | undefined;
   resetToNewUpload: () => void;
 };
 export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
   errorsAndWarnings,
-  setErrorsAndWarnings,
   selectedSystem,
   resetToNewUpload,
 }) => {
@@ -58,7 +54,7 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
   const systemFileName =
     selectedSystem && systemToTemplateSpreadsheetFileName[selectedSystem];
   const hasWarningsOnly =
-    errorsAndWarnings.warningCount && !errorsAndWarnings.errorCount;
+    !!errorsAndWarnings.warningCount && !errorsAndWarnings.errorCount;
 
   return (
     <UserPromptContainer>
@@ -111,23 +107,44 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
             <UserPromptError key={sheet.display_name}>
               <MetricTitle>{sheet.display_name}</MetricTitle>
 
-              {sheet.messages?.map((message: any) => (
-                <Fragment key={message.title + message.description}>
+              {!sheet.display_name && (
+                <Fragment key={sheet.title + sheet.description}>
                   <ErrorIconWrapper>
-                    {message.type === "ERROR" ? <ErrorIcon /> : <WarningIcon />}
+                    {sheet.type === "ERROR" ? <ErrorIcon /> : <WarningIcon />}
 
                     <ErrorMessageWrapper>
-                      <ErrorMessageTitle>{message.title}</ErrorMessageTitle>
+                      <ErrorMessageTitle>{sheet.title}</ErrorMessageTitle>
                       <ErrorMessageDescription>
-                        {message.subtitle}
+                        {sheet.subtitle}
                       </ErrorMessageDescription>
                     </ErrorMessageWrapper>
                   </ErrorIconWrapper>
-                  <ErrorAdditionalInfo>
-                    {message.description}
-                  </ErrorAdditionalInfo>
+                  <ErrorAdditionalInfo>{sheet.description}</ErrorAdditionalInfo>
                 </Fragment>
-              ))}
+              )}
+
+              {sheet.display_name &&
+                sheet.messages?.map((message: any) => (
+                  <Fragment key={message.title + message.description}>
+                    <ErrorIconWrapper>
+                      {message.type === "ERROR" ? (
+                        <ErrorIcon />
+                      ) : (
+                        <WarningIcon />
+                      )}
+
+                      <ErrorMessageWrapper>
+                        <ErrorMessageTitle>{message.title}</ErrorMessageTitle>
+                        <ErrorMessageDescription>
+                          {message.subtitle}
+                        </ErrorMessageDescription>
+                      </ErrorMessageWrapper>
+                    </ErrorIconWrapper>
+                    <ErrorAdditionalInfo>
+                      {message.description}
+                    </ErrorAdditionalInfo>
+                  </Fragment>
+                ))}
             </UserPromptError>
           ))}
         </UserPromptErrorContainer>

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -54,19 +54,15 @@ export type MetricErrors = {
   messages: ErrorWarningMessage[];
 };
 
-export type MetricErrorsWarnings = {
+export type ErrorsWarnings = {
   errorCount: number;
   warningCount: number;
   metricErrors: MetricErrors[];
-};
-
-export type PreIngestErrors = {
-  errorCount: number;
-  messages: ErrorWarningMessage[];
+  preIngestErrors?: ErrorWarningMessage[];
 };
 
 type UploadErrorsWarningsProps = {
-  errorsAndWarnings: MetricErrorsWarnings | PreIngestErrors;
+  errorsAndWarnings: ErrorsWarnings;
   selectedSystem: string | undefined;
   resetToNewUpload: () => void;
 };
@@ -84,51 +80,53 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
     !errorsAndWarnings.errorCount;
 
   const renderMessages = () => {
-    if ("messages" in errorsAndWarnings) {
-      return errorsAndWarnings.messages.map((message) => (
-        <UserPromptError key={message.title + message.description}>
-          <MetricTitle />
-          <ErrorIconWrapper>
-            {message.type === "ERROR" ? <ErrorIcon /> : <WarningIcon />}
+    return (
+      <>
+        {errorsAndWarnings.metricErrors.map((sheet) => (
+          <UserPromptError key={sheet.display_name}>
+            <MetricTitle>
+              {sheet.display_name} <span>{sheet.sheet_name}</span>
+            </MetricTitle>
 
-            <ErrorMessageWrapper>
-              <ErrorMessageTitle>{message.title}</ErrorMessageTitle>
-              <ErrorMessageDescription>
-                {message.subtitle}
-              </ErrorMessageDescription>
-            </ErrorMessageWrapper>
-          </ErrorIconWrapper>
-          <ErrorAdditionalInfo>{message.description}</ErrorAdditionalInfo>
-        </UserPromptError>
-      ));
-    }
+            {sheet.display_name &&
+              sheet.messages?.map((message) => (
+                <Fragment key={message.title + message.description}>
+                  <ErrorIconWrapper>
+                    {message.type === "ERROR" ? <ErrorIcon /> : <WarningIcon />}
 
-    if ("metricErrors" in errorsAndWarnings) {
-      return errorsAndWarnings.metricErrors.map((sheet) => (
-        <UserPromptError key={sheet.display_name}>
-          <MetricTitle>
-            {sheet.display_name} <span>{sheet.sheet_name}</span>
-          </MetricTitle>
+                    <ErrorMessageWrapper>
+                      <ErrorMessageTitle>{message.title}</ErrorMessageTitle>
+                      <ErrorMessageDescription>
+                        {message.subtitle}
+                      </ErrorMessageDescription>
+                    </ErrorMessageWrapper>
+                  </ErrorIconWrapper>
+                  <ErrorAdditionalInfo>
+                    {message.description}
+                  </ErrorAdditionalInfo>
+                </Fragment>
+              ))}
+          </UserPromptError>
+        ))}
 
-          {sheet.display_name &&
-            sheet.messages?.map((message) => (
-              <Fragment key={message.title + message.description}>
-                <ErrorIconWrapper>
-                  {message.type === "ERROR" ? <ErrorIcon /> : <WarningIcon />}
+        {errorsAndWarnings.preIngestErrors?.map((message) => (
+          <UserPromptError key={message.title + message.description}>
+            <MetricTitle />
+            <ErrorIconWrapper>
+              {message.type === "ERROR" ? <ErrorIcon /> : <WarningIcon />}
 
-                  <ErrorMessageWrapper>
-                    <ErrorMessageTitle>{message.title}</ErrorMessageTitle>
-                    <ErrorMessageDescription>
-                      {message.subtitle}
-                    </ErrorMessageDescription>
-                  </ErrorMessageWrapper>
-                </ErrorIconWrapper>
-                <ErrorAdditionalInfo>{message.description}</ErrorAdditionalInfo>
-              </Fragment>
-            ))}
-        </UserPromptError>
-      ));
-    }
+              <ErrorMessageWrapper>
+                <ErrorMessageTitle>{message.title}</ErrorMessageTitle>
+                <ErrorMessageDescription>
+                  {message.subtitle}
+                </ErrorMessageDescription>
+              </ErrorMessageWrapper>
+            </ErrorIconWrapper>
+            <ErrorAdditionalInfo>{message.description}</ErrorAdditionalInfo>
+          </UserPromptError>
+        ))}
+      </>
+    );
   };
 
   return (

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -29,6 +29,8 @@ import {
   ErrorMessageTitle,
   ErrorMessageWrapper,
   MetricTitle,
+  OrangeText,
+  RedText,
   systemToTemplateSpreadsheetFileName,
   UploadErrorButtonWrapper,
   UserPromptContainer,
@@ -135,18 +137,25 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
         {/* Error/Warning Header */}
         {hasWarningsOnly ? (
           <>
-            <UserPromptTitle>Warning title.</UserPromptTitle>
+            <UserPromptTitle>
+              We found{" "}
+              <OrangeText>{errorsAndWarnings?.warningCount}</OrangeText> warning
+              {errorsAndWarnings?.warningCount > 1 ? "s" : ""}, but you can
+              still proceed.
+            </UserPromptTitle>
             <UserPromptDescription>
-              Lorem ipsum dolor, sit amet consectetur adipisicing elit. Quaerat
-              quasi placeat maxime error esse sapiente similique beatae fugit id
-              provident eligendi ad fugiat iure tempora a vitae, incidunt ea
-              accusamus.
+              We ran into a few discrepancies between the uploaded data and the
+              Justice Counts format for the X system, but we did our best to
+              resolve them. Please review the warnings and determine if it is
+              safe to proceed. If not, resolve the warnings in your file and
+              reupload.
             </UserPromptDescription>
           </>
         ) : (
           <>
             <UserPromptTitle>
-              Uh oh, we found <span>{errorsAndWarnings?.errorCount}</span> error
+              Uh oh, we found <RedText>{errorsAndWarnings?.errorCount}</RedText>{" "}
+              error
               {errorsAndWarnings?.errorCount > 1 ? "s" : ""}.
             </UserPromptTitle>
             <UserPromptDescription>

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -1,0 +1,110 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2022 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import React, { Fragment } from "react";
+
+import { removeSnakeCase } from "../../utils";
+import { ReactComponent as ErrorIcon } from "../assets/error-icon.svg";
+import { ReactComponent as WarningIcon } from "../assets/warning-icon.svg";
+import {
+  Button,
+  ButtonWrapper,
+  ErrorAdditionalInfo,
+  ErrorIconWrapper,
+  ErrorMessageDescription,
+  ErrorMessageTitle,
+  ErrorMessageWrapper,
+  ErrorsAndWarnings,
+  MetricTitle,
+  systemToTemplateSpreadsheetFileName,
+  UserPromptContainer,
+  UserPromptDescription,
+  UserPromptError,
+  UserPromptErrorContainer,
+  UserPromptTitle,
+  UserPromptWrapper,
+} from ".";
+
+type UploadErrorsWarningsProps = {
+  errorsAndWarnings: ErrorsAndWarnings;
+  setErrorsAndWarnings: (
+    value: React.SetStateAction<ErrorsAndWarnings | undefined>
+  ) => void;
+  selectedSystem: string | undefined;
+};
+export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
+  errorsAndWarnings,
+  setErrorsAndWarnings,
+  selectedSystem,
+}) => {
+  const systemFileName =
+    selectedSystem && systemToTemplateSpreadsheetFileName[selectedSystem];
+
+  return (
+    <UserPromptContainer>
+      <UserPromptWrapper>
+        <UserPromptTitle>
+          Uh oh, we found <span>{errorsAndWarnings?.errorCount}</span> errors.
+        </UserPromptTitle>
+
+        <UserPromptDescription>
+          We ran into a few discrepancies between the uploaded data and the
+          Justice Counts format for the{" "}
+          <span>
+            <a href={`./assets/${systemFileName}`} download={systemFileName}>
+              {selectedSystem && removeSnakeCase(selectedSystem).toLowerCase()}
+            </a>
+          </span>{" "}
+          system. To continue, please resolve the errors in your file and
+          reupload.
+        </UserPromptDescription>
+
+        <ButtonWrapper>
+          <Button type="blue" onClick={() => setErrorsAndWarnings(undefined)}>
+            New Upload
+          </Button>
+        </ButtonWrapper>
+
+        <UserPromptErrorContainer>
+          {errorsAndWarnings?.errors.map((sheet: any) => (
+            <UserPromptError key={sheet.display_name}>
+              <MetricTitle>{sheet.display_name}</MetricTitle>
+
+              {sheet.messages?.map((message: any) => (
+                <Fragment key={message.title + message.description}>
+                  <ErrorIconWrapper>
+                    {message.type === "ERROR" ? <ErrorIcon /> : <WarningIcon />}
+
+                    <ErrorMessageWrapper>
+                      <ErrorMessageTitle>{message.title}</ErrorMessageTitle>
+                      <ErrorMessageDescription>
+                        {message.subtitle}
+                      </ErrorMessageDescription>
+                    </ErrorMessageWrapper>
+                  </ErrorIconWrapper>
+                  <ErrorAdditionalInfo>
+                    {message.description}
+                  </ErrorAdditionalInfo>
+                </Fragment>
+              ))}
+            </UserPromptError>
+          ))}
+        </UserPromptErrorContainer>
+      </UserPromptWrapper>
+    </UserPromptContainer>
+  );
+};

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -104,7 +104,9 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
     if ("metricErrors" in errorsAndWarnings) {
       return errorsAndWarnings.metricErrors.map((sheet) => (
         <UserPromptError key={sheet.display_name}>
-          <MetricTitle>{sheet.display_name}</MetricTitle>
+          <MetricTitle>
+            {sheet.display_name} <span>{sheet.sheet_name}</span>
+          </MetricTitle>
 
           {sheet.display_name &&
             sheet.messages?.map((message) => (

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -28,9 +28,7 @@ import {
   ErrorMessageDescription,
   ErrorMessageTitle,
   ErrorMessageWrapper,
-  MetricErrorsWarnings,
   MetricTitle,
-  PreIngestErrors,
   systemToTemplateSpreadsheetFileName,
   UploadErrorButtonWrapper,
   UserPromptContainer,
@@ -40,6 +38,30 @@ import {
   UserPromptTitle,
   UserPromptWrapper,
 } from ".";
+
+export type ErrorWarningMessage = {
+  title: string;
+  subtitle: string;
+  description: string;
+  type: "ERROR" | "WARNING";
+};
+
+export type MetricErrors = {
+  display_name: string;
+  sheet_name: string;
+  messages: ErrorWarningMessage[];
+};
+
+export type MetricErrorsWarnings = {
+  errorCount: number;
+  warningCount: number;
+  metricErrors: MetricErrors[];
+};
+
+export type PreIngestErrors = {
+  errorCount: number;
+  messages: ErrorWarningMessage[];
+};
 
 type UploadErrorsWarningsProps = {
   errorsAndWarnings: MetricErrorsWarnings | PreIngestErrors;

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -16,13 +16,13 @@
 // =============================================================================
 
 import React, { Fragment } from "react";
+import { useNavigate } from "react-router-dom";
 
 import { removeSnakeCase } from "../../utils";
 import { ReactComponent as ErrorIcon } from "../assets/error-icon.svg";
 import { ReactComponent as WarningIcon } from "../assets/warning-icon.svg";
 import {
   Button,
-  ButtonWrapper,
   ErrorAdditionalInfo,
   ErrorIconWrapper,
   ErrorMessageDescription,
@@ -31,6 +31,7 @@ import {
   ErrorsAndWarnings,
   MetricTitle,
   systemToTemplateSpreadsheetFileName,
+  UploadErrorButtonWrapper,
   UserPromptContainer,
   UserPromptDescription,
   UserPromptError,
@@ -51,33 +52,59 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
   setErrorsAndWarnings,
   selectedSystem,
 }) => {
+  const navigate = useNavigate();
   const systemFileName =
     selectedSystem && systemToTemplateSpreadsheetFileName[selectedSystem];
+  const hasWarningsOnly =
+    errorsAndWarnings.warningCount && !errorsAndWarnings.errorCount;
 
   return (
     <UserPromptContainer>
       <UserPromptWrapper>
-        <UserPromptTitle>
-          Uh oh, we found <span>{errorsAndWarnings?.errorCount}</span> errors.
-        </UserPromptTitle>
+        {hasWarningsOnly ? (
+          <>
+            <UserPromptTitle>Warning title.</UserPromptTitle>
+            <UserPromptDescription>
+              Lorem ipsum dolor, sit amet consectetur adipisicing elit. Quaerat
+              quasi placeat maxime error esse sapiente similique beatae fugit id
+              provident eligendi ad fugiat iure tempora a vitae, incidunt ea
+              accusamus.
+            </UserPromptDescription>
+          </>
+        ) : (
+          <>
+            <UserPromptTitle>
+              Uh oh, we found <span>{errorsAndWarnings?.errorCount}</span>{" "}
+              errors.
+            </UserPromptTitle>
+            <UserPromptDescription>
+              We ran into a few discrepancies between the uploaded data and the
+              Justice Counts format for the{" "}
+              <span>
+                <a
+                  href={`./assets/${systemFileName}`}
+                  download={systemFileName}
+                >
+                  {selectedSystem &&
+                    removeSnakeCase(selectedSystem).toLowerCase()}
+                </a>
+              </span>{" "}
+              system. To continue, please resolve the errors in your file and
+              reupload.
+            </UserPromptDescription>
+          </>
+        )}
 
-        <UserPromptDescription>
-          We ran into a few discrepancies between the uploaded data and the
-          Justice Counts format for the{" "}
-          <span>
-            <a href={`./assets/${systemFileName}`} download={systemFileName}>
-              {selectedSystem && removeSnakeCase(selectedSystem).toLowerCase()}
-            </a>
-          </span>{" "}
-          system. To continue, please resolve the errors in your file and
-          reupload.
-        </UserPromptDescription>
-
-        <ButtonWrapper>
-          <Button type="blue" onClick={() => setErrorsAndWarnings(undefined)}>
+        <UploadErrorButtonWrapper>
+          <Button onClick={() => setErrorsAndWarnings(undefined)}>
             New Upload
           </Button>
-        </ButtonWrapper>
+
+          {/* (TODO(#15195): Placeholder - this should navigate to the confirmation component */}
+          {hasWarningsOnly && (
+            <Button onClick={() => navigate("/")}>Continue</Button>
+          )}
+        </UploadErrorButtonWrapper>
 
         <UserPromptErrorContainer>
           {errorsAndWarnings?.errors.map((sheet: any) => (

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
@@ -20,7 +20,6 @@ import { observer } from "mobx-react-lite";
 import React, { useEffect } from "react";
 
 import {
-  Datapoint,
   DatapointsGroupedByAggregateAndDisaggregations,
   DatapointValue,
   DataVizAggregateName,


### PR DESCRIPTION
## Description of the change

Fleshes out the Error/Warning page. There are a two main types of errors that can occur after an upload:

1. Pre-ingest errors (errors that occur when the file cannot be properly parsed)
2. Metric errors and/or warnings that occur within the sheets of the Excel file

If an upload has only warnings (and no errors), the user will have a `Continue` button that will enable them to continue to the confirmation page.

Uploading a file that only has warnings (lorem ipsum for now - would love copy ideas):

https://user-images.githubusercontent.com/59492998/190512328-b79ac837-2191-4591-b712-52739dcf86bb.mov



Uploading a file that has metric errors & a file that generates pre-ingest errors:

https://user-images.githubusercontent.com/59492998/190512319-69e7de02-0c04-4757-915f-987c220f208e.mov




## Related issues

Closes #18 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
