### PR TITLE
Settings: Metric Configuration: Definitions (3/n)

### DIFF
--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -504,6 +504,7 @@ export const DefinitionItem = styled.div`
 
 export const DefinitionDisplayName = styled.div`
   ${typography.sizeCSS.medium}
+  margin-right: 8px;
 `;
 
 export const DefinitionSelection = styled.div`

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -17,7 +17,7 @@
 
 import styled from "styled-components/macro";
 
-import { BinaryRadioGroupWrapper } from "../Forms";
+import { BinaryRadioGroupWrapper, Button } from "../Forms";
 import { palette, typography } from "../GlobalStyles";
 
 export const MetricsViewContainer = styled.div`
@@ -442,10 +442,93 @@ export const MetricConfigurationWrapper = styled.div`
   gap: 126px;
 `;
 
-export const DefinitionsDisplay = styled.div`
+export const DefinitionsDisplayContainer = styled.div`
   display: flex;
   flex: 1 1 50%;
-  padding-top: 44px;
+  padding-top: 48px;
+`;
+
+export const DefinitionsDisplay = styled.div`
+  width: 100%;
+`;
+
+export const DefinitionsTitle = styled.div`
+  ${typography.sizeCSS.large}
+  margin-bottom: 24px;
+`;
+
+export const DefinitionsSubTitle = styled.div`
+  ${typography.sizeCSS.medium}
+  margin-bottom: 16px;
+`;
+
+export const DefinitionsDescription = styled.div`
+  ${typography.sizeCSS.normal}
+  margin-bottom: 32px;
+
+  span {
+    display: block;
+    color: ${palette.solid.orange};
+  }
+`;
+
+export const RevertToDefaultButton = styled(Button)`
+  ${typography.sizeCSS.normal}
+  background: ${palette.solid.white};
+  height: unset;
+  padding: 9px 0;
+`;
+
+export const Definitions = styled.div`
+  width: 100%;
+  display: flex;
+  flex-direction: column;
+  margin-top: 16px;
+`;
+
+export const DefinitionItem = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+`;
+
+export const DefinitionDisplayName = styled.div`
+  ${typography.sizeCSS.medium}
+`;
+
+export const DefinitionSelection = styled.div`
+  display: flex;
+  gap: 4px;
+`;
+
+export const DefinitionMiniButton = styled(RevertToDefaultButton)<{
+  selected?: boolean;
+}>`
+  width: unset;
+  padding: 9px 16px;
+
+  ${({ selected }) =>
+    selected &&
+    `
+      color: ${palette.solid.white};
+      background: ${palette.highlight.grey9};
+      
+      &:hover {
+        background: ${palette.highlight.grey9};
+        opacity: 0.9;
+      }
+
+      &:nth-child(3) {
+        background: ${palette.solid.blue};
+
+        &:hover {
+        opacity: 0.9;
+        }
+      }
+
+
+  `};
 `;
 
 export const NoDefinitionsSelected = styled.div`

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -25,6 +25,7 @@ export const MetricsViewContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
+  overflow: hidden;
 `;
 
 export const MetricsViewControlPanel = styled.div`
@@ -33,6 +34,7 @@ export const MetricsViewControlPanel = styled.div`
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
+  overflow-y: scroll;
 `;
 
 export const PanelContainerLeft = styled.div`
@@ -141,7 +143,7 @@ export const MetricDescription = styled.div`
 export const MetricDetailsDisplay = styled.div`
   width: 100%;
   overflow-y: scroll;
-  padding: 24px 0;
+  padding: 24px 12px 24px 0;
 `;
 
 export const MetricOnOffWrapper = styled.div`
@@ -436,10 +438,12 @@ export const MetricConfigurationDisplay = styled.div`
 `;
 
 export const MetricConfigurationWrapper = styled.div`
+  height: 85vh;
   width: 100%;
   display: flex;
   justify-content: space-between;
   gap: 126px;
+  overflow-y: hidden;
 `;
 
 export const DefinitionsDisplayContainer = styled.div`
@@ -447,6 +451,8 @@ export const DefinitionsDisplayContainer = styled.div`
   flex-direction: column;
   flex: 1 1 55%;
   padding-top: 48px;
+  padding-right: 12px;
+  overflow-y: scroll;
 `;
 
 export const DefinitionsDisplay = styled.div`

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -432,7 +432,7 @@ export const MetricConfigurationDisplay = styled.div`
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  flex: 1 1 50%;
+  flex: 1 1 45%;
 `;
 
 export const MetricConfigurationWrapper = styled.div`
@@ -444,7 +444,8 @@ export const MetricConfigurationWrapper = styled.div`
 
 export const DefinitionsDisplayContainer = styled.div`
   display: flex;
-  flex: 1 1 50%;
+  flex-direction: column;
+  flex: 1 1 55%;
   padding-top: 48px;
 `;
 
@@ -484,6 +485,7 @@ export const Definitions = styled.div`
   display: flex;
   flex-direction: column;
   margin-top: 16px;
+  margin-bottom: 32px;
 `;
 
 export const DefinitionItem = styled.div`
@@ -491,6 +493,7 @@ export const DefinitionItem = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
+  margin-bottom: 6px;
 `;
 
 export const DefinitionDisplayName = styled.div`
