### PR TITLE
Settings: Metric Configuration: Refactor & Clean Up (5/n)

### DIFF
--- a/publisher/src/App.tsx
+++ b/publisher/src/App.tsx
@@ -23,6 +23,7 @@ import { trackNavigation } from "./analytics";
 import { DataUpload } from "./components/DataUpload";
 import { PageWrapper } from "./components/Forms";
 import Header from "./components/Header";
+import { MetricsView } from "./components/MetricConfiguration/MetricsView";
 import CreateReports from "./components/Reports/CreateReport";
 import ReportDataEntry from "./components/Reports/ReportDataEntry";
 import ReviewMetrics from "./components/ReviewMetrics/ReviewMetrics";
@@ -42,6 +43,7 @@ const App: React.FC = (): ReactElement => {
 
         <Routes>
           <Route path="/" element={<Reports />} />
+          <Route path="/data" element={<MetricsView />} />
           <Route path="/reports/create" element={<CreateReports />} />
           <Route path="/reports/:id" element={<ReportDataEntry />} />
           <Route path="/settings" element={<Settings />} />

--- a/publisher/src/components/DataViz/DatapointsView.styles.tsx
+++ b/publisher/src/components/DataViz/DatapointsView.styles.tsx
@@ -37,6 +37,7 @@ export const DatapointsViewControlsContainer = styled.div`
   display: flex;
   flex-direction: row;
   border-bottom: 1px solid ${palette.highlight.grey9};
+  border-top: 1px solid ${palette.highlight.grey9};
 `;
 
 const DatapointsViewDropdown = styled(Dropdown)`

--- a/publisher/src/components/Forms/NotReportedIcon.tsx
+++ b/publisher/src/components/Forms/NotReportedIcon.tsx
@@ -114,8 +114,8 @@ export const NotReportedIcon: React.FC<{
             This has been disabled by an admin because the data is unavailable.{" "}
             If you have the data for this, consider changing the configuration
             in the{" "}
-            <MetricsViewLink onClick={() => navigate("/metrics")}>
-              Metrics View
+            <MetricsViewLink onClick={() => navigate("/settings")}>
+              Settings
             </MetricsViewLink>
             .
           </NotReportedIconTooltip>

--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -37,6 +37,7 @@ enum MenuItems {
   LearnMore = "LEARN MORE",
   Settings = "SETTINGS",
   Agencies = "AGENCIES",
+  Data = "DATA",
 }
 
 const Menu = () => {
@@ -76,6 +77,8 @@ const Menu = () => {
       setActiveMenuItem(MenuItems.CreateReport);
     } else if (location.pathname === "/settings") {
       setActiveMenuItem(MenuItems.Settings);
+    } else if (location.pathname === "/data") {
+      setActiveMenuItem(MenuItems.Data);
     } else {
       setActiveMenuItem(undefined);
     }
@@ -95,6 +98,14 @@ const Menu = () => {
         active={activeMenuItem === MenuItems.Reports}
       >
         Reports
+      </MenuItem>
+
+      {/* Data (Visualizations) */}
+      <MenuItem
+        onClick={() => navigate("/data")}
+        active={activeMenuItem === MenuItems.Data}
+      >
+        Data
       </MenuItem>
 
       {/* Learn More */}

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -17,6 +17,7 @@
 
 import React, { useEffect, useState } from "react";
 
+import { Metric, MetricDisaggregationDimensions } from "../../shared/types";
 import { removeSnakeCase } from "../../utils";
 import blueCheck from "../assets/status-check-icon.png";
 import { BinaryRadioButton } from "../Forms";
@@ -33,8 +34,8 @@ import {
   DisaggregationTab,
   Header,
   MetricConfigurationContainer,
-  MetricConfigurationMetric,
-  MetricConfigurationMetricDimension,
+  // MetricConfigurationMetric,
+  // MetricConfigurationMetricDimension,
   MetricDisaggregations,
   MetricOnOffWrapper,
   MetricSettings,
@@ -44,14 +45,14 @@ import {
 
 type MetricConfigurationProps = {
   activeMetricKey: string;
-  filteredMetricSettings: { [key: string]: MetricConfigurationMetric };
+  filteredMetricSettings: { [key: string]: Metric };
   saveAndUpdateMetricSettings: (
     typeOfUpdate: "METRIC" | "DISAGGREGATION" | "DIMENSION" | "CONTEXT",
     updatedSetting: MetricSettings,
     debounce?: boolean
   ) => void;
   setActiveDimension: React.Dispatch<
-    React.SetStateAction<MetricConfigurationMetricDimension | undefined>
+    React.SetStateAction<MetricDisaggregationDimensions | undefined>
   >;
 };
 

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -81,7 +81,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = ({
       if (updatedDisaggregation)
         return setActiveDisaggregation(updatedDisaggregation);
       setActiveDisaggregation(
-        filteredMetricSettings[activeMetricKey].disaggregations[0]
+        filteredMetricSettings[activeMetricKey]?.disaggregations?.[0]
       );
     },
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -1,0 +1,254 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2022 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import React, { useEffect, useState } from "react";
+
+import { removeSnakeCase } from "../../utils";
+import blueCheck from "../assets/status-check-icon.png";
+import { BinaryRadioButton } from "../Forms";
+import { TabbedBar, TabbedItem, TabbedOptions } from "../Reports";
+import {
+  BlueCheckIcon,
+  BreakdownHeader,
+  Checkbox,
+  CheckboxWrapper,
+  Dimension,
+  DimensionTitle,
+  DimensionTitleWrapper,
+  Disaggregation,
+  DisaggregationTab,
+  Header,
+  MetricConfigurationContainer,
+  MetricConfigurationMetric,
+  MetricConfigurationMetricDimension,
+  MetricDisaggregations,
+  MetricOnOffWrapper,
+  MetricSettings,
+  RadioButtonGroupWrapper,
+  Subheader,
+} from ".";
+
+type MetricConfigurationProps = {
+  activeMetricKey: string;
+  filteredMetricSettings: { [key: string]: MetricConfigurationMetric };
+  saveAndUpdateMetricSettings: (
+    typeOfUpdate: "METRIC" | "DISAGGREGATION" | "DIMENSION" | "CONTEXT",
+    updatedSetting: MetricSettings,
+    debounce?: boolean
+  ) => void;
+  setActiveDimension: React.Dispatch<
+    React.SetStateAction<MetricConfigurationMetricDimension | undefined>
+  >;
+};
+
+export const Configuration: React.FC<MetricConfigurationProps> = ({
+  activeMetricKey,
+  filteredMetricSettings,
+  saveAndUpdateMetricSettings,
+  setActiveDimension,
+}): JSX.Element => {
+  const [activeDisaggregation, setActiveDisaggregation] = useState(
+    filteredMetricSettings[activeMetricKey]?.disaggregations?.[0]
+  );
+  const metricDisplayName =
+    filteredMetricSettings[activeMetricKey]?.display_name;
+  const metricEnabled = Boolean(
+    filteredMetricSettings[activeMetricKey]?.enabled
+  );
+
+  useEffect(
+    () => {
+      const updatedDisaggregation =
+        activeDisaggregation &&
+        filteredMetricSettings[activeMetricKey]?.disaggregations?.find(
+          (disaggregation) => disaggregation.key === activeDisaggregation.key
+        );
+
+      setActiveDimension(undefined);
+
+      if (updatedDisaggregation)
+        return setActiveDisaggregation(updatedDisaggregation);
+      setActiveDisaggregation(
+        filteredMetricSettings[activeMetricKey].disaggregations[0]
+      );
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeMetricKey]
+  );
+
+  return (
+    <MetricConfigurationContainer>
+      <MetricOnOffWrapper>
+        <Header>
+          Are you currently able to report any part of this metric?
+        </Header>
+        <Subheader>
+          Answering “No” means that {metricDisplayName} will not appear on
+          automatically generated reports from here on out. You can change this
+          later.
+        </Subheader>
+        <RadioButtonGroupWrapper>
+          <BinaryRadioButton
+            type="radio"
+            id="yes"
+            name="metric-config"
+            label="Yes"
+            value="yes"
+            checked={metricEnabled}
+            onChange={() =>
+              saveAndUpdateMetricSettings("METRIC", {
+                key: activeMetricKey,
+                enabled: true,
+              })
+            }
+          />
+          <BinaryRadioButton
+            type="radio"
+            id="no"
+            name="metric-config"
+            label="No"
+            value="no"
+            checked={!metricEnabled}
+            onChange={() =>
+              saveAndUpdateMetricSettings("METRIC", {
+                key: activeMetricKey,
+                enabled: false,
+              })
+            }
+          />
+        </RadioButtonGroupWrapper>
+      </MetricOnOffWrapper>
+
+      {filteredMetricSettings[activeMetricKey]?.disaggregations.length > 0 && (
+        <MetricDisaggregations enabled={metricEnabled}>
+          <BreakdownHeader>Breakdowns</BreakdownHeader>
+          <Subheader>
+            Mark (using the checkmark) each of the breakdowns below that your
+            agency will be able to report. Click the arrow to edit the
+            definition for each metric.
+          </Subheader>
+
+          <TabbedBar noPadding>
+            <TabbedOptions>
+              {activeDisaggregation &&
+                filteredMetricSettings[activeMetricKey]?.disaggregations?.map(
+                  (disaggregation) => (
+                    <TabbedItem
+                      key={disaggregation.key}
+                      onClick={() => {
+                        setActiveDimension(disaggregation.dimensions[0]);
+                        setActiveDisaggregation(disaggregation);
+                      }}
+                      selected={disaggregation.key === activeDisaggregation.key}
+                      capitalize
+                    >
+                      <DisaggregationTab>
+                        <span>
+                          {removeSnakeCase(
+                            disaggregation.display_name.toLowerCase()
+                          )}
+                        </span>
+
+                        <CheckboxWrapper>
+                          <Checkbox
+                            type="checkbox"
+                            checked={disaggregation.enabled}
+                            onChange={() =>
+                              saveAndUpdateMetricSettings("DISAGGREGATION", {
+                                key: activeMetricKey,
+                                disaggregations: [
+                                  {
+                                    key: disaggregation.key,
+                                    enabled: !disaggregation.enabled,
+                                  },
+                                ],
+                              })
+                            }
+                          />
+                          <BlueCheckIcon
+                            src={blueCheck}
+                            alt=""
+                            enabled={disaggregation.enabled}
+                          />
+                        </CheckboxWrapper>
+                      </DisaggregationTab>
+                    </TabbedItem>
+                  )
+                )}
+            </TabbedOptions>
+          </TabbedBar>
+
+          <Disaggregation>
+            {activeDisaggregation?.dimensions.map((dimension) => {
+              return (
+                <Dimension
+                  key={dimension.key}
+                  enabled={!metricEnabled || activeDisaggregation.enabled}
+                  onClick={() => setActiveDimension(dimension)}
+                >
+                  <CheckboxWrapper>
+                    <Checkbox
+                      type="checkbox"
+                      checked={
+                        activeDisaggregation.enabled && dimension.enabled
+                      }
+                      onChange={() => {
+                        if (activeDisaggregation.enabled) {
+                          saveAndUpdateMetricSettings("DIMENSION", {
+                            key: activeMetricKey,
+                            disaggregations: [
+                              {
+                                key: activeDisaggregation.key,
+                                dimensions: [
+                                  {
+                                    key: dimension.key,
+                                    enabled: !dimension.enabled,
+                                  },
+                                ],
+                              },
+                            ],
+                          });
+                        }
+                      }}
+                    />
+                    <BlueCheckIcon
+                      src={blueCheck}
+                      alt=""
+                      enabled={
+                        activeDisaggregation.enabled && dimension.enabled
+                      }
+                    />
+                  </CheckboxWrapper>
+
+                  <DimensionTitleWrapper>
+                    <DimensionTitle
+                      enabled={
+                        activeDisaggregation.enabled && dimension.enabled
+                      }
+                    >
+                      {dimension.label}
+                    </DimensionTitle>
+                  </DimensionTitleWrapper>
+                </Dimension>
+              );
+            })}
+          </Disaggregation>
+        </MetricDisaggregations>
+      )}
+    </MetricConfigurationContainer>
+  );
+};

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -78,14 +78,18 @@ export const Configuration: React.FC<MetricConfigurationProps> = ({
           (disaggregation) => disaggregation.key === activeDisaggregation.key
         );
 
-      setActiveDimension(undefined);
-
       if (updatedDisaggregation)
         return setActiveDisaggregation(updatedDisaggregation);
       setActiveDisaggregation(
         filteredMetricSettings[activeMetricKey].disaggregations[0]
       );
     },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [filteredMetricSettings]
+  );
+
+  useEffect(
+    () => setActiveDimension(undefined),
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [activeMetricKey]
   );

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -34,8 +34,6 @@ import {
   DisaggregationTab,
   Header,
   MetricConfigurationContainer,
-  // MetricConfigurationMetric,
-  // MetricConfigurationMetricDimension,
   MetricDisaggregations,
   MetricOnOffWrapper,
   MetricSettings,

--- a/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
@@ -30,14 +30,12 @@ import {
   Label,
   MetricContextContainer,
   MetricContextItem,
+  MetricSettings,
+  MetricSettingsUpdateOptions,
   MultipleChoiceWrapper,
   RadioButtonGroupWrapper,
   Subheader,
 } from ".";
-import {
-  MetricSettings,
-  MetricSettingsUpdateOptions,
-} from "./MetricConfiguration";
 
 type MetricContextConfigurationProps = {
   metricKey: string;

--- a/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
@@ -1,0 +1,220 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2022 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import React, { useEffect, useState } from "react";
+
+import { FormError, MetricContext } from "../../shared/types";
+import { isPositiveNumber, removeCommaSpaceAndTrim } from "../../utils";
+import {
+  BinaryRadioButton,
+  BinaryRadioGroupClearButton,
+  BinaryRadioGroupContainer,
+  BinaryRadioGroupQuestion,
+  TextInput,
+} from "../Forms";
+import {
+  Label,
+  MetricContextContainer,
+  MetricContextItem,
+  MultipleChoiceWrapper,
+  RadioButtonGroupWrapper,
+  Subheader,
+} from ".";
+import {
+  MetricSettings,
+  MetricSettingsUpdateOptions,
+} from "./MetricConfiguration";
+
+type MetricContextConfigurationProps = {
+  metricKey: string;
+  contexts: MetricContext[];
+  saveAndUpdateMetricSettings: (
+    typeOfUpdate: MetricSettingsUpdateOptions,
+    updatedSetting: MetricSettings,
+    debounce?: boolean
+  ) => void;
+};
+
+export const ContextConfiguration: React.FC<
+  MetricContextConfigurationProps
+> = ({ metricKey, contexts, saveAndUpdateMetricSettings }) => {
+  const [contextErrors, setContextErrors] = useState<{
+    [key: string]: FormError;
+  }>();
+
+  const contextNumberValidation = (key: string, value: string) => {
+    const cleanValue = removeCommaSpaceAndTrim(value);
+
+    if (!isPositiveNumber(cleanValue) && cleanValue !== "") {
+      setContextErrors({
+        [key]: {
+          message: "Please enter a valid number.",
+        },
+      });
+
+      return false;
+    }
+
+    setContextErrors((prev) => {
+      const otherContextErrors = { ...prev };
+      delete otherContextErrors[key];
+
+      return otherContextErrors;
+    });
+    return true;
+  };
+
+  useEffect(() => {
+    if (contexts) {
+      contexts.forEach((context) => {
+        if (context.type === "NUMBER") {
+          contextNumberValidation(context.key, (context.value || "") as string);
+        }
+      });
+    }
+  }, [contexts]);
+
+  return (
+    <MetricContextContainer>
+      <Subheader>
+        Anything entered here will appear as the default value for all reports.
+        If you are entering data for a particular month, you can still replace
+        this as necessary.
+      </Subheader>
+
+      {contexts?.map((context) => (
+        <MetricContextItem key={context.key}>
+          {context.type === "BOOLEAN" && (
+            <>
+              <Label noBottomMargin>{context.display_name}</Label>
+              <RadioButtonGroupWrapper>
+                <BinaryRadioButton
+                  type="radio"
+                  id={`${context.key}-yes`}
+                  name={context.key}
+                  label="Yes"
+                  value="yes"
+                  checked={context.value === "yes"}
+                  onChange={() =>
+                    saveAndUpdateMetricSettings("CONTEXT", {
+                      key: metricKey,
+                      contexts: [{ key: context.key, value: "yes" }],
+                    })
+                  }
+                />
+                <BinaryRadioButton
+                  type="radio"
+                  id={`${context.key}-no`}
+                  name={context.key}
+                  label="No"
+                  value="no"
+                  checked={context.value === "no"}
+                  onChange={() =>
+                    saveAndUpdateMetricSettings("CONTEXT", {
+                      key: metricKey,
+                      contexts: [{ key: context.key, value: "no" }],
+                    })
+                  }
+                />
+              </RadioButtonGroupWrapper>
+              <BinaryRadioGroupClearButton
+                onClick={() =>
+                  saveAndUpdateMetricSettings("CONTEXT", {
+                    key: metricKey,
+                    contexts: [{ key: context.key, value: "" }],
+                  })
+                }
+              >
+                Clear Input
+              </BinaryRadioGroupClearButton>
+            </>
+          )}
+
+          {(context.type === "TEXT" || context.type === "NUMBER") && (
+            <>
+              <Label>{context.display_name}</Label>
+              <TextInput
+                type="text"
+                name={context.key}
+                id={context.key}
+                label=""
+                value={(context.value || "") as string}
+                multiline={context.type === "TEXT"}
+                error={contextErrors?.[context.key]}
+                onChange={(e) => {
+                  if (context.type === "NUMBER") {
+                    contextNumberValidation(context.key, e.currentTarget.value);
+                  }
+
+                  saveAndUpdateMetricSettings(
+                    "CONTEXT",
+                    {
+                      key: metricKey,
+                      contexts: [
+                        { key: context.key, value: e.currentTarget.value },
+                      ],
+                    },
+                    true
+                  );
+                }}
+              />
+            </>
+          )}
+
+          {context.type === "MULTIPLE_CHOICE" && (
+            <BinaryRadioGroupContainer key={context.key}>
+              <BinaryRadioGroupQuestion>
+                {context.display_name}
+              </BinaryRadioGroupQuestion>
+
+              <MultipleChoiceWrapper>
+                {context.multiple_choice_options?.map((option) => (
+                  <BinaryRadioButton
+                    type="radio"
+                    key={option}
+                    id={`${context.key}-${option}`}
+                    name={`${context.key}`}
+                    label={option}
+                    value={option}
+                    checked={context.value === option}
+                    onChange={() =>
+                      saveAndUpdateMetricSettings("CONTEXT", {
+                        key: metricKey,
+                        contexts: [{ key: context.key, value: option }],
+                      })
+                    }
+                  />
+                ))}
+              </MultipleChoiceWrapper>
+
+              <BinaryRadioGroupClearButton
+                onClick={() =>
+                  saveAndUpdateMetricSettings("CONTEXT", {
+                    key: metricKey,
+                    contexts: [{ key: context.key, value: "" }],
+                  })
+                }
+              >
+                Clear Input
+              </BinaryRadioGroupClearButton>
+            </BinaryRadioGroupContainer>
+          )}
+        </MetricContextItem>
+      ))}
+    </MetricContextContainer>
+  );
+};

--- a/publisher/src/components/MetricConfiguration/MetricBox.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricBox.tsx
@@ -1,0 +1,60 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2022 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import React from "react";
+
+import { ReportFrequency } from "../../shared/types";
+import { Badge } from "../Badge";
+import {
+  MetricBoxContainer,
+  MetricDescription,
+  MetricName,
+  MetricNameBadgeWrapper,
+} from ".";
+
+type MetricBoxProps = {
+  metricKey: string;
+  displayName: string;
+  frequency: ReportFrequency;
+  description: string;
+  enabled?: boolean;
+  setActiveMetricKey: React.Dispatch<React.SetStateAction<string | undefined>>;
+};
+
+export const MetricBox: React.FC<MetricBoxProps> = ({
+  metricKey,
+  displayName,
+  frequency,
+  description,
+  enabled,
+  setActiveMetricKey,
+}): JSX.Element => {
+  return (
+    <MetricBoxContainer
+      onClick={() => setActiveMetricKey(metricKey)}
+      enabled={enabled}
+    >
+      <MetricName>{displayName}</MetricName>
+      <MetricDescription>{description}</MetricDescription>
+      <MetricNameBadgeWrapper>
+        <Badge color={!enabled ? "GREY" : "GREEN"} disabled={!enabled} noMargin>
+          {!enabled ? "Inactive" : frequency.toLowerCase()}
+        </Badge>
+      </MetricNameBadgeWrapper>
+    </MetricBoxContainer>
+  );
+};

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -37,6 +37,12 @@ export const MetricsViewControlPanel = styled.div`
   overflow-y: scroll;
 `;
 
+export const MetricsViewControlPanelOverflowHidden = styled(
+  MetricsViewControlPanel
+)`
+  overflow-y: hidden;
+`;
+
 export const PanelContainerLeft = styled.div`
   width: 35%;
   height: 100%;
@@ -54,6 +60,7 @@ export const PanelContainerRight = styled.div`
   display: flex;
   position: relative;
   flex-direction: column;
+  overflow-y: scroll;
 `;
 
 type MetricBoxContainerProps = {
@@ -79,6 +86,15 @@ export const MetricBoxContainer = styled.div<MetricBoxContainerProps>`
   }
 `;
 
+export const MetricViewBoxContainer = styled(MetricBoxContainer)<{
+  selected?: boolean;
+}>`
+  max-width: 100%;
+  min-height: 50px;
+  border: ${({ selected }) => selected && `1px solid ${palette.solid.blue}`};
+  margin-bottom: 5px;
+`;
+
 export const MetricBoxWrapper = styled.div`
   display: flex;
 `;
@@ -88,6 +104,7 @@ export const ActiveMetricSettingHeader = styled.div`
   z-index: 1;
   background: ${palette.solid.white};
   padding: 10px 15px 0 15px;
+  margin-bottom: 20px;
 `;
 
 export const MetricNameBadgeToggleWrapper = styled.div`

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -29,7 +29,7 @@ export const MetricsViewContainer = styled.div`
 `;
 
 export const MetricsViewControlPanel = styled.div`
-  height: calc(100% - 170px);
+  height: 100%;
   width: 100%;
   display: flex;
   flex-wrap: wrap;
@@ -438,7 +438,7 @@ export const MetricConfigurationDisplay = styled.div`
 `;
 
 export const MetricConfigurationWrapper = styled.div`
-  height: 85vh;
+  height: 100%;
   width: 100%;
   display: flex;
   justify-content: space-between;

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -124,9 +124,7 @@ export const MetricConfiguration: React.FC<{
 
   const [activeMetricFilter, setActiveMetricFilter] = useState<string>();
   const [isLoading, setIsLoading] = useState<boolean>(true);
-  const [loadingError, setLoadingError] = useState<string | undefined>(
-    undefined
-  );
+  const [loadingError, setLoadingError] = useState<string>();
   const [activeDimension, setActiveDimension] =
     useState<MetricConfigurationMetricDimension>();
   const [metricSettings, setMetricSettings] = useState<{

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -390,20 +390,20 @@ export const MetricConfiguration: React.FC<{
     []
   );
 
-  // reload report overviews when the current agency ID changes
+  // reload metric overviews when the current agency ID changes
   useEffect(
     () =>
       // return disposer so it is cleaned up if it never runs
       reaction(
         () => userStore.currentAgencyId,
         async (currentAgencyId, previousAgencyId) => {
-          // prevents us from calling getDatapoints twice on initial load
           if (previousAgencyId !== undefined) {
             setIsLoading(true);
             fetchAndSetReportSettings();
             setActiveMetricFilter(
               removeSnakeCase(userStore.currentAgency?.systems[0] as string)
             );
+            setActiveMetricKey(undefined);
           }
         }
       ),

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -22,8 +22,8 @@ import React, { useEffect, useRef, useState } from "react";
 
 import { ListOfMetricsForNavigation } from "../../pages/Settings";
 import {
-  AgencySystems,
-  MetricContext,
+  Metric as MetricType,
+  MetricDisaggregationDimensions,
   ReportFrequency,
 } from "../../shared/types";
 import { useStore } from "../../stores";
@@ -46,45 +46,6 @@ import {
   MetricsViewControlPanel,
   StickyHeader,
 } from ".";
-
-export type MetricConfigurationSettingsOptions = "Yes" | "No" | "N/A";
-
-export type MetricConfigurationSettings = {
-  key: string;
-  label: string;
-  included: MetricConfigurationSettingsOptions;
-  default: MetricConfigurationSettingsOptions;
-};
-
-export type MetricConfigurationMetricDimension = {
-  key: string;
-  label: string;
-  value: string | number | boolean | null | undefined;
-  reporting_note: string;
-  enabled?: boolean;
-  settings: MetricConfigurationSettings[];
-};
-
-export type MetricConfigurationMetricDisaggregation = {
-  key: string;
-  display_name: string;
-  dimensions: MetricConfigurationMetricDimension[];
-  required: boolean;
-  helper_text: string | null | undefined;
-  enabled?: boolean;
-};
-
-export type MetricConfigurationMetric = {
-  key: string;
-  display_name: string;
-  description: string;
-  frequency: string;
-  enabled: boolean;
-  system: AgencySystems;
-  contexts: MetricContext[];
-  disaggregations: MetricConfigurationMetricDisaggregation[];
-  settings: MetricConfigurationSettings[];
-};
 
 export type MetricSettingsUpdateOptions =
   | "METRIC"
@@ -110,7 +71,7 @@ export type MetricSettings = {
 };
 
 type MetricSettingsObj = {
-  [key: string]: MetricConfigurationMetric;
+  [key: string]: MetricType;
 };
 
 export const MetricConfiguration: React.FC<{
@@ -126,9 +87,9 @@ export const MetricConfiguration: React.FC<{
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [loadingError, setLoadingError] = useState<string>();
   const [activeDimension, setActiveDimension] =
-    useState<MetricConfigurationMetricDimension>();
+    useState<MetricDisaggregationDimensions>();
   const [metricSettings, setMetricSettings] = useState<{
-    [key: string]: MetricConfigurationMetric;
+    [key: string]: MetricType;
   }>({});
 
   const filteredMetricSettings: MetricSettingsObj = Object.values(
@@ -360,10 +321,8 @@ export const MetricConfiguration: React.FC<{
       return setLoadingError(response.message);
     }
 
-    const reportSettings =
-      (await response.json()) as MetricConfigurationMetric[];
-    const metricKeyToMetricMap: { [key: string]: MetricConfigurationMetric } =
-      {};
+    const reportSettings = (await response.json()) as MetricType[];
+    const metricKeyToMetricMap: { [key: string]: MetricType } = {};
 
     reportSettings?.forEach((metric) => {
       metricKeyToMetricMap[metric.key] = metric;

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -70,7 +70,7 @@ export type MetricSettings = {
   }[];
 };
 
-type MetricSettingsObj = {
+export type MetricSettingsObj = {
   [key: string]: MetricType;
 };
 

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -17,7 +17,12 @@
 
 import React, { Fragment, useEffect, useState } from "react";
 
-import { MetricContext } from "../../shared/types";
+import {
+  Metric,
+  MetricConfigurationSettingsOptions,
+  MetricContext,
+  MetricDisaggregationDimensions,
+} from "../../shared/types";
 import {
   ContextConfiguration,
   DefinitionDisplayName,
@@ -30,9 +35,6 @@ import {
   DefinitionSelection,
   DefinitionsSubTitle,
   DefinitionsTitle,
-  MetricConfigurationMetric,
-  MetricConfigurationMetricDimension,
-  MetricConfigurationSettingsOptions,
   MetricSettings,
   MetricSettingsUpdateOptions,
   RevertToDefaultButton,
@@ -40,8 +42,8 @@ import {
 
 type MetricDefinitionsProps = {
   activeMetricKey: string;
-  filteredMetricSettings: { [key: string]: MetricConfigurationMetric };
-  activeDimension?: MetricConfigurationMetricDimension | undefined;
+  filteredMetricSettings: { [key: string]: Metric };
+  activeDimension?: MetricDisaggregationDimensions | undefined;
   contexts: MetricContext[];
   saveAndUpdateMetricSettings: (
     typeOfUpdate: MetricSettingsUpdateOptions,
@@ -66,11 +68,9 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
   /** TODO(#82): Remove mocks when GET & POST are implemented */
   /** Mocks To Be Removed */
   const generateMockDefinitions = ():
-    | MetricConfigurationMetricDimension
-    | MetricConfigurationMetric => {
-    const dimensionOrMetric:
-      | MetricConfigurationMetricDimension
-      | MetricConfigurationMetric =
+    | MetricDisaggregationDimensions
+    | Metric => {
+    const dimensionOrMetric: MetricDisaggregationDimensions | Metric =
       activeDimension || filteredMetricSettings[activeMetricKey];
 
     const mockSettings = dimensionOrMetric
@@ -92,7 +92,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
   const initialDefinitionsToDisplay = generateMockDefinitions();
 
   const [mockDefinitionsToDisplay, setMockDefinitionsToDisplay] = useState<
-    MetricConfigurationMetricDimension | MetricConfigurationMetric
+    MetricDisaggregationDimensions | Metric
   >(initialDefinitionsToDisplay);
 
   const mockUpdateSelection = (
@@ -102,7 +102,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
     setMockDefinitionsToDisplay((prev) => {
       return {
         ...prev,
-        settings: prev.settings.map((setting) => {
+        settings: prev.settings?.map((setting) => {
           if (setting.key === key) {
             return { ...setting, included: selection };
           }
@@ -148,7 +148,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
         </RevertToDefaultButton>
 
         <Definitions>
-          {mockDefinitionsToDisplay?.settings.map((setting) => (
+          {mockDefinitionsToDisplay?.settings?.map((setting) => (
             <DefinitionItem key={setting.key}>
               <DefinitionDisplayName>{setting.label}</DefinitionDisplayName>
 

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -73,21 +73,20 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
     const dimensionOrMetric: MetricDisaggregationDimensions | Metric =
       activeDimension || filteredMetricSettings[activeMetricKey];
 
-    // const mockSettings = dimensionOrMetric
-    //   ? Array.from({ length: 10 }, (_, i) => ({
-    //       key: `SETTING ${i}`,
-    //       label: `Includes/Excludes Q#${i + 1} for ${
-    //         "display_name" in dimensionOrMetric
-    //           ? dimensionOrMetric.display_name
-    //           : dimensionOrMetric.label
-    //       }?`,
-    //       included: selectionOptions[i % 3],
-    //       default: selectionOptions[i % 3],
-    //     }))
-    //   : [];
+    const mockSettings = dimensionOrMetric
+      ? Array.from({ length: 10 }, (_, i) => ({
+          key: `SETTING ${i}`,
+          label: `Includes/Excludes Q#${i + 1} for ${
+            "display_name" in dimensionOrMetric
+              ? dimensionOrMetric.display_name
+              : dimensionOrMetric.label
+          }?`,
+          included: selectionOptions[i % 3],
+          default: selectionOptions[i % 3],
+        }))
+      : [];
 
-    // return { ...dimensionOrMetric, settings: mockSettings };
-    return { ...dimensionOrMetric };
+    return { ...dimensionOrMetric, settings: mockSettings };
   };
 
   const initialDefinitionsToDisplay = generateMockDefinitions();

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -73,20 +73,21 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
     const dimensionOrMetric: MetricDisaggregationDimensions | Metric =
       activeDimension || filteredMetricSettings[activeMetricKey];
 
-    const mockSettings = dimensionOrMetric
-      ? Array.from({ length: 10 }, (_, i) => ({
-          key: `SETTING ${i}`,
-          label: `Includes/Excludes Q#${i + 1} for ${
-            "display_name" in dimensionOrMetric
-              ? dimensionOrMetric.display_name
-              : dimensionOrMetric.label
-          }?`,
-          included: selectionOptions[i % 3],
-          default: selectionOptions[i % 3],
-        }))
-      : [];
+    // const mockSettings = dimensionOrMetric
+    //   ? Array.from({ length: 10 }, (_, i) => ({
+    //       key: `SETTING ${i}`,
+    //       label: `Includes/Excludes Q#${i + 1} for ${
+    //         "display_name" in dimensionOrMetric
+    //           ? dimensionOrMetric.display_name
+    //           : dimensionOrMetric.label
+    //       }?`,
+    //       included: selectionOptions[i % 3],
+    //       default: selectionOptions[i % 3],
+    //     }))
+    //   : [];
 
-    return { ...dimensionOrMetric, settings: mockSettings };
+    // return { ...dimensionOrMetric, settings: mockSettings };
+    return { ...dimensionOrMetric };
   };
 
   const initialDefinitionsToDisplay = generateMockDefinitions();
