### PR TITLE
Data Entry Form: Dimension Field Wrapping

### DIFF
--- a/publisher/src/components/Forms/Form.styles.tsx
+++ b/publisher/src/components/Forms/Form.styles.tsx
@@ -213,6 +213,8 @@ export const TabDisplay = styled.div`
 `;
 
 export const DisaggregationInputWrapper = styled.div`
+  width: 49%;
+
   label {
     width: 100%;
     padding-right: 60px;


### PR DESCRIPTION
## Description of the change

The dimension fields are currently not wrapping and showing as one column in the breakdown sections of the form.

Example:
<img width="1728" alt="Screen Shot 2022-09-30 at 10 54 30 AM" src="https://user-images.githubusercontent.com/59492998/193310483-c2c2de40-09cc-44ea-8b6e-859a0f298569.png">


This adjusts the width of the fields so that they can properly wrap & appear side by side.

After adjusting width:
<img width="1728" alt="Screen Shot 2022-09-30 at 10 54 21 AM" src="https://user-images.githubusercontent.com/59492998/193310500-54623ad1-d6ec-4d49-8f2b-08fd7b8f6c16.png">


## Related issues

Closes #48 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
