### PR TITLE
Add /auth path to proxy

### DIFF
--- a/publisher/src/setupProxy.js
+++ b/publisher/src/setupProxy.js
@@ -2,7 +2,7 @@ const { createProxyMiddleware } = require("http-proxy-middleware");
 
 module.exports = function (app) {
   app.use(
-    ["/api", "/app_public_config.js"],
+    ["/auth", "/api", "/app_public_config.js"],
     createProxyMiddleware({
       target: process.env.REACT_APP_PROXY_HOST,
       changeOrigin: true,


### PR DESCRIPTION
## Description of the change

Adds `/auth` to the list of paths in `setupProxy.js` to allow logging out.


## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
