### PR TITLE
Settings: Metric Configuration: Playtesting Followups - Default Definition Hover State (3/n)

### DIFF
--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -221,22 +221,20 @@ export const Configuration: React.FC<MetricConfigurationProps> = ({
                         activeDisaggregation.enabled && dimension.enabled
                       }
                       onChange={() => {
-                        if (activeDisaggregation.enabled) {
-                          saveAndUpdateMetricSettings("DIMENSION", {
-                            key: activeMetricKey,
-                            disaggregations: [
-                              {
-                                key: activeDisaggregation.key,
-                                dimensions: [
-                                  {
-                                    key: dimension.key,
-                                    enabled: !dimension.enabled,
-                                  },
-                                ],
-                              },
-                            ],
-                          });
-                        }
+                        saveAndUpdateMetricSettings("DIMENSION", {
+                          key: activeMetricKey,
+                          disaggregations: [
+                            {
+                              key: activeDisaggregation.key,
+                              dimensions: [
+                                {
+                                  key: dimension.key,
+                                  enabled: !dimension.enabled,
+                                },
+                              ],
+                            },
+                          ],
+                        });
                       }}
                     />
                     <BlueCheckIcon

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -576,11 +576,8 @@ export const DefinitionMiniButton = styled(RevertToDefaultButton)<{
 
   `};
 
-  ${({ showDefault, selected }) => {
-    if (showDefault && !selected) {
-      return `color: ${palette.highlight.grey4}`;
-    }
-  }};
+  ${({ showDefault, selected }) =>
+    showDefault && !selected && `color: ${palette.highlight.grey4};`};
 `;
 
 export const NoDefinitionsSelected = styled.div`

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -549,6 +549,7 @@ export const DefinitionSelection = styled.div`
 
 export const DefinitionMiniButton = styled(RevertToDefaultButton)<{
   selected?: boolean;
+  showDefault?: boolean;
 }>`
   width: unset;
   padding: 9px 16px;
@@ -574,6 +575,12 @@ export const DefinitionMiniButton = styled(RevertToDefaultButton)<{
 
 
   `};
+
+  ${({ showDefault, selected }) => {
+    if (showDefault && !selected) {
+      return `color: ${palette.highlight.grey4}`;
+    }
+  }};
 `;
 
 export const NoDefinitionsSelected = styled.div`

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -20,12 +20,18 @@ import styled from "styled-components/macro";
 import { BinaryRadioGroupWrapper, Button } from "../Forms";
 import { palette, typography } from "../GlobalStyles";
 
+const METRICS_VIEW_CONTAINER_BREAKPOINT = 1200;
+
 export const MetricsViewContainer = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
   overflow: hidden;
+
+  @media only screen and (max-width: ${METRICS_VIEW_CONTAINER_BREAKPOINT}px) {
+    overflow: unset;
+  }
 `;
 
 export const MetricsViewControlPanel = styled.div`
@@ -35,6 +41,12 @@ export const MetricsViewControlPanel = styled.div`
   flex-wrap: wrap;
   justify-content: space-between;
   overflow-y: scroll;
+
+  @media only screen and (max-width: ${METRICS_VIEW_CONTAINER_BREAKPOINT}px) {
+    flex-direction: column;
+    flex-wrap: nowrap;
+    justify-content: unset;
+  }
 `;
 
 export const MetricsViewControlPanelOverflowHidden = styled(
@@ -63,6 +75,13 @@ export const PanelContainerRight = styled.div`
   overflow-y: scroll;
 `;
 
+export const MetricBoxBottomPaddingContainer = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  padding-bottom: 100px;
+  overflow-y: scroll;
+`;
+
 type MetricBoxContainerProps = {
   enabled?: boolean;
 };
@@ -83,6 +102,12 @@ export const MetricBoxContainer = styled.div<MetricBoxContainerProps>`
   &:hover {
     cursor: pointer;
     border: 1px solid ${palette.solid.blue};
+  }
+
+  @media only screen and (max-width: ${METRICS_VIEW_CONTAINER_BREAKPOINT}px) {
+    width: 100%;
+    max-width: unset;
+    flex: unset;
   }
 `;
 
@@ -169,7 +194,12 @@ export const MetricDescription = styled.div`
 export const MetricDetailsDisplay = styled.div`
   width: 100%;
   overflow-y: scroll;
-  padding: 24px 12px 24px 0;
+  padding: 24px 12px 50px 0;
+
+  @media only screen and (max-width: ${METRICS_VIEW_CONTAINER_BREAKPOINT}px) {
+    overflow-y: unset;
+    padding: 24px 12px 10px 0;
+  }
 `;
 
 export const MetricOnOffWrapper = styled.div`
@@ -209,6 +239,8 @@ export const MetricDisaggregations = styled.div<{ enabled?: boolean }>`
         height: 100%;
         width: 100%;
         top: 0;
+        left: 0;
+        z-index: 2;
         opacity: 0.5;
       }
     `}
@@ -288,6 +320,7 @@ export const Dimension = styled.div<{ enabled?: boolean; inView?: boolean }>`
         height: 100%;
         width: 100%;
         top: 0;
+        left: 0;
         opacity: 0.5;
       }
     `}
@@ -307,6 +340,7 @@ export const DimensionTitle = styled.div<{ enabled?: boolean }>`
 export const CheckboxWrapper = styled.div`
   display: flex;
   position: relative;
+  z-index: 1;
 `;
 
 export const Checkbox = styled.input`
@@ -478,16 +512,25 @@ export const MetricConfigurationWrapper = styled.div`
   display: flex;
   justify-content: space-between;
   overflow-y: hidden;
