### PR TITLE
[Frontend] Data Upload v1: Move Uploaded Files to New Settings Page

### DIFF
--- a/publisher/src/components/DataUpload/DataUpload.styles.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.styles.tsx
@@ -29,8 +29,6 @@ import {
   Table,
 } from "../Reports";
 
-const ROW_HEIGHT = 42;
-
 export const DataUploadContainer = styled.div`
   width: 100%;
   height: 100%;
@@ -311,14 +309,14 @@ export const Icon = styled.img<{ grayscale?: boolean }>`
   ${({ grayscale }) => grayscale && `filter: grayscale(1);`}
 `;
 
-export const ModalLoadingWrapper = styled.div`
-  div {
-    height: 100%;
-    top: 25%;
-  }
+export const UploadedFilesLoading = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin-top: 50px;
 `;
 
-export const ModalErrorWrapper = styled.div`
+export const UploadedFilesError = styled.div`
   display: flex;
   justify-content: center;
   margin-top: 25px;
@@ -336,16 +334,22 @@ export const ActionsContainer = styled.div`
   justify-content: flex-end;
   align-items: center;
   background: ${palette.solid.offwhite};
-  gap: 10px;
-  padding-left: 20px;
+  padding: 0 20px;
   position: absolute;
-  right: 22px;
+  right: 0;
   z-index: 3;
-  width: 25vw;
+  width: 30vw;
 `;
 
 export const ActionButton = styled.div<{ red?: boolean }>`
+  white-space: nowrap;
+  background: ${palette.solid.offwhite};
   color: ${({ red }) => (red ? palette.solid.red : palette.solid.blue)};
+
+  &:not(:last-child) {
+    margin-right: 10px;
+  }
+
   &:hover {
     color: ${palette.solid.darkgrey};
   }
@@ -497,13 +501,18 @@ export const ConfirmationPageContainer = styled.div`
 `;
 
 export const UploadedFilesContainer = styled.div`
-  height: 100%;
-  padding: ${ROW_HEIGHT}px 0;
+  max-height: 50vh;
   overflow-y: scroll;
+`;
+
+export const UploadedFilesWrapper = styled.div`
+  margin-top: 50px;
 `;
 
 export const UploadedFilesTable = styled(Table)`
   padding: unset;
+  max-height: 40vh;
+  overflow-y: scroll;
 `;
 
 export const ExtendedTabbedBar = styled(TabbedBar)`
@@ -514,23 +523,35 @@ export const ExtendedRow = styled(Row)`
   color: ${({ selected }) => selected && palette.highlight.grey9};
   position: relative;
   transition: unset;
+  padding-left: 0;
+  padding-right: 8px;
 `;
 
 export const ExtendedLabelRow = styled(LabelRow)`
-  position: fixed;
+  position: sticky;
+  top: 0;
   background: ${palette.solid.white};
-  z-index: 1;
+  z-index: 5;
+  padding-left: 0;
+  padding-right: 8px;
 `;
 
 export const ExtendedCell = styled(Cell)`
   &:first-child {
-    flex: 4 1 auto;
+    flex: 3 1 auto;
+  }
+
+  &:nth-child(2) {
+    flex: 3 1 auto;
   }
 `;
 
 export const ExtendedLabelCell = styled(LabelCell)`
   &:first-child {
-    flex: 4 1 auto;
+    flex: 3 1 auto;
+  }
+  &:nth-child(2) {
+    flex: 3 1 auto;
   }
 `;
 

--- a/publisher/src/components/DataUpload/DataUpload.styles.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.styles.tsx
@@ -338,7 +338,6 @@ export const ActionsContainer = styled.div`
   position: absolute;
   right: 0;
   z-index: 3;
-  width: 30vw;
 `;
 
 export const ActionButton = styled.div<{ red?: boolean }>`

