### PR TITLE
Require Pull Request Labels on all PRs

### DIFF
--- a/.github/workflows/require_labels.yml
+++ b/.github/workflows/require_labels.yml
@@ -1,0 +1,13 @@
+name: Pull Request Labels
+on:
+  pull_request:
+    types: [opened, labeled, unlabeled, synchronize]
+jobs:
+  label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: mheap/github-action-required-labels@v1
+        with:
+          mode: minimum
+          count: 1
+          labels: "Type: Bug, Type: Feature, Type: Breaking Change, Type: Non-breaking refactor, Type: Configuration Change, Type: Dependency Upgrade"


### PR DESCRIPTION
## Description of the change

Adds pull request label requirement to our CI workflows.

## Related issues

Closes #9

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