@@ -130,52 +131,70 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
             ? mockDefinitionsToDisplay.display_name
             : mockDefinitionsToDisplay.label}
         </DefinitionsTitle>
-        <DefinitionsSubTitle>Definitions</DefinitionsSubTitle>
-        <DefinitionsDescription>
-          Indicate which of the following categories your agency considers to be
-          part of this metric or breakdown.
-          <span>
-            You are NOT required to gather data for these specific categories.
-          </span>
-        </DefinitionsDescription>
 
-        <RevertToDefaultButton
-          onClick={() =>
-            setMockDefinitionsToDisplay(initialDefinitionsToDisplay)
-          }
-        >
-          Revert to Default Definition
-        </RevertToDefaultButton>
+        {mockDefinitionsToDisplay?.settings?.length && (
+          <>
+            <DefinitionsSubTitle>Definitions</DefinitionsSubTitle>
+            <DefinitionsDescription>
+              Indicate which of the following categories your agency considers
+              to be part of this metric or breakdown.
+              <span>
+                You are NOT required to gather data for these specific
+                categories.
+              </span>
+            </DefinitionsDescription>
 
-        <Definitions>
-          {mockDefinitionsToDisplay?.settings?.map((setting) => (
-            <DefinitionItem key={setting.key}>
-              <DefinitionDisplayName>{setting.label}</DefinitionDisplayName>
+            <RevertToDefaultButton
+              onClick={() =>
+                setMockDefinitionsToDisplay(initialDefinitionsToDisplay)
+              }
+            >
+              Revert to Default Definition
+            </RevertToDefaultButton>
 
-              <DefinitionSelection>
-                {selectionOptions.map((option) => (
-                  <Fragment key={option}>
-                    <DefinitionMiniButton
-                      selected={setting.included === option}
-                      onClick={() => mockUpdateSelection(setting.key, option)}
-                    >
-                      {option}
-                    </DefinitionMiniButton>
-                  </Fragment>
-                ))}
-              </DefinitionSelection>
-            </DefinitionItem>
-          ))}
-        </Definitions>
+            <Definitions>
+              {mockDefinitionsToDisplay?.settings?.map((setting) => (
+                <DefinitionItem key={setting.key}>
+                  <DefinitionDisplayName>{setting.label}</DefinitionDisplayName>
+
+                  <DefinitionSelection>
+                    {selectionOptions.map((option) => (
+                      <Fragment key={option}>
+                        <DefinitionMiniButton
+                          selected={setting.included === option}
+                          onClick={() =>
+                            mockUpdateSelection(setting.key, option)
+                          }
+                        >
+                          {option}
+                        </DefinitionMiniButton>
+                      </Fragment>
+                    ))}
+                  </DefinitionSelection>
+                </DefinitionItem>
+              ))}
+            </Definitions>
+          </>
+        )}
+
+        {/* Display when user is viewing a dimension & there are no settings available */}
+        {!mockDefinitionsToDisplay?.settings?.length && activeDimension && (
+          <DefinitionsSubTitle>
+            This breakdown has no customizations available yet.
+          </DefinitionsSubTitle>
+        )}
       </DefinitionsDisplay>
 
       {/* Additional Context (only appears on overall metric settings and not individual dimension settings) */}
       {!activeDimension && (
-        <ContextConfiguration
-          metricKey={activeMetricKey}
-          contexts={contexts}
-          saveAndUpdateMetricSettings={saveAndUpdateMetricSettings}
-        />
+        <>
+          <DefinitionsSubTitle>Context</DefinitionsSubTitle>
+          <ContextConfiguration
+            metricKey={activeMetricKey}
+            contexts={contexts}
+            saveAndUpdateMetricSettings={saveAndUpdateMetricSettings}
+          />
+        </>
       )}
     </DefinitionsDisplayContainer>
   );

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -19,6 +19,7 @@ import React, { Fragment, useEffect, useState } from "react";
 
 import { MetricContext } from "../../shared/types";
 import {
+  ContextConfiguration,
   DefinitionDisplayName,
   DefinitionItem,
   DefinitionMiniButton,
@@ -32,7 +33,6 @@ import {
   MetricConfigurationMetric,
   MetricConfigurationMetricDimension,
   MetricConfigurationSettingsOptions,
-  MetricContextConfiguration,
   MetricSettings,
   MetricSettingsUpdateOptions,
   RevertToDefaultButton,
@@ -171,7 +171,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
 
       {/* Additional Context (only appears on overall metric settings and not individual dimension settings) */}
       {!activeDimension && (
-        <MetricContextConfiguration
+        <ContextConfiguration
           metricKey={activeMetricKey}
           contexts={contexts}
           saveAndUpdateMetricSettings={saveAndUpdateMetricSettings}

--- a/publisher/src/components/MetricConfiguration/MetricsView.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricsView.tsx
@@ -1,0 +1,265 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2022 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { reaction, when } from "mobx";
+import { observer } from "mobx-react-lite";
+import React, { useEffect, useState } from "react";
+
+import { Metric, ReportFrequency } from "../../shared/types";
+import { useStore } from "../../stores";
+import { removeSnakeCase } from "../../utils";
+import { Badge, BadgeColorMapping } from "../Badge";
+import ConnectedDatapointsView from "../DataViz/DatapointsView";
+import { NotReportedIcon } from "../Forms";
+import { Loading } from "../Loading";
+import { PageTitle, TabbedBar, TabbedItem, TabbedOptions } from "../Reports";
+import {
+  ActiveMetricSettingHeader,
+  MetricBoxWrapper,
+  MetricDescription,
+  MetricName,
+  MetricNameBadgeToggleWrapper,
+  MetricNameBadgeWrapper,
+  MetricSettingsObj,
+  MetricsViewContainer,
+  MetricsViewControlPanelOverflowHidden,
+  MetricViewBoxContainer,
+  PanelContainerLeft,
+  PanelContainerRight,
+} from ".";
+
+type MetricBoxProps = {
+  metricKey: string;
+  displayName: string;
+  frequency: ReportFrequency;
+  description: string;
+  enabled?: boolean;
+  activeMetricKey: string;
+  setActiveMetricKey: React.Dispatch<React.SetStateAction<string>>;
+};
+
+const reportFrequencyBadgeColors: BadgeColorMapping = {
+  ANNUAL: "ORANGE",
+  MONTHLY: "GREEN",
+};
+
+const MetricBox: React.FC<MetricBoxProps> = ({
+  metricKey,
+  displayName,
+  frequency,
+  description,
+  enabled,
+  activeMetricKey,
+  setActiveMetricKey,
+}): JSX.Element => {
+  return (
+    <MetricViewBoxContainer
+      onClick={() => setActiveMetricKey(metricKey)}
+      enabled={enabled}
+      selected={metricKey === activeMetricKey}
+    >
+      <MetricNameBadgeToggleWrapper>
+        <MetricNameBadgeWrapper>
+          <MetricName>{displayName}</MetricName>
+          <Badge
+            color={reportFrequencyBadgeColors[frequency]}
+            disabled={!enabled}
+          >
+            {frequency}
+          </Badge>
+        </MetricNameBadgeWrapper>
+
+        {!enabled && <NotReportedIcon noTooltip />}
+      </MetricNameBadgeToggleWrapper>
+
+      <MetricDescription>{description}</MetricDescription>
+    </MetricViewBoxContainer>
+  );
+};
+
+export const MetricsView: React.FC = observer(() => {
+  const { reportStore, userStore, datapointsStore } = useStore();
+
+  const [activeMetricFilter, setActiveMetricFilter] = useState<string>();
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [loadingError, setLoadingError] = useState<string | undefined>(
+    undefined
+  );
+  const [activeMetricKey, setActiveMetricKey] = useState<string>("");
+  const [metricSettings, setMetricSettings] = useState<{
+    [key: string]: Metric;
+  }>({});
+
+  const filteredMetricSettings: MetricSettingsObj = Object.values(
+    metricSettings
+  )
+    .filter(
+      (metric) =>
+        metric.system.toLowerCase() === activeMetricFilter?.toLowerCase()
+    )
+    ?.reduce((res: MetricSettingsObj, metric) => {
+      res[metric.key] = metric;
+      return res;
+    }, {});
+
+  const fetchAndSetReportSettings = async () => {
+    const response = (await reportStore.getReportSettings()) as
+      | Response
+      | Error;
+
+    setIsLoading(false);
+
+    if (response instanceof Error) {
+      return setLoadingError(response.message);
+    }
+
+    const reportSettings = (await response.json()) as Metric[];
+    const metricKeyToMetricMap: { [key: string]: Metric } = {};
+
+    reportSettings?.forEach((metric) => {
+      metricKeyToMetricMap[metric.key] = metric;
+    });
+
+    setMetricSettings(metricKeyToMetricMap);
+    setActiveMetricKey(Object.keys(metricKeyToMetricMap)[0]);
+  };
+
+  useEffect(
+    () =>
+      // return when's disposer so it is cleaned up if it never runs
+      when(
+        () => userStore.userInfoLoaded,
+        async () => {
+          fetchAndSetReportSettings();
+          datapointsStore.getDatapoints();
+          setActiveMetricFilter(
+            removeSnakeCase(userStore.currentAgency?.systems[0] as string)
+          );
+        }
+      ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    []
+  );
+
+  // reload report overviews when the current agency ID changes
+  useEffect(
+    () =>
+      // return disposer so it is cleaned up if it never runs
+      reaction(
+        () => userStore.currentAgencyId,
+        async (currentAgencyId, previousAgencyId) => {
+          // prevents us from calling getDatapoints twice on initial load
+          if (previousAgencyId !== undefined) {
+            setIsLoading(true);
+            fetchAndSetReportSettings();
+            await datapointsStore.getDatapoints();
+            setActiveMetricFilter(
+              removeSnakeCase(userStore.currentAgency?.systems[0] as string)
+            );
+          }
+        }
+      ),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [userStore]
+  );
+
+  useEffect(
+    () => {
+      setActiveMetricKey(Object.keys(filteredMetricSettings)[0]);
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [activeMetricFilter]
+  );
+
+  if (isLoading) {
+    return <Loading />;
+  }
+
+  if (!metricSettings[activeMetricKey]) {
+    return <div>Error: {loadingError}</div>;
+  }
+
+  return (
+    <>
+      <MetricsViewContainer>
+        <PageTitle>Metrics</PageTitle>
+
+        <TabbedBar>
+          <TabbedOptions>
+            {userStore.currentAgency?.systems.map((filterOption) => (
+              <TabbedItem
+                key={filterOption}
+                selected={activeMetricFilter === removeSnakeCase(filterOption)}
+                onClick={() =>
+                  setActiveMetricFilter(removeSnakeCase(filterOption))
+                }
+                capitalize
+              >
+                {removeSnakeCase(filterOption.toLowerCase())}
+              </TabbedItem>
+            ))}
+          </TabbedOptions>
+        </TabbedBar>
+
+        <MetricsViewControlPanelOverflowHidden>
+          {/* List Of Metrics */}
+          <PanelContainerLeft>
+            {filteredMetricSettings &&
+              Object.values(filteredMetricSettings).map((metric) => (
+                <MetricBoxWrapper key={metric.key}>
+                  <MetricBox
+                    metricKey={metric.key}
+                    displayName={metric.display_name}
+                    frequency={metric.frequency as ReportFrequency}
+                    description={metric.description}
+                    enabled={metric.enabled}
+                    activeMetricKey={activeMetricKey}
+                    setActiveMetricKey={setActiveMetricKey}
+                  />
+                </MetricBoxWrapper>
+              ))}
+          </PanelContainerLeft>
+
+          {/* Data Visualization */}
+          <PanelContainerRight>
+            <ActiveMetricSettingHeader>
+              <MetricNameBadgeWrapper>
+                <MetricName isTitle>
+                  {filteredMetricSettings[activeMetricKey]?.display_name}
+                </MetricName>
+                {filteredMetricSettings[activeMetricKey]?.frequency && (
+                  <Badge
+                    color={
+                      reportFrequencyBadgeColors[
+                        filteredMetricSettings[activeMetricKey]
+                          .frequency as ReportFrequency
+                      ]
+                    }
+                  >
+                    {filteredMetricSettings[activeMetricKey].frequency}
+                  </Badge>
+                )}
+              </MetricNameBadgeWrapper>
+            </ActiveMetricSettingHeader>
+
+            <ConnectedDatapointsView metric={activeMetricKey} />
+          </PanelContainerRight>
+        </MetricsViewControlPanelOverflowHidden>
+      </MetricsViewContainer>
+    </>
+  );
+});

--- a/publisher/src/components/MetricConfiguration/index.ts
+++ b/publisher/src/components/MetricConfiguration/index.ts
@@ -15,6 +15,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+export * from "./Configuration";
+export * from "./ContextConfiguration";
+export * from "./MetricBox";
 export * from "./MetricConfiguration";
 export * from "./MetricConfiguration.styles";
 export * from "./MetricDefinitions";

--- a/publisher/src/components/Settings/Settings.styles.tsx
+++ b/publisher/src/components/Settings/Settings.styles.tsx
@@ -22,7 +22,6 @@ import { MetricDisplayName } from "../Reports/ReportSummaryPanel";
 
 export const SettingsContainer = styled.div`
   width: 100%;
-  height: 100%;
   display: flex;
   align-items: flex-start;
   padding: 39px 24px 0 24px;
@@ -31,7 +30,7 @@ export const SettingsContainer = styled.div`
 `;
 
 export const ContentDisplay = styled.div`
-  max-height: 90%;
+  height: 89vh;
   display: flex;
   flex-direction: column;
   justify-content: flex-start;

--- a/publisher/src/components/Settings/SettingsMenu.tsx
+++ b/publisher/src/components/Settings/SettingsMenu.tsx
@@ -68,6 +68,7 @@ export const SettingsMenu: React.FC<{
               <MetricsListContainer>
                 {listOfMetrics.map((metric) => (
                   <MetricsListItem
+                    key={metric.key}
                     activeSection={metric.key === activeMetricKey}
                     onClick={() => setActiveMetricKey(metric.key)}
                   >

--- a/publisher/src/pages/Settings.tsx
+++ b/publisher/src/pages/Settings.tsx
@@ -18,7 +18,7 @@
 import React, { useState } from "react";
 
 import { UploadedFiles } from "../components/DataUpload";
-import { MetricsView } from "../components/MetricConfiguration";
+import { MetricConfiguration } from "../components/MetricConfiguration";
 import {
   AccountSettings,
   ContentDisplay,
@@ -65,7 +65,7 @@ const Settings = () => {
         {activeMenuItem === "Your Account" && <AccountSettings />}
         {activeMenuItem === "Uploaded Files" && <UploadedFiles />}
         {activeMenuItem === "Metric Configuration" && (
-          <MetricsView
+          <MetricConfiguration
             activeMetricKey={activeMetricKey}
             setActiveMetricKey={setActiveMetricKey}
             setListOfMetrics={setListOfMetrics}

--- a/publisher/src/shared/types.ts
+++ b/publisher/src/shared/types.ts
@@ -81,6 +81,15 @@ export type MetricDisaggregationDimensionsWithErrors =
     error?: string;
   };
 
+export type MetricConfigurationSettingsOptions = "Yes" | "No" | "N/A";
+
+export type MetricConfigurationSettings = {
+  key: string;
+  label: string;
+  included: MetricConfigurationSettingsOptions;
+  default: MetricConfigurationSettingsOptions;
+};
+
 export interface Metric {
   key: string;
   system: AgencySystems;
@@ -95,6 +104,8 @@ export interface Metric {
   contexts: MetricContext[];
   disaggregations: MetricDisaggregations[];
   enabled?: boolean;
+  settings?: MetricConfigurationSettings[];
+  frequency?: ReportFrequency;
 }
 
 export interface MetricDefinition {
@@ -127,6 +138,8 @@ export interface MetricDisaggregationDimensions {
   value: string | number | boolean | null | undefined;
   reporting_note: string;
   enabled?: boolean;
+  settings?: MetricConfigurationSettings[];
+  display_name?: string;
 }
 
 export interface CreateReportFormValuesType extends Record<string, unknown> {


### PR DESCRIPTION
## Description of the change

Cleans up the Metric Configuration component and specifically accomplishes the following items:
- Move components into their respective files and general code clean up
- Merge newly created types for metric config with original types
- Fix bugs (switching agencies, out-of-sync checking and unchecking)
- Handles case where no definitions are sent

## Related issues

Closes #81 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