@@ -513,7 +516,7 @@ export const DefinitionMiniButton = styled(RevertToDefaultButton)<{
     `
       color: ${palette.solid.white};
       background: ${palette.highlight.grey9};
-      
+
       &:hover {
         background: ${palette.highlight.grey9};
         opacity: 0.9;

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -124,7 +124,7 @@ type MetricBoxProps = {
   frequency: ReportFrequency;
   description: string;
   enabled?: boolean;
-  setActiveMetricKey: React.Dispatch<React.SetStateAction<string>>;
+  setActiveMetricKey: React.Dispatch<React.SetStateAction<string | undefined>>;
 };
 
 const MetricBox: React.FC<MetricBoxProps> = ({
@@ -570,7 +570,7 @@ export const MetricsView: React.FC = observer(() => {
   const [loadingError, setLoadingError] = useState<string | undefined>(
     undefined
   );
-  const [activeMetricKey, setActiveMetricKey] = useState<string>("");
+  const [activeMetricKey, setActiveMetricKey] = useState<string | undefined>();
   const [activeDimension, setActiveDimension] =
     useState<MetricConfigurationMetricDimension>();
   const [metricSettings, setMetricSettings] = useState<{
@@ -895,7 +895,7 @@ export const MetricsView: React.FC = observer(() => {
               <MetricConfigurationDisplay>
                 <BackToMetrics
                   onClick={() => {
-                    setActiveMetricKey("");
+                    setActiveMetricKey(undefined);
                     setActiveDimension(undefined);
                   }}
                 >

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -74,7 +74,6 @@ import {
   MetricsViewContainer,
   MetricsViewControlPanel,
   MultipleChoiceWrapper,
-  NoDefinitionsSelected,
   RadioButtonGroupWrapper,
   StickyHeader,
   Subheader,

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -20,7 +20,12 @@ import { reaction, when } from "mobx";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useRef, useState } from "react";
 
-import { AgencySystems, FormError, ReportFrequency } from "../../shared/types";
+import {
+  AgencySystems,
+  FormError,
+  MetricContext,
+  ReportFrequency,
+} from "../../shared/types";
 import { useStore } from "../../stores";
 import {
   isPositiveNumber,
@@ -75,33 +80,43 @@ import {
   Subheader,
 } from ".";
 
-export type MetricsViewMetric = {
+export type MetricConfigurationSettingsOptions = "Yes" | "No" | "N/A";
+
+export type MetricConfigurationSettings = {
+  key: string;
+  label: string;
+  included: MetricConfigurationSettingsOptions;
+  default: MetricConfigurationSettingsOptions;
+};
+
+export type MetricConfigurationMetricDimension = {
+  key: string;
+  label: string;
+  value: string | number | boolean | null | undefined;
+  reporting_note: string;
+  enabled?: boolean;
+  settings: MetricConfigurationSettings[];
+};
+
+export type MetricConfigurationMetricDisaggregation = {
+  key: string;
+  display_name: string;
+  dimensions: MetricConfigurationMetricDimension[];
+  required: boolean;
+  helper_text: string | null | undefined;
+  enabled?: boolean;
+};
+
+export type MetricConfigurationMetric = {
   key: string;
   display_name: string;
   description: string;
   frequency: string;
   enabled: boolean;
   system: AgencySystems;
-  contexts: {
-    key: string;
-    display_name: string;
-    reporting_note: string;
-    required: boolean;
-    type: string;
-    value: string | null;
-    multiple_choice_options?: string[];
-  }[];
-  disaggregations: {
-    key: string;
-    display_name: string;
-    enabled: boolean;
-    dimensions: {
-      key: string;
-      label: string;
-      reporting_note: string;
-      enabled: boolean;
-    }[];
-  }[];
+  contexts: MetricContext[];
+  disaggregations: MetricConfigurationMetricDisaggregation[];
+  settings: MetricConfigurationSettings[];
 };
 
 type MetricBoxProps = {
@@ -110,7 +125,6 @@ type MetricBoxProps = {
   frequency: ReportFrequency;
   description: string;
   enabled?: boolean;
-  activeMetricKey: string;
   setActiveMetricKey: React.Dispatch<React.SetStateAction<string>>;
 };
 
@@ -120,7 +134,6 @@ const MetricBox: React.FC<MetricBoxProps> = ({
   frequency,
   description,
   enabled,
-  activeMetricKey,
   setActiveMetricKey,
 }): JSX.Element => {
   return (
@@ -141,18 +154,22 @@ const MetricBox: React.FC<MetricBoxProps> = ({
 
 type MetricConfigurationProps = {
   activeMetricKey: string;
-  filteredMetricSettings: { [key: string]: MetricsViewMetric };
+  filteredMetricSettings: { [key: string]: MetricConfigurationMetric };
   saveAndUpdateMetricSettings: (
     typeOfUpdate: "METRIC" | "DISAGGREGATION" | "DIMENSION" | "CONTEXT",
     updatedSetting: MetricSettings,
     debounce?: boolean
   ) => void;
+  setActiveDimension: React.Dispatch<
+    React.SetStateAction<MetricConfigurationMetricDimension | undefined>
+  >;
 };
 
 const MetricConfiguration: React.FC<MetricConfigurationProps> = ({
   activeMetricKey,
   filteredMetricSettings,
   saveAndUpdateMetricSettings,
+  setActiveDimension,
 }): JSX.Element => {
   const [activeDisaggregation, setActiveDisaggregation] = useState(
     filteredMetricSettings[activeMetricKey]?.disaggregations?.[0]
@@ -234,7 +251,10 @@ const MetricConfiguration: React.FC<MetricConfigurationProps> = ({
                 (disaggregation) => (
                   <TabbedItem
                     key={disaggregation.key}
-                    onClick={() => setActiveDisaggregation(disaggregation)}
+                    onClick={() => {
+                      setActiveDimension(disaggregation.dimensions[0]);
+                      setActiveDisaggregation(disaggregation);
+                    }}
                     selected={disaggregation.key === activeDisaggregation.key}
                     capitalize
                   >
@@ -280,6 +300,7 @@ const MetricConfiguration: React.FC<MetricConfigurationProps> = ({
                 <Dimension
                   key={dimension.key}
                   enabled={!metricEnabled || activeDisaggregation.enabled}
+                  onClick={() => setActiveDimension(dimension)}
                 >
                   <CheckboxWrapper>
                     <Checkbox
@@ -334,7 +355,7 @@ const MetricConfiguration: React.FC<MetricConfigurationProps> = ({
   );
 };
 
-type MetricSettingsUpdateOptions =
+export type MetricSettingsUpdateOptions =
   | "METRIC"
   | "DISAGGREGATION"
   | "DIMENSION"
@@ -342,15 +363,7 @@ type MetricSettingsUpdateOptions =
 
 type MetricContextConfigurationProps = {
   metricKey: string;
-  contexts: {
-    key: string;
-    display_name: string;
-    reporting_note: string;
-    required: boolean;
-    type: string;
-    value: string | null;
-    multiple_choice_options?: string[];
-  }[];
+  contexts: MetricContext[];
   saveAndUpdateMetricSettings: (
     typeOfUpdate: MetricSettingsUpdateOptions,
     updatedSetting: MetricSettings,
@@ -360,11 +373,9 @@ type MetricContextConfigurationProps = {
 
 // TODO(#73) Plug into the Definitions panel once implemented
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
-const MetricContextConfiguration: React.FC<MetricContextConfigurationProps> = ({
-  metricKey,
-  contexts,
-  saveAndUpdateMetricSettings,
-}) => {
+export const MetricContextConfiguration: React.FC<
+  MetricContextConfigurationProps
+> = ({ metricKey, contexts, saveAndUpdateMetricSettings }) => {
   const [contextErrors, setContextErrors] = useState<{
     [key: string]: FormError;
   }>();
@@ -395,7 +406,7 @@ const MetricContextConfiguration: React.FC<MetricContextConfigurationProps> = ({
     if (contexts) {
       contexts.forEach((context) => {
         if (context.type === "NUMBER") {
-          contextNumberValidation(context.key, context.value || "");
+          contextNumberValidation(context.key, (context.value || "") as string);
         }
       });
     }
@@ -465,7 +476,7 @@ const MetricContextConfiguration: React.FC<MetricContextConfigurationProps> = ({
                 name={context.key}
                 id={context.key}
                 label=""
-                value={context.value || ""}
+                value={(context.value || "") as string}
                 multiline={context.type === "TEXT"}
                 error={contextErrors?.[context.key]}
                 onChange={(e) => {
@@ -549,7 +560,7 @@ export type MetricSettings = {
 };
 
 type MetricSettingsObj = {
-  [key: string]: MetricsViewMetric;
+  [key: string]: MetricConfigurationMetric;
 };
 
 export const MetricsView: React.FC = observer(() => {
@@ -561,8 +572,12 @@ export const MetricsView: React.FC = observer(() => {
     undefined
   );
   const [activeMetricKey, setActiveMetricKey] = useState<string>("");
+  const [activeDimension, setActiveDimension] =
+    useState<
+      MetricConfigurationMetric["disaggregations"][0]["dimensions"][0]
+    >();
   const [metricSettings, setMetricSettings] = useState<{
-    [key: string]: MetricsViewMetric;
+    [key: string]: MetricConfigurationMetric;
   }>({});
 
   const filteredMetricSettings: MetricSettingsObj = Object.values(
@@ -776,8 +791,10 @@ export const MetricsView: React.FC = observer(() => {
       return setLoadingError(response.message);
     }
 
-    const reportSettings = (await response.json()) as MetricsViewMetric[];
-    const metricKeyToMetricMap: { [key: string]: MetricsViewMetric } = {};
+    const reportSettings =
+      (await response.json()) as MetricConfigurationMetric[];
+    const metricKeyToMetricMap: { [key: string]: MetricConfigurationMetric } =
+      {};
 
     reportSettings?.forEach((metric) => {
       metricKeyToMetricMap[metric.key] = metric;
@@ -871,7 +888,6 @@ export const MetricsView: React.FC = observer(() => {
                 frequency={metric.frequency as ReportFrequency}
                 description={metric.description}
                 enabled={metric.enabled}
-                activeMetricKey={activeMetricKey}
                 setActiveMetricKey={setActiveMetricKey}
               />
             ))}
@@ -880,11 +896,16 @@ export const MetricsView: React.FC = observer(() => {
           {activeMetricKey && (
             <MetricConfigurationWrapper>
               <MetricConfigurationDisplay>
-                <BackToMetrics onClick={() => setActiveMetricKey("")}>
+                <BackToMetrics
+                  onClick={() => {
+                    setActiveMetricKey("");
+                    setActiveDimension(undefined);
+                  }}
+                >
                   ← Back to Metrics
                 </BackToMetrics>
 
-                <Metric>
+                <Metric onClick={() => setActiveDimension(undefined)}>
                   <MetricName isTitle>
                     {metricSettings[activeMetricKey]?.display_name}
                   </MetricName>
@@ -898,18 +919,18 @@ export const MetricsView: React.FC = observer(() => {
                     activeMetricKey={activeMetricKey}
                     filteredMetricSettings={filteredMetricSettings}
                     saveAndUpdateMetricSettings={saveAndUpdateMetricSettings}
+                    setActiveDimension={setActiveDimension}
                   />
-                  {/* <MetricContextConfiguration
-                  metricKey={activeMetricKey}
-                  contexts={metricSettings[activeMetricKey]?.contexts}
-                  saveAndUpdateMetricSettings={saveAndUpdateMetricSettings}
-                /> */}
                 </MetricDetailsDisplay>
               </MetricConfigurationDisplay>
 
+              {/* Metric/Dimension Definitions (Includes/Excludes) */}
               <MetricDefinitions
                 activeMetricKey={activeMetricKey}
                 filteredMetricSettings={filteredMetricSettings}
+                activeDimension={activeDimension}
+                contexts={metricSettings[activeMetricKey]?.contexts}
+                saveAndUpdateMetricSettings={saveAndUpdateMetricSettings}
               />
             </MetricConfigurationWrapper>
           )}

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -27,7 +27,6 @@ import {
   removeCommaSpaceAndTrim,
   removeSnakeCase,
 } from "../../utils";
-import { ReactComponent as GearsIcon } from "../assets/gears-icon.svg";
 import blueCheck from "../assets/status-check-icon.png";
 import { Badge } from "../Badge";
 import {
@@ -46,7 +45,6 @@ import {
   BreakdownHeader,
   Checkbox,
   CheckboxWrapper,
-  DefinitionsDisplay,
   Dimension,
   DimensionTitle,
   DimensionTitleWrapper,
@@ -61,6 +59,7 @@ import {
   MetricConfigurationWrapper,
   MetricContextContainer,
   MetricContextItem,
+  MetricDefinitions,
   MetricDescription,
   MetricDetailsDisplay,
   MetricDisaggregations,
@@ -76,7 +75,7 @@ import {
   Subheader,
 } from ".";
 
-type MetricsViewMetric = {
+export type MetricsViewMetric = {
   key: string;
   display_name: string;
   description: string;
@@ -908,13 +907,10 @@ export const MetricsView: React.FC = observer(() => {
                 </MetricDetailsDisplay>
               </MetricConfigurationDisplay>
 
-              <DefinitionsDisplay>
-                <NoDefinitionsSelected>
-                  <GearsIcon />
-                  Choose the Annual or Monthly reporting frequency to edit the
-                  definitions and context.
-                </NoDefinitionsSelected>
-              </DefinitionsDisplay>
+              <MetricDefinitions
+                activeMetricKey={activeMetricKey}
+                filteredMetricSettings={filteredMetricSettings}
+              />
             </MetricConfigurationWrapper>
           )}
         </MetricsViewControlPanel>

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -20,6 +20,7 @@ import { reaction, when } from "mobx";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useRef, useState } from "react";
 
+import { ListOfMetricsForNavigation } from "../../pages/Settings";
 import {
   AgencySystems,
   FormError,
@@ -181,17 +182,24 @@ const MetricConfiguration: React.FC<MetricConfigurationProps> = ({
 
   useEffect(
     () => {
-      const updatedDisaggregation = filteredMetricSettings[
-        activeMetricKey
-      ]?.disaggregations?.find(
-        (disaggregation) => disaggregation.key === activeDisaggregation.key
-      );
+      const updatedDisaggregation =
+        activeDisaggregation &&
+        filteredMetricSettings[activeMetricKey]?.disaggregations?.find(
+          (disaggregation) => disaggregation.key === activeDisaggregation.key
+        );
 
-      if (updatedDisaggregation) setActiveDisaggregation(updatedDisaggregation);
+      setActiveDimension(undefined);
+
+      if (updatedDisaggregation)
+        return setActiveDisaggregation(updatedDisaggregation);
+      setActiveDisaggregation(
+        filteredMetricSettings[activeMetricKey].disaggregations[0]
+      );
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [filteredMetricSettings]
+    [activeMetricKey]
   );
+
   return (
     <MetricConfigurationContainer>
       <MetricOnOffWrapper>
@@ -246,50 +254,51 @@ const MetricConfiguration: React.FC<MetricConfigurationProps> = ({
 
           <TabbedBar noPadding>
             <TabbedOptions>
-              {filteredMetricSettings[activeMetricKey]?.disaggregations?.map(
-                (disaggregation) => (
-                  <TabbedItem
-                    key={disaggregation.key}
-                    onClick={() => {
-                      setActiveDimension(disaggregation.dimensions[0]);
-                      setActiveDisaggregation(disaggregation);
-                    }}
-                    selected={disaggregation.key === activeDisaggregation.key}
-                    capitalize
-                  >
-                    <DisaggregationTab>
-                      <span>
-                        {removeSnakeCase(
-                          disaggregation.display_name.toLowerCase()
-                        )}
-                      </span>
+              {activeDisaggregation &&
+                filteredMetricSettings[activeMetricKey]?.disaggregations?.map(
+                  (disaggregation) => (
+                    <TabbedItem
+                      key={disaggregation.key}
+                      onClick={() => {
+                        setActiveDimension(disaggregation.dimensions[0]);
+                        setActiveDisaggregation(disaggregation);
+                      }}
+                      selected={disaggregation.key === activeDisaggregation.key}
+                      capitalize
+                    >
+                      <DisaggregationTab>
+                        <span>
+                          {removeSnakeCase(
+                            disaggregation.display_name.toLowerCase()
+                          )}
+                        </span>
 
-                      <CheckboxWrapper>
-                        <Checkbox
-                          type="checkbox"
-                          checked={disaggregation.enabled}
-                          onChange={() =>
-                            saveAndUpdateMetricSettings("DISAGGREGATION", {
-                              key: activeMetricKey,
-                              disaggregations: [
-                                {
-                                  key: disaggregation.key,
-                                  enabled: !disaggregation.enabled,
-                                },
-                              ],
-                            })
-                          }
-                        />
-                        <BlueCheckIcon
-                          src={blueCheck}
-                          alt=""
-                          enabled={disaggregation.enabled}
-                        />
-                      </CheckboxWrapper>
-                    </DisaggregationTab>
-                  </TabbedItem>
-                )
-              )}
+                        <CheckboxWrapper>
+                          <Checkbox
+                            type="checkbox"
+                            checked={disaggregation.enabled}
+                            onChange={() =>
+                              saveAndUpdateMetricSettings("DISAGGREGATION", {
+                                key: activeMetricKey,
+                                disaggregations: [
+                                  {
+                                    key: disaggregation.key,
+                                    enabled: !disaggregation.enabled,
+                                  },
+                                ],
+                              })
+                            }
+                          />
+                          <BlueCheckIcon
+                            src={blueCheck}
+                            alt=""
+                            enabled={disaggregation.enabled}
+                          />
+                        </CheckboxWrapper>
+                      </DisaggregationTab>
+                    </TabbedItem>
+                  )
+                )}
             </TabbedOptions>
           </TabbedBar>
 
@@ -562,7 +571,13 @@ type MetricSettingsObj = {
   [key: string]: MetricConfigurationMetric;
 };
 
-export const MetricsView: React.FC = observer(() => {
+export const MetricsView: React.FC<{
+  activeMetricKey: string | undefined;
+  setActiveMetricKey: React.Dispatch<React.SetStateAction<string | undefined>>;
+  setListOfMetrics: React.Dispatch<
+    React.SetStateAction<ListOfMetricsForNavigation[] | undefined>
+  >;
+}> = observer(({ activeMetricKey, setActiveMetricKey, setListOfMetrics }) => {
   const { reportStore, userStore, datapointsStore } = useStore();
 
   const [activeMetricFilter, setActiveMetricFilter] = useState<string>();
@@ -570,7 +585,6 @@ export const MetricsView: React.FC = observer(() => {
   const [loadingError, setLoadingError] = useState<string | undefined>(
     undefined
   );
-  const [activeMetricKey, setActiveMetricKey] = useState<string | undefined>();
   const [activeDimension, setActiveDimension] =
     useState<MetricConfigurationMetricDimension>();
   const [metricSettings, setMetricSettings] = useState<{
@@ -588,6 +602,24 @@ export const MetricsView: React.FC = observer(() => {
       res[metric.key] = metric;
       return res;
     }, {});
+
+  /** Updates shared state `listOfMetrics` so the SettingsMenu component can render the metric navigation */
+  useEffect(
+    () => {
+      const listOfMetricsForMetricNavigation = Object.values(
+        filteredMetricSettings
+      ).map((metric) => {
+        return {
+          key: metric.key,
+          display_name: metric.display_name,
+        };
+      });
+
+      setListOfMetrics(listOfMetricsForMetricNavigation);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [filteredMetricSettings]
+  );
 
   const updateMetricSettings = (
     typeOfUpdate: MetricSettingsUpdateOptions,

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -572,9 +572,7 @@ export const MetricsView: React.FC = observer(() => {
   );
   const [activeMetricKey, setActiveMetricKey] = useState<string>("");
   const [activeDimension, setActiveDimension] =
-    useState<
-      MetricConfigurationMetric["disaggregations"][0]["dimensions"][0]
-    >();
+    useState<MetricConfigurationMetricDimension>();
   const [metricSettings, setMetricSettings] = useState<{
     [key: string]: MetricConfigurationMetric;
   }>({});

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -1,0 +1,99 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2022 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import React, { useState } from "react";
+
+import { ReactComponent as GearsIcon } from "../assets/gears-icon.svg";
+import {
+  DefinitionDisplayName,
+  DefinitionItem,
+  DefinitionMiniButton,
+  Definitions,
+  DefinitionsDescription,
+  DefinitionsDisplay,
+  DefinitionsDisplayContainer,
+  DefinitionSelection,
+  DefinitionsSubTitle,
+  DefinitionsTitle,
+  MetricsViewMetric,
+  NoDefinitionsSelected,
+  RevertToDefaultButton,
+} from ".";
+
+type MetricDefinitionsProps = {
+  activeMetricKey: string;
+  filteredMetricSettings: { [key: string]: MetricsViewMetric };
+};
+
+export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
+  activeMetricKey,
+  filteredMetricSettings,
+}) => {
+  const [currentMockSelection, setCurrentMockSelection] = useState<string>();
+  console.log(filteredMetricSettings[activeMetricKey]);
+
+  return (
+    <DefinitionsDisplayContainer>
+      <DefinitionsDisplay>
+        <DefinitionsTitle>
+          {filteredMetricSettings[activeMetricKey].display_name}
+        </DefinitionsTitle>
+        <DefinitionsSubTitle>Definitions</DefinitionsSubTitle>
+        <DefinitionsDescription>
+          Indicate which of the following categories your agency considers to be
+          part of this metric or breakdown.
+          <span>
+            You are NOT required to gather data for these specific categories.
+          </span>
+        </DefinitionsDescription>
+
+        <RevertToDefaultButton>
+          Revert to Default Definition
+        </RevertToDefaultButton>
+
+        <Definitions>
+          <DefinitionItem>
+            <DefinitionDisplayName>
+              Staff available to work?
+            </DefinitionDisplayName>
+
+            <DefinitionSelection>
+              <DefinitionMiniButton
+                selected={currentMockSelection === "N/A"}
+                onClick={() => setCurrentMockSelection("N/A")}
+              >
+                N/A
+              </DefinitionMiniButton>
+              <DefinitionMiniButton
+                selected={currentMockSelection === "No"}
+                onClick={() => setCurrentMockSelection("No")}
+              >
+                No
+              </DefinitionMiniButton>
+              <DefinitionMiniButton
+                selected={currentMockSelection === "Yes"}
+                onClick={() => setCurrentMockSelection("Yes")}
+              >
+                Yes
+              </DefinitionMiniButton>
+            </DefinitionSelection>
+          </DefinitionItem>
+        </Definitions>
+      </DefinitionsDisplay>
+    </DefinitionsDisplayContainer>
+  );
+};

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -73,16 +73,18 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
       | MetricConfigurationMetric =
       activeDimension || filteredMetricSettings[activeMetricKey];
 
-    const mockSettings = Array.from({ length: 10 }, (_, i) => ({
-      key: `SETTING ${i}`,
-      label: `Includes/Excludes Q#${i + 1} for ${
-        "display_name" in dimensionOrMetric
-          ? dimensionOrMetric.display_name
-          : dimensionOrMetric.label
-      }?`,
-      included: selectionOptions[i % 3],
-      default: selectionOptions[i % 3],
-    }));
+    const mockSettings = dimensionOrMetric
+      ? Array.from({ length: 10 }, (_, i) => ({
+          key: `SETTING ${i}`,
+          label: `Includes/Excludes Q#${i + 1} for ${
+            "display_name" in dimensionOrMetric
+              ? dimensionOrMetric.display_name
+              : dimensionOrMetric.label
+          }?`,
+          included: selectionOptions[i % 3],
+          default: selectionOptions[i % 3],
+        }))
+      : [];
 
     return { ...dimensionOrMetric, settings: mockSettings };
   };

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -63,12 +63,8 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
     "Yes",
   ];
 
-  /** TODO(#82): Uncomment `definitionToDisplay` */
-  //   const definitionToDisplay =
-  //     activeDimension || filteredMetricSettings[activeMetricKey];
-
-  /** TODO(#82): Replace mocks when GET & POST are implemented */
-  /** Mocks To Be Replaced */
+  /** TODO(#82): Remove mocks when GET & POST are implemented */
+  /** Mocks To Be Removed */
   const generateMockDefinitions = ():
     | MetricConfigurationMetricDimension
     | MetricConfigurationMetric => {
@@ -122,7 +118,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [activeMetricKey, activeDimension]
   );
-  /** End of Mocks To Be Replaced */
+  /** End of Mocks To Be Removed */
 
   return (
     <DefinitionsDisplayContainer>

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -146,16 +146,16 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
         </RevertToDefaultButton>
 
         <Definitions>
-          {mockDefinitionsToDisplay?.settings.map((item) => (
-            <DefinitionItem>
-              <DefinitionDisplayName>{item.label}</DefinitionDisplayName>
+          {mockDefinitionsToDisplay?.settings.map((setting) => (
+            <DefinitionItem key={setting.key}>
+              <DefinitionDisplayName>{setting.label}</DefinitionDisplayName>
 
               <DefinitionSelection>
                 {selectionOptions.map((option) => (
                   <Fragment key={option}>
                     <DefinitionMiniButton
-                      selected={item.included === option}
-                      onClick={() => mockUpdateSelection(item.key, option)}
+                      selected={setting.included === option}
+                      onClick={() => mockUpdateSelection(setting.key, option)}
                     >
                       {option}
                     </DefinitionMiniButton>

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -18,7 +18,6 @@
 import React, { Fragment, useEffect, useState } from "react";
 
 import { MetricContext } from "../../shared/types";
-import { ReactComponent as GearsIcon } from "../assets/gears-icon.svg";
 import {
   DefinitionDisplayName,
   DefinitionItem,
@@ -36,7 +35,6 @@ import {
   MetricContextConfiguration,
   MetricSettings,
   MetricSettingsUpdateOptions,
-  NoDefinitionsSelected,
   RevertToDefaultButton,
 } from ".";
 
@@ -74,7 +72,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
   const generateMockDefinitions = ():
     | MetricConfigurationMetricDimension
     | MetricConfigurationMetric => {
-    const definition:
+    const dimensionOrMetric:
       | MetricConfigurationMetricDimension
       | MetricConfigurationMetric =
       activeDimension || filteredMetricSettings[activeMetricKey];
@@ -82,36 +80,36 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
     const mockSettings = Array.from({ length: 10 }, (_, i) => ({
       key: `SETTING ${i}`,
       label: `Includes/Excludes Q#${i + 1} for ${
