### PR TITLE
Settings: Metric Configuration: Navigation (Table of Contents) (4/n) 

### DIFF
--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -200,14 +200,6 @@ const MetricConfiguration: React.FC<MetricConfigurationProps> = ({
     [activeMetricKey]
   );
 
-  useEffect(
-    () => {
-      // console.log("activeDisaggregation", activeDisaggregation);
-    },
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [activeMetricKey]
-  );
-
   return (
     <MetricConfigurationContainer>
       <MetricOnOffWrapper>

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -603,6 +603,7 @@ export const MetricsView: React.FC<{
       return res;
     }, {});
 
+  /** Updates shared state `listOfMetrics` so the SettingsMenu component can render the metric navigation */
   useEffect(
     () => {
       const listOfMetricsForMetricNavigation = Object.values(

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -73,16 +73,18 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
       | MetricConfigurationMetric =
       activeDimension || filteredMetricSettings[activeMetricKey];
 
-    const mockSettings = Array.from({ length: 10 }, (_, i) => ({
-      key: `SETTING ${i}`,
-      label: `Includes/Excludes Q#${i + 1} for ${
-        "display_name" in dimensionOrMetric
-          ? dimensionOrMetric.display_name
-          : dimensionOrMetric.label
-      }?`,
-      included: selectionOptions[i % 3],
-      default: selectionOptions[i % 3],
-    }));
+    const mockSettings = dimensionOrMetric
+      ? Array.from({ length: 10 }, (_, i) => ({
+          key: `SETTING ${i}`,
+          label: `Includes/Excludes Q#${i + 1} for ${
+            "display_name" in dimensionOrMetric
+              ? dimensionOrMetric.display_name
+              : dimensionOrMetric.label
+          }?`,
+          included: selectionOptions[i % 3],
+          default: selectionOptions[i % 3],
+        }))
+      : [];
 
     return { ...dimensionOrMetric, settings: mockSettings };
   };

--- a/publisher/src/components/Reports/ReportSummaryPanel.tsx
+++ b/publisher/src/components/Reports/ReportSummaryPanel.tsx
@@ -111,7 +111,7 @@ const ReportSummarySection = styled.a`
   }
 `;
 
-const MetricDisplayName = styled.div<{
+export const MetricDisplayName = styled.div<{
   activeSection?: boolean;
 }>`
   ${({ activeSection }) =>

--- a/publisher/src/components/Settings/Settings.styles.tsx
+++ b/publisher/src/components/Settings/Settings.styles.tsx
@@ -18,6 +18,7 @@
 import styled from "styled-components/macro";
 
 import { palette, typography } from "../GlobalStyles";
+import { MetricDisplayName } from "../Reports/ReportSummaryPanel";
 
 export const SettingsContainer = styled.div`
   width: 100%;
@@ -73,5 +74,32 @@ export const InputWrapper = styled.div`
 
   div {
     width: 100%;
+  }
+`;
+
+export const MetricsListContainer = styled.div`
+  div {
+    ${typography.sizeCSS.normal}
+    height: 24px;
+    display: flex;
+    align-items: center;
+    justify-content: flex-start;
+    position: relative;
+    text-decoration: none;
+    margin-bottom: 2px;
+    border-radius: 2px;
+    transition: 0.2s ease;
+  }
+`;
+
+export const MetricsListItem = styled(MetricDisplayName)`
+  ${typography.sizeCSS.normal}
+  width: fit-content;
+  color: ${({ activeSection }) =>
+    activeSection ? palette.solid.darkgrey : palette.highlight.grey8};
+
+  &:hover {
+    cursor: pointer;
+    color: ${palette.solid.darkgrey};
   }
 `;

--- a/publisher/src/components/Settings/Settings.styles.tsx
+++ b/publisher/src/components/Settings/Settings.styles.tsx
@@ -77,20 +77,7 @@ export const InputWrapper = styled.div`
   }
 `;
 
-export const MetricsListContainer = styled.div`
-  div {
-    ${typography.sizeCSS.normal}
-    height: 24px;
-    display: flex;
-    align-items: center;
-    justify-content: flex-start;
-    position: relative;
-    text-decoration: none;
-    margin-bottom: 2px;
-    border-radius: 2px;
-    transition: 0.2s ease;
-  }
-`;
+export const MetricsListContainer = styled.div``;
 
 export const MetricsListItem = styled(MetricDisplayName)`
   ${typography.sizeCSS.normal}

--- a/publisher/src/components/Settings/SettingsMenu.tsx
+++ b/publisher/src/components/Settings/SettingsMenu.tsx
@@ -15,25 +15,66 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React from "react";
+import React, { Fragment } from "react";
 
-import { MenuOptions, menuOptions } from "../../pages/Settings";
-import { MenuItem, SettingsMenuContainer } from "./Settings.styles";
+import {
+  ListOfMetricsForNavigation,
+  MenuOptions,
+  menuOptions,
+} from "../../pages/Settings";
+import {
+  MenuItem,
+  MetricsListContainer,
+  MetricsListItem,
+  SettingsMenuContainer,
+} from ".";
 
 export const SettingsMenu: React.FC<{
   activeMenuItem: MenuOptions;
   goToMenuItem: (destination: MenuOptions) => void;
-}> = ({ activeMenuItem, goToMenuItem }) => {
+  activeMetricKey: string | undefined;
+  setActiveMetricKey: React.Dispatch<React.SetStateAction<string | undefined>>;
+  listOfMetrics: ListOfMetricsForNavigation[] | undefined;
+}> = ({
+  activeMenuItem,
+  goToMenuItem,
+  activeMetricKey,
+  setActiveMetricKey,
+  listOfMetrics,
+}) => {
   return (
     <SettingsMenuContainer>
       {menuOptions.map((option) => (
-        <MenuItem
-          key={option}
-          selected={option === activeMenuItem}
-          onClick={() => goToMenuItem(option)}
-        >
-          {option}
-        </MenuItem>
+        <Fragment key={option}>
+          <MenuItem
+            selected={option === activeMenuItem}
+            onClick={() => {
+              goToMenuItem(option);
+
+              if (option === "Metric Configuration") {
+                setActiveMetricKey(undefined);
+              }
+            }}
+          >
+            {option}
+          </MenuItem>
+
+          {option === "Metric Configuration" &&
+            activeMenuItem === "Metric Configuration" &&
+            activeMetricKey &&
+            listOfMetrics && (
+              <MetricsListContainer>
+                {listOfMetrics.map((metric) => (
+                  <MetricsListItem
+                    activeSection={metric.key === activeMetricKey}
+                    onClick={() => setActiveMetricKey(metric.key)}
+                  >
+                    {metric.display_name}
+                  </MetricsListItem>
+                ))}
+              </MetricsListContainer>
+            )}
+        </Fragment>
       ))}
     </SettingsMenuContainer>
   );

--- a/publisher/src/components/Settings/SettingsMenu.tsx
+++ b/publisher/src/components/Settings/SettingsMenu.tsx
@@ -59,6 +59,8 @@ export const SettingsMenu: React.FC<{
             {option}
           </MenuItem>
 
+          {/* Metrics Navigation (appears when a metric has been 
+              selected and allows users to toggle between metrics) */}
           {option === "Metric Configuration" &&
             activeMenuItem === "Metric Configuration" &&
             activeMetricKey &&

--- a/publisher/src/pages/Settings.tsx
+++ b/publisher/src/pages/Settings.tsx
@@ -33,10 +33,18 @@ export const menuOptions = [
 ] as const;
 export type MenuOptions = typeof menuOptions[number];
 
+export type ListOfMetricsForNavigation = {
+  key: string;
+  display_name: string;
+};
+
 const Settings = () => {
   const [activeMenuItem, setActiveMenuItem] = useState<MenuOptions>(
     menuOptions[0]
   );
+  const [listOfMetrics, setListOfMetrics] =
+    useState<ListOfMetricsForNavigation[]>();
+  const [activeMetricKey, setActiveMetricKey] = useState<string | undefined>();
 
   const goToMenuItem = (destination: MenuOptions) =>
     setActiveMenuItem(destination);
@@ -46,12 +54,21 @@ const Settings = () => {
       <SettingsMenu
         activeMenuItem={activeMenuItem}
         goToMenuItem={goToMenuItem}
+        activeMetricKey={activeMetricKey}
+        setActiveMetricKey={setActiveMetricKey}
+        listOfMetrics={listOfMetrics}
       />
 
       <ContentDisplay>
         {activeMenuItem === "Your Account" && <AccountSettings />}
         {activeMenuItem === "Uploaded Files" && <UploadedFiles />}
-        {activeMenuItem === "Metric Configuration" && <MetricsView />}
+        {activeMenuItem === "Metric Configuration" && (
+          <MetricsView
+            activeMetricKey={activeMetricKey}
+            setActiveMetricKey={setActiveMetricKey}
+            setListOfMetrics={setListOfMetrics}
+          />
+        )}
       </ContentDisplay>
     </SettingsContainer>
   );

--- a/publisher/src/pages/Settings.tsx
+++ b/publisher/src/pages/Settings.tsx
@@ -42,12 +42,14 @@ const Settings = () => {
   const [activeMenuItem, setActiveMenuItem] = useState<MenuOptions>(
     menuOptions[0]
   );
-  const [listOfMetrics, setListOfMetrics] =
-    useState<ListOfMetricsForNavigation[]>();
-  const [activeMetricKey, setActiveMetricKey] = useState<string | undefined>();
 
   const goToMenuItem = (destination: MenuOptions) =>
     setActiveMenuItem(destination);
+
+  /** State specific to Metrics Configuration & Settings Menu */
+  const [listOfMetrics, setListOfMetrics] =
+    useState<ListOfMetricsForNavigation[]>();
+  const [activeMetricKey, setActiveMetricKey] = useState<string | undefined>();
 
   return (
     <SettingsContainer>


### PR DESCRIPTION
## Description of the change

Adds table-of-content navigation of metrics in the settings menu once a user has clicked into a metric that allows users an easy way to toggle between metrics while in the detailed view.


https://user-images.githubusercontent.com/59492998/195896182-9e69ea0c-509a-497a-990c-9dc27cba9b7a.mov


## Related issues

Closes #80

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