--- a/publisher/src/components/DataUpload/DataUpload.styles.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.styles.tsx
@@ -546,6 +546,12 @@ export const ExtendedCell = styled(Cell)`
   &:nth-child(2) {
     flex: 3 1 auto;
   }
+
+  @media only screen and (max-width: 1050px) {
+    &:not(:first-child, :last-child) {
+      display: none;
+    }
+  }
 `;
 
 export const ExtendedLabelCell = styled(LabelCell)`
@@ -554,6 +560,12 @@ export const ExtendedLabelCell = styled(LabelCell)`
   }
   &:nth-child(2) {
     flex: 3 1 auto;
+  }
+
+  @media only screen and (max-width: 1050px) {
+    &:not(:first-child, :last-child) {
+      display: none;
+    }
   }
 `;
 

--- a/publisher/src/components/DataUpload/DataUpload.styles.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.styles.tsx
@@ -18,6 +18,7 @@
 import styled from "styled-components/macro";
 
 import { rem } from "../../utils";
+import { OpacityGradient } from "../Forms";
 import { HEADER_BAR_HEIGHT, palette, typography } from "../GlobalStyles";
 import {
   Cell,
@@ -506,12 +507,14 @@ export const UploadedFilesContainer = styled.div`
 
 export const UploadedFilesWrapper = styled.div`
   margin-top: 50px;
+  position: relative;
 `;
 
 export const UploadedFilesTable = styled(Table)`
   padding: unset;
   max-height: 40vh;
   overflow-y: scroll;
+  padding-bottom: 50px;
 `;
 
 export const ExtendedTabbedBar = styled(TabbedBar)`
@@ -593,4 +596,9 @@ export const LoadingSubheader = styled.div`
 export const CheckIcon = styled.img`
   width: 16px;
   margin-right: 5px;
+`;
+
+export const ExtendedOpacityGradient = styled(OpacityGradient)`
+  height: 50px;
+  position: absolute;
 `;