-        "display_name" in definition
-          ? definition.display_name
-          : definition.label
+        "display_name" in dimensionOrMetric
+          ? dimensionOrMetric.display_name
+          : dimensionOrMetric.label
       }?`,
       included: selectionOptions[i % 3],
       default: selectionOptions[i % 3],
     }));
 
-    return { ...definition, settings: mockSettings };
+    return { ...dimensionOrMetric, settings: mockSettings };
   };
 
-  const initialDefinitionToDisplay = generateMockDefinitions();
+  const initialDefinitionsToDisplay = generateMockDefinitions();
 
-  const [mockDefinitionToDisplay, setMockDefinitionToDisplay] = useState<
+  const [mockDefinitionsToDisplay, setMockDefinitionsToDisplay] = useState<
     MetricConfigurationMetricDimension | MetricConfigurationMetric
-  >(initialDefinitionToDisplay);
+  >(initialDefinitionsToDisplay);
 
   const mockUpdateSelection = (
     key: string,
     selection: MetricConfigurationSettingsOptions
   ) => {
-    setMockDefinitionToDisplay((prev) => {
+    setMockDefinitionsToDisplay((prev) => {
       return {
         ...prev,
-        settings: prev.settings.map((item) => {
-          if (item.key === key) {
-            return { ...item, included: selection };
+        settings: prev.settings.map((setting) => {
+          if (setting.key === key) {
+            return { ...setting, included: selection };
           }
 
-          return item;
+          return setting;
         }),
       };
     });
@@ -119,7 +117,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
 
   useEffect(
     () => {
-      setMockDefinitionToDisplay(initialDefinitionToDisplay);
+      setMockDefinitionsToDisplay(initialDefinitionsToDisplay);
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [activeMetricKey, activeDimension]
@@ -130,9 +128,9 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
     <DefinitionsDisplayContainer>
       <DefinitionsDisplay>
         <DefinitionsTitle>
-          {"display_name" in mockDefinitionToDisplay
-            ? mockDefinitionToDisplay.display_name
-            : mockDefinitionToDisplay.label}
+          {"display_name" in mockDefinitionsToDisplay
+            ? mockDefinitionsToDisplay.display_name
+            : mockDefinitionsToDisplay.label}
         </DefinitionsTitle>
         <DefinitionsSubTitle>Definitions</DefinitionsSubTitle>
         <DefinitionsDescription>
@@ -144,13 +142,15 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
         </DefinitionsDescription>
 
         <RevertToDefaultButton
-          onClick={() => setMockDefinitionToDisplay(initialDefinitionToDisplay)}
+          onClick={() =>
+            setMockDefinitionsToDisplay(initialDefinitionsToDisplay)
+          }
         >
           Revert to Default Definition
         </RevertToDefaultButton>
 
         <Definitions>
-          {mockDefinitionToDisplay?.settings.map((item) => (
+          {mockDefinitionsToDisplay?.settings.map((item) => (
             <DefinitionItem>
               <DefinitionDisplayName>{item.label}</DefinitionDisplayName>
 

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -15,8 +15,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React, { useState } from "react";
+import React, { Fragment, useEffect, useState } from "react";
 
+import { MetricContext } from "../../shared/types";
 import { ReactComponent as GearsIcon } from "../assets/gears-icon.svg";
 import {
   DefinitionDisplayName,
@@ -29,28 +30,109 @@ import {
   DefinitionSelection,
   DefinitionsSubTitle,
   DefinitionsTitle,
-  MetricsViewMetric,
+  MetricConfigurationMetric,
+  MetricConfigurationMetricDimension,
+  MetricConfigurationSettingsOptions,
+  MetricContextConfiguration,
+  MetricSettings,
+  MetricSettingsUpdateOptions,
   NoDefinitionsSelected,
   RevertToDefaultButton,
 } from ".";
 
 type MetricDefinitionsProps = {
   activeMetricKey: string;
-  filteredMetricSettings: { [key: string]: MetricsViewMetric };
+  filteredMetricSettings: { [key: string]: MetricConfigurationMetric };
+  activeDimension?: MetricConfigurationMetricDimension | undefined;
+  contexts: MetricContext[];
+  saveAndUpdateMetricSettings: (
+    typeOfUpdate: MetricSettingsUpdateOptions,
+    updatedSetting: MetricSettings,
+    debounce?: boolean
+  ) => void;
 };
 
 export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
   activeMetricKey,
   filteredMetricSettings,
+  activeDimension,
+  contexts,
+  saveAndUpdateMetricSettings,
 }) => {
-  const [currentMockSelection, setCurrentMockSelection] = useState<string>();
-  console.log(filteredMetricSettings[activeMetricKey]);
+  const selectionOptions: MetricConfigurationSettingsOptions[] = [
+    "N/A",
+    "No",
+    "Yes",
+  ];
+
+  /** TODO(#82): Uncomment `definitionToDisplay` */
+  //   const definitionToDisplay =
+  //     activeDimension || filteredMetricSettings[activeMetricKey];
+
+  /** TODO(#82): Replace mocks when GET & POST are implemented */
+  /** Mocks To Be Replaced */
+  const generateMockDefinitions = ():
+    | MetricConfigurationMetricDimension
+    | MetricConfigurationMetric => {
+    const definition:
+      | MetricConfigurationMetricDimension
+      | MetricConfigurationMetric =
+      activeDimension || filteredMetricSettings[activeMetricKey];
+
+    const mockSettings = Array.from({ length: 10 }, (_, i) => ({
+      key: `SETTING ${i}`,
+      label: `Includes/Excludes Q#${i + 1} for ${
+        "display_name" in definition
+          ? definition.display_name
+          : definition.label
+      }?`,
+      included: selectionOptions[i % 3],
+      default: selectionOptions[i % 3],
+    }));
+
+    return { ...definition, settings: mockSettings };
+  };
+
+  const initialDefinitionToDisplay = generateMockDefinitions();
+
+  const [mockDefinitionToDisplay, setMockDefinitionToDisplay] = useState<
+    MetricConfigurationMetricDimension | MetricConfigurationMetric
+  >(initialDefinitionToDisplay);
+
+  const mockUpdateSelection = (
+    key: string,
+    selection: MetricConfigurationSettingsOptions
+  ) => {
+    setMockDefinitionToDisplay((prev) => {
+      return {
+        ...prev,
+        settings: prev.settings.map((item) => {
+          if (item.key === key) {
+            return { ...item, included: selection };
+          }
+
+          return item;
+        }),
+      };
+    });
+  };
+
+  useEffect(
+    () => {
+      setMockDefinitionToDisplay(initialDefinitionToDisplay);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeMetricKey, activeDimension]
+  );
+  /** End of Mocks To Be Replaced */
 
   return (
     <DefinitionsDisplayContainer>
       <DefinitionsDisplay>
         <DefinitionsTitle>
-          {filteredMetricSettings[activeMetricKey].display_name}
+          {"display_name" in mockDefinitionToDisplay
+            ? mockDefinitionToDisplay.display_name
+            : mockDefinitionToDisplay.label}
         </DefinitionsTitle>
         <DefinitionsSubTitle>Definitions</DefinitionsSubTitle>
         <DefinitionsDescription>
@@ -61,39 +143,42 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
           </span>
         </DefinitionsDescription>
 
-        <RevertToDefaultButton>
+        <RevertToDefaultButton
+          onClick={() => setMockDefinitionToDisplay(initialDefinitionToDisplay)}
+        >
           Revert to Default Definition
         </RevertToDefaultButton>
 
         <Definitions>
-          <DefinitionItem>
-            <DefinitionDisplayName>
-              Staff available to work?
-            </DefinitionDisplayName>
+          {mockDefinitionToDisplay?.settings.map((item) => (
+            <DefinitionItem>
+              <DefinitionDisplayName>{item.label}</DefinitionDisplayName>
 
-            <DefinitionSelection>
-              <DefinitionMiniButton
-                selected={currentMockSelection === "N/A"}
-                onClick={() => setCurrentMockSelection("N/A")}
-              >
-                N/A
-              </DefinitionMiniButton>
-              <DefinitionMiniButton
-                selected={currentMockSelection === "No"}
-                onClick={() => setCurrentMockSelection("No")}
-              >
-                No
-              </DefinitionMiniButton>
-              <DefinitionMiniButton
-                selected={currentMockSelection === "Yes"}
-                onClick={() => setCurrentMockSelection("Yes")}
-              >
-                Yes
-              </DefinitionMiniButton>
-            </DefinitionSelection>
-          </DefinitionItem>
+              <DefinitionSelection>
+                {selectionOptions.map((option) => (
+                  <Fragment key={option}>
+                    <DefinitionMiniButton
+                      selected={item.included === option}
+                      onClick={() => mockUpdateSelection(item.key, option)}
+                    >
+                      {option}
+                    </DefinitionMiniButton>
+                  </Fragment>
+                ))}
+              </DefinitionSelection>
+            </DefinitionItem>
+          ))}
         </Definitions>
       </DefinitionsDisplay>
+
+      {/* Additional Context (only appears on overall metric settings and not individual dimension settings) */}
+      {!activeDimension && (
+        <MetricContextConfiguration
+          metricKey={activeMetricKey}
+          contexts={contexts}
+          saveAndUpdateMetricSettings={saveAndUpdateMetricSettings}
+        />
+      )}
     </DefinitionsDisplayContainer>
   );
 };

--- a/publisher/src/components/MetricConfiguration/index.ts
+++ b/publisher/src/components/MetricConfiguration/index.ts
@@ -17,3 +17,4 @@
 
 export * from "./MetricConfiguration";
 export * from "./MetricConfiguration.styles";
+export * from "./MetricDefinitions";

--- a/publisher/src/components/Reports/ReportSummaryPanel.tsx
+++ b/publisher/src/components/Reports/ReportSummaryPanel.tsx
@@ -111,7 +111,7 @@ const ReportSummarySection = styled.a`
   }
 `;
 
-const MetricDisplayName = styled.div<{
+export const MetricDisplayName = styled.div<{
   activeSection?: boolean;
 }>`
   ${({ activeSection }) =>

--- a/publisher/src/components/Settings/Settings.styles.tsx
+++ b/publisher/src/components/Settings/Settings.styles.tsx
@@ -18,6 +18,7 @@
 import styled from "styled-components/macro";
 
 import { palette, typography } from "../GlobalStyles";
+import { MetricDisplayName } from "../Reports/ReportSummaryPanel";
 
 export const SettingsContainer = styled.div`
   width: 100%;
@@ -73,5 +74,19 @@ export const InputWrapper = styled.div`
 
   div {
     width: 100%;
+  }
+`;
+
+export const MetricsListContainer = styled.div``;
+
+export const MetricsListItem = styled(MetricDisplayName)`
+  ${typography.sizeCSS.normal}
+  width: fit-content;
+  color: ${({ activeSection }) =>
+    activeSection ? palette.solid.darkgrey : palette.highlight.grey8};
+
+  &:hover {
+    cursor: pointer;
+    color: ${palette.solid.darkgrey};
   }
 `;

--- a/publisher/src/components/Settings/SettingsMenu.tsx
+++ b/publisher/src/components/Settings/SettingsMenu.tsx
@@ -15,25 +15,68 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React from "react";
+import React, { Fragment } from "react";
 
-import { MenuOptions, menuOptions } from "../../pages/Settings";
-import { MenuItem, SettingsMenuContainer } from "./Settings.styles";
+import {
+  ListOfMetricsForNavigation,
+  MenuOptions,
+  menuOptions,
+} from "../../pages/Settings";
+import {
+  MenuItem,
+  MetricsListContainer,
+  MetricsListItem,
+  SettingsMenuContainer,
+} from ".";
 
 export const SettingsMenu: React.FC<{
   activeMenuItem: MenuOptions;
   goToMenuItem: (destination: MenuOptions) => void;
-}> = ({ activeMenuItem, goToMenuItem }) => {
+  activeMetricKey: string | undefined;
+  setActiveMetricKey: React.Dispatch<React.SetStateAction<string | undefined>>;
+  listOfMetrics: ListOfMetricsForNavigation[] | undefined;
+}> = ({
+  activeMenuItem,
+  goToMenuItem,
+  activeMetricKey,
+  setActiveMetricKey,
+  listOfMetrics,
+}) => {
   return (
     <SettingsMenuContainer>
       {menuOptions.map((option) => (
-        <MenuItem
-          key={option}
-          selected={option === activeMenuItem}
-          onClick={() => goToMenuItem(option)}
-        >
-          {option}
-        </MenuItem>
+        <Fragment key={option}>
+          <MenuItem
+            selected={option === activeMenuItem}
+            onClick={() => {
+              goToMenuItem(option);
+
+              if (option === "Metric Configuration") {
+                setActiveMetricKey(undefined);
+              }
+            }}
+          >
+            {option}
+          </MenuItem>
+
+          {/* Metrics Navigation (appears when a metric has been 
+              selected and allows users to toggle between metrics) */}
+          {option === "Metric Configuration" &&
+            activeMenuItem === "Metric Configuration" &&
+            activeMetricKey &&
+            listOfMetrics && (
+              <MetricsListContainer>
+                {listOfMetrics.map((metric) => (
+                  <MetricsListItem
+                    activeSection={metric.key === activeMetricKey}
+                    onClick={() => setActiveMetricKey(metric.key)}
+                  >
+                    {metric.display_name}
+                  </MetricsListItem>
+                ))}
+              </MetricsListContainer>
+            )}
+        </Fragment>
       ))}
     </SettingsMenuContainer>
   );

--- a/publisher/src/pages/Settings.tsx
+++ b/publisher/src/pages/Settings.tsx
@@ -33,6 +33,11 @@ export const menuOptions = [
 ] as const;
 export type MenuOptions = typeof menuOptions[number];
 
+export type ListOfMetricsForNavigation = {
+  key: string;
+  display_name: string;
+};
+
 const Settings = () => {
   const [activeMenuItem, setActiveMenuItem] = useState<MenuOptions>(
     menuOptions[0]
@@ -41,17 +46,31 @@ const Settings = () => {
   const goToMenuItem = (destination: MenuOptions) =>
     setActiveMenuItem(destination);
 
+  /** State specific to Metrics Configuration & Settings Menu */
+  const [listOfMetrics, setListOfMetrics] =
+    useState<ListOfMetricsForNavigation[]>();
+  const [activeMetricKey, setActiveMetricKey] = useState<string | undefined>();
+
   return (
     <SettingsContainer>
       <SettingsMenu
         activeMenuItem={activeMenuItem}
         goToMenuItem={goToMenuItem}
+        activeMetricKey={activeMetricKey}
+        setActiveMetricKey={setActiveMetricKey}
+        listOfMetrics={listOfMetrics}
       />
 
       <ContentDisplay>
         {activeMenuItem === "Your Account" && <AccountSettings />}
         {activeMenuItem === "Uploaded Files" && <UploadedFiles />}
-        {activeMenuItem === "Metric Configuration" && <MetricsView />}
+        {activeMenuItem === "Metric Configuration" && (
+          <MetricsView
+            activeMetricKey={activeMetricKey}
+            setActiveMetricKey={setActiveMetricKey}
+            setListOfMetrics={setListOfMetrics}
+          />
+        )}
       </ContentDisplay>
     </SettingsContainer>
   );

--- a/publisher/src/shared/types.ts
+++ b/publisher/src/shared/types.ts
@@ -107,7 +107,7 @@ export interface MetricContext {
   display_name: string | null | undefined;
   reporting_note: string | null | undefined;
   required: boolean;
-  type: "TEXT" | "NUMBER" | "MULTIPLE_CHOICE";
+  type: "TEXT" | "NUMBER" | "MULTIPLE_CHOICE" | "BOOLEAN";
   value: string | number | boolean | null | undefined;
   multiple_choice_options: string[];
 }


### PR DESCRIPTION
## Description of the change

Implements the UI for the metric configuration definitions (includes/excludes) and moves the metric context configuration to the overall metric's definition. Currently it uses a mock settings object that is appended to the response and for now updates do not persist - the logic to save settings and send them to the backend will be implemented in a follow up PR (#82 specifically).

https://user-images.githubusercontent.com/59492998/195665047-73f32934-72a3-4914-8109-74eff6e3044a.mov

## Related issues

Closes #73

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