+
+  @media only screen and (max-width: ${METRICS_VIEW_CONTAINER_BREAKPOINT}px) {
+    flex-direction: column;
+  }
 `;
 
 export const DefinitionsDisplayContainer = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1 1 55%;
-  padding-top: 48px;
-  padding-right: 12px;
-  padding-left: 126px;
+  padding: 48px 12px 50px 126px;
   overflow-y: scroll;
+
+  @media only screen and (max-width: ${METRICS_VIEW_CONTAINER_BREAKPOINT}px) {
+    border-top: 1px solid ${palette.highlight.grey3};
+    padding: 30px 0 50px 0;
+    overflow-y: unset;
+    margin-right: 12px;
+  }
 `;
 
 export const DefinitionsDisplay = styled.div`

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -40,6 +40,7 @@ import {
   Configuration,
   Metric,
   MetricBox,
+  MetricBoxBottomPaddingContainer,
   MetricConfigurationDisplay,
   MetricConfigurationWrapper,
   MetricDefinitions,
@@ -279,6 +280,7 @@ export const MetricConfiguration: React.FC<{
 
               return {
                 ...disaggregation,
+                enabled: true,
                 dimensions: disaggregation.dimensions.map((dimension) => {
                   if (
                     dimension.key ===
@@ -521,19 +523,21 @@ export const MetricConfiguration: React.FC<{
 
         <MetricsViewControlPanel>
           {/* List Of Metrics */}
-          {filteredMetricSettings &&
-            !activeMetricKey &&
-            Object.values(filteredMetricSettings).map((metric) => (
-              <MetricBox
-                key={metric.key}
-                metricKey={metric.key}
-                displayName={metric.display_name}
-                frequency={metric.frequency as ReportFrequency}
-                description={metric.description}
-                enabled={metric.enabled}
-                setActiveMetricKey={setActiveMetricKey}
-              />
-            ))}
+          {filteredMetricSettings && !activeMetricKey && (
+            <MetricBoxBottomPaddingContainer>
+              {Object.values(filteredMetricSettings).map((metric) => (
+                <MetricBox
+                  key={metric.key}
+                  metricKey={metric.key}
+                  displayName={metric.display_name}
+                  frequency={metric.frequency as ReportFrequency}
+                  description={metric.description}
+                  enabled={metric.enabled}
+                  setActiveMetricKey={setActiveMetricKey}
+                />
+              ))}
+            </MetricBoxBottomPaddingContainer>
+          )}
 
           {/* Metric Configuration */}
           {activeMetricKey && (

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -143,7 +143,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
               }
               onMouseLeave={() => setShowDefaultSettings(false)}
             >
-              Revert to Default Definition
+              Choose Default Definition
             </RevertToDefaultButton>
 
             <Definitions>

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React, { Fragment } from "react";
+import React, { Fragment, useState } from "react";
 
 import {
   Metric,
@@ -62,6 +62,8 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
   contexts,
   saveAndUpdateMetricSettings,
 }) => {
+  const [showDefaultSettings, setShowDefaultSettings] = useState(false);
+
   const selectionOptions: MetricConfigurationSettingsOptions[] = [
     "N/A",
     "No",
@@ -131,65 +133,84 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
               </span>
             </DefinitionsDescription>
 
-            <RevertToDefaultButton onClick={revertToDefaultValues}>
+            <RevertToDefaultButton
+              onClick={() => {
+                setShowDefaultSettings(false);
+                revertToDefaultValues();
+              }}
+              onMouseEnter={() =>
+                !showDefaultSettings && setShowDefaultSettings(true)
+              }
+              onMouseLeave={() => setShowDefaultSettings(false)}
+            >
               Revert to Default Definition
             </RevertToDefaultButton>
 
             <Definitions>
-              {activeSettings?.map((setting) => (
-                <DefinitionItem key={setting.key}>
-                  <DefinitionDisplayName>{setting.label}</DefinitionDisplayName>
+              {(showDefaultSettings ? defaultSettings : activeSettings)?.map(
+                (setting) => (
+                  <DefinitionItem key={setting.key}>
+                    <DefinitionDisplayName>
+                      {setting.label}
+                    </DefinitionDisplayName>
 
-                  <DefinitionSelection>
-                    {selectionOptions.map((option) => (
-                      <Fragment key={option}>
-                        <DefinitionMiniButton
-                          selected={setting.included === option}
-                          onClick={() => {
-                            if (isMetricSettings(activeDimensionOrMetric)) {
-                              return saveAndUpdateMetricSettings(
-                                "METRIC_SETTING",
-                                {
-                                  key: activeMetricKey,
-                                  settings: [{ ...setting, included: option }],
-                                }
-                              );
-                            }
-
-                            const activeDimensionKey =
-                              activeDimensionOrMetric.key;
-
-                            return (
-                              activeDisaggregation &&
-                              saveAndUpdateMetricSettings("DIMENSION_SETTING", {
-                                key: activeMetricKey,
-                                disaggregations: [
+                    <DefinitionSelection>
+                      {selectionOptions.map((option) => (
+                        <Fragment key={option}>
+                          <DefinitionMiniButton
+                            selected={setting.included === option}
+                            showDefault={showDefaultSettings}
+                            onClick={() => {
+                              if (isMetricSettings(activeDimensionOrMetric)) {
+                                return saveAndUpdateMetricSettings(
+                                  "METRIC_SETTING",
                                   {
-                                    key: activeDisaggregation.key,
-                                    dimensions: [
+                                    key: activeMetricKey,
+                                    settings: [
+                                      { ...setting, included: option },
+                                    ],
+                                  }
+                                );
+                              }
+
+                              const activeDimensionKey =
+                                activeDimensionOrMetric.key;
+
+                              return (
+                                activeDisaggregation &&
+                                saveAndUpdateMetricSettings(
+                                  "DIMENSION_SETTING",
+                                  {
+                                    key: activeMetricKey,
+                                    disaggregations: [
                                       {
-                                        key: activeDimensionKey,
-                                        settings: [
+                                        key: activeDisaggregation.key,
+                                        dimensions: [
                                           {
-                                            ...setting,
-                                            included: option,
+                                            key: activeDimensionKey,
+                                            settings: [
+                                              {
+                                                ...setting,
+                                                included: option,
+                                              },
+                                            ],
                                           },
                                         ],
                                       },
                                     ],
-                                  },
-                                ],
-                              })
-                            );
-                          }}
-                        >
-                          {option}
-                        </DefinitionMiniButton>
-                      </Fragment>
-                    ))}
-                  </DefinitionSelection>
-                </DefinitionItem>
-              ))}
+                                  }
+                                )
+                              );
+                            }}
+                          >
+                            {option}
+                          </DefinitionMiniButton>
+                        </Fragment>
+                      ))}
+                    </DefinitionSelection>
+                  </DefinitionItem>
+                )
+              )}
             </Definitions>
           </>
         )}


### PR DESCRIPTION
## Description of the change

Highlights the default settings values when hovered over the `Choose Default Definition` button.

https://user-images.githubusercontent.com/59492998/197642025-c4daa319-8bd6-422c-8c05-d3799c8698f1.mov


## Related issues

Contributes to #109 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