--- a/publisher/src/components/DataUpload/UploadedFiles.tsx
+++ b/publisher/src/components/DataUpload/UploadedFiles.tsx
@@ -108,7 +108,7 @@ export const UploadedFileRow: React.FC<{
     } = fileRowDetails;
 
     useEffect(() => {
-      setRowHovered(false);
+      if (rowHovered) setRowHovered(false);
     }, [fileRowDetails]);
 
     return (
@@ -245,9 +245,7 @@ export const UploadedFiles: React.FC = observer(() => {
     }
 
     return setUploadedFiles((prev) => {
-      const filteredFiles = prev.filter(
-        (file) => (file as UploadedFile).id !== spreadsheetID
-      );
+      const filteredFiles = prev.filter((file) => file.id !== spreadsheetID);
 
       return filteredFiles;
     });

--- a/publisher/src/components/DataUpload/UploadedFiles.tsx
+++ b/publisher/src/components/DataUpload/UploadedFiles.tsx
@@ -107,9 +107,13 @@ export const UploadedFileRow: React.FC<{
       uploadedBy,
     } = fileRowDetails;
 
-    useEffect(() => {
-      if (rowHovered) setRowHovered(false);
-    }, [fileRowDetails]);
+    useEffect(
+      () => {
+        if (rowHovered) setRowHovered(false);
+      },
+      // eslint-disable-next-line react-hooks/exhaustive-deps
+      [fileRowDetails]
+    );
 
     return (
       <ExtendedRow

--- a/publisher/src/components/Forms/TextInput.tsx
+++ b/publisher/src/components/Forms/TextInput.tsx
@@ -47,7 +47,7 @@ export const Input = styled.input<InputProps>`
   resize: none;
   height: ${({ multiline }) => (multiline ? "200px;" : "71px;")};
   padding: ${({ persistLabel }) =>
-    persistLabel ? "42px 16px 16px 16px" : "16px 55px 10px 16px"}};
+    persistLabel ? "42px 55px 16px 16px" : "16px 55px 10px 16px"}};
   background: ${({ value, error, notReporting }) => {
     if (error) {
       return palette.highlight.red;

--- a/publisher/src/pages/AccountSettings.tsx
+++ b/publisher/src/pages/AccountSettings.tsx
@@ -19,6 +19,7 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components/macro";
 
+import { UploadedFiles, UploadedFilesWrapper } from "../components/DataUpload";
 import { Button, TextInput, Title, TitleWrapper } from "../components/Forms";
 import { typography } from "../components/GlobalStyles";
 import { useStore } from "../stores";
@@ -30,6 +31,8 @@ const SettingsContainer = styled.div`
   justify-content: center;
   align-items: flex-start;
   padding: 39px 24px 0 24px;
+  position: fixed;
+  overflow-y: scroll;
 `;
 
 const SettingsFormPanel = styled.div``;
@@ -53,7 +56,7 @@ const InputWrapper = styled.div`
 const SettingsFormUploadedFilesWrapper = styled.div`
   display: flex;
   flex-direction: column;
-  flex: 1 1 auto;
+  flex: 3 1 auto;
 `;
 
 const SettingsTitle = styled.div`
@@ -79,11 +82,13 @@ const AccountSettings = () => {
 
           <InputWrapper>
             <TextInput
+              persistLabel
               label="Full Name"
               value={name}
               onChange={(e) => setName(e.target.value)}
             />
             <TextInput
+              persistLabel
               label="Email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
@@ -108,6 +113,13 @@ const AccountSettings = () => {
             </Button>
           </ButtonWrapper>
         </SettingsFormPanel>
+
+        <UploadedFilesWrapper>
+          <TitleWrapper>
+            <Title>Uploaded Files</Title>
+          </TitleWrapper>
+          <UploadedFiles />
+        </UploadedFilesWrapper>
       </SettingsFormUploadedFilesWrapper>
     </SettingsContainer>
   );

--- a/publisher/src/pages/AccountSettings.tsx
+++ b/publisher/src/pages/AccountSettings.tsx
@@ -19,8 +19,18 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components/macro";
 
-import { UploadedFiles, UploadedFilesWrapper } from "../components/DataUpload";
-import { Button, TextInput, Title, TitleWrapper } from "../components/Forms";
+import {
+  ExtendedOpacityGradient,
+  UploadedFiles,
+  UploadedFilesWrapper,
+} from "../components/DataUpload";
+import {
+  Button,
+  OpacityGradient,
+  TextInput,
+  Title,
+  TitleWrapper,
+} from "../components/Forms";
 import { typography } from "../components/GlobalStyles";
 import { useStore } from "../stores";
 
@@ -98,18 +108,10 @@ const AccountSettings = () => {
           <ButtonWrapper>
             <Button
               onClick={() => {
-                navigate(-1);
-              }}
-            >
-              Cancel
-            </Button>
-            <Button
-              onClick={() => {
                 userStore.updateUserNameAndEmail(name, email);
-                navigate(-1);
               }}
             >
-              Save & Close
+              Save
             </Button>
           </ButtonWrapper>
         </SettingsFormPanel>
@@ -119,6 +121,7 @@ const AccountSettings = () => {
             <Title>Uploaded Files</Title>
           </TitleWrapper>
           <UploadedFiles />
+          <ExtendedOpacityGradient />
         </UploadedFilesWrapper>
       </SettingsFormUploadedFilesWrapper>
     </SettingsContainer>

--- a/publisher/src/pages/AccountSettings.tsx
+++ b/publisher/src/pages/AccountSettings.tsx
@@ -77,6 +77,7 @@ const AccountSettings = () => {
   const { userStore } = useStore();
   const [email, setEmail] = React.useState<string>(userStore?.email || "");
   const [name, setName] = React.useState<string>(userStore?.name || "");
+
   return (
     <SettingsContainer>
       <SettingsTitle>Settings</SettingsTitle>
@@ -117,6 +118,7 @@ const AccountSettings = () => {
           <TitleWrapper>
             <Title>Uploaded Files</Title>
           </TitleWrapper>
+
           <UploadedFiles />
           <ExtendedOpacityGradient />
         </UploadedFilesWrapper>

--- a/publisher/src/pages/AccountSettings.tsx
+++ b/publisher/src/pages/AccountSettings.tsx
@@ -16,7 +16,6 @@
 // =============================================================================
 
 import React from "react";
-import { useNavigate } from "react-router-dom";
 import styled from "styled-components/macro";
 
 import {
@@ -24,13 +23,7 @@ import {
   UploadedFiles,
   UploadedFilesWrapper,
 } from "../components/DataUpload";
-import {
-  Button,
-  OpacityGradient,
-  TextInput,
-  Title,
-  TitleWrapper,
-} from "../components/Forms";
+import { Button, TextInput, Title, TitleWrapper } from "../components/Forms";
 import { typography } from "../components/GlobalStyles";
 import { useStore } from "../stores";
 
@@ -77,7 +70,6 @@ const SettingsTitle = styled.div`
 
 const AccountSettings = () => {
   const { userStore } = useStore();
-  const navigate = useNavigate();
   const [email, setEmail] = React.useState<string>(userStore?.email || "");
   const [name, setName] = React.useState<string>(userStore?.name || "");
   return (

--- a/publisher/src/pages/AccountSettings.tsx
+++ b/publisher/src/pages/AccountSettings.tsx
@@ -36,6 +36,11 @@ const SettingsContainer = styled.div`
   padding: 39px 24px 0 24px;
   position: fixed;
   overflow-y: scroll;
+
+  @media only screen and (max-width: 1050px) {
+    width: unset;
+    flex-direction: column;
+  }
 `;
 
 const SettingsFormPanel = styled.div``;

--- a/publisher/src/pages/AccountSettings.tsx
+++ b/publisher/src/pages/AccountSettings.tsx
@@ -19,32 +19,47 @@ import React from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components/macro";
 
-import {
-  Button,
-  GoBack,
-  TextInput,
-  Title,
-  TitleWrapper,
-} from "../components/Forms";
+import { Button, TextInput, Title, TitleWrapper } from "../components/Forms";
+import { typography } from "../components/GlobalStyles";
 import { useStore } from "../stores";
 
-const AccountSettingsPage = styled.div`
+const SettingsContainer = styled.div`
   width: 100%;
   height: 100%;
   display: flex;
-  flex-direction: column;
   justify-content: center;
-  align-items: center;
+  align-items: flex-start;
+  padding: 39px 24px 0 24px;
 `;
 
-const SettingsFormPanel = styled.div`
-  width: 644px;
-`;
+const SettingsFormPanel = styled.div``;
 
 const ButtonWrapper = styled.div`
   display: flex;
   flex: 1 1 auto;
-  justify-content: space-between;
+  justify-content: flex-end;
+  gap: 10px;
+`;
+
+const InputWrapper = styled.div`
+  display: flex;
+  gap: 10px;
+
+  div {
+    width: 100%;
+  }
+`;
+
+const SettingsFormUploadedFilesWrapper = styled.div`
+  display: flex;
+  flex-direction: column;
+  flex: 1 1 auto;
+`;
+
+const SettingsTitle = styled.div`
+  ${typography.sizeCSS.headline}
+  display: flex;
+  flex: 1 1 auto;
 `;
 
 const AccountSettings = () => {
@@ -53,46 +68,48 @@ const AccountSettings = () => {
   const [email, setEmail] = React.useState<string>(userStore?.email || "");
   const [name, setName] = React.useState<string>(userStore?.name || "");
   return (
-    <AccountSettingsPage>
-      <GoBack
-        style={{ position: "absolute", top: 100, left: 20 }}
-        onClick={() => navigate(-1)}
-      />
-      <SettingsFormPanel>
-        <TitleWrapper underlined>
-          <Title>Settings</Title>
-        </TitleWrapper>
+    <SettingsContainer>
+      <SettingsTitle>Settings</SettingsTitle>
 
-        <TextInput
-          label="Full Name"
-          value={name}
-          onChange={(e) => setName(e.target.value)}
-        />
-        <TextInput
-          label="Email"
-          value={email}
-          onChange={(e) => setEmail(e.target.value)}
-        />
+      <SettingsFormUploadedFilesWrapper>
+        <SettingsFormPanel>
+          <TitleWrapper>
+            <Title>Account</Title>
+          </TitleWrapper>
 
-        <ButtonWrapper>
-          <Button
-            onClick={() => {
-              navigate(-1);
-            }}
-          >
-            Cancel
-          </Button>
-          <Button
-            onClick={() => {
-              userStore.updateUserNameAndEmail(name, email);
-              navigate(-1);
-            }}
-          >
-            Save & Close
-          </Button>
-        </ButtonWrapper>
-      </SettingsFormPanel>
-    </AccountSettingsPage>
+          <InputWrapper>
+            <TextInput
+              label="Full Name"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+            />
+            <TextInput
+              label="Email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+            />
+          </InputWrapper>
+
+          <ButtonWrapper>
+            <Button
+              onClick={() => {
+                navigate(-1);
+              }}
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={() => {
+                userStore.updateUserNameAndEmail(name, email);
+                navigate(-1);
+              }}
+            >
+              Save & Close
+            </Button>
+          </ButtonWrapper>
+        </SettingsFormPanel>
+      </SettingsFormUploadedFilesWrapper>
+    </SettingsContainer>
   );
 };
 


### PR DESCRIPTION
## Description of the change

Moves the UploadedFiles component (which displays a list of files the user uploaded) to the new Settings page, and updates the Settings page to the new design.

Demo:

https://user-images.githubusercontent.com/59492998/191997458-6f8ae4e3-dea1-4faf-9941-613ef5b6827b.mov

Loading & Error States (ignore the buttons - updated in the demo above):
<img width="1728" alt="Screen Shot 2022-09-22 at 8 59 37 PM" src="https://user-images.githubusercontent.com/59492998/192002934-27446d30-28da-4745-96be-b51e356f02e6.png">
<img width="1728" alt="Screen Shot 2022-09-22 at 8 57 35 PM" src="https://user-images.githubusercontent.com/59492998/192002939-3d581313-4f99-487e-ac8a-00a6b7dab8a1.png">


## Related issues

Closes #38

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
