### PR TITLE
Settings: Metric Configuration: Playtesting Followups - Misc. Styling Adjustments (6/n)

### DIFF
--- a/publisher/src/components/DataUpload/DataUpload.styles.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.styles.tsx
@@ -521,12 +521,12 @@ export const UploadedFilesContainer = styled.div``;
 
 export const UploadedFilesWrapper = styled.div`
   position: relative;
+  overflow-y: scroll;
 `;
 
 export const UploadedFilesTable = styled(Table)`
   padding: unset;
-  overflow-y: scroll;
-  padding-bottom: 50px;
+  padding-bottom: 100px;
 `;
 
 export const ExtendedTabbedBar = styled(TabbedBar)`
@@ -624,5 +624,6 @@ export const CheckIcon = styled.img`
 
 export const ExtendedOpacityGradient = styled(OpacityGradient)`
   height: 50px;
-  position: absolute;
+  position: fixed;
+  bottom: 0;
 `;

--- a/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
@@ -29,6 +29,7 @@ import {
 import {
   Label,
   MetricContextContainer,
+  MetricContextHeader,
   MetricContextItem,
   MetricSettings,
   MetricSettingsUpdateOptions,
@@ -88,6 +89,7 @@ export const ContextConfiguration: React.FC<
 
   return (
     <MetricContextContainer>
+      <MetricContextHeader>Context</MetricContextHeader>
       <Subheader>
         Anything entered here will appear as the default value for all reports.
         If you are entering data for a particular month, you can still replace

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -150,7 +150,7 @@ export const Metric = styled.div<{ inView: boolean }>`
   align-items: center;
   justify-content: flex-start;
   border-bottom: 1px solid ${palette.solid.darkgrey};
-  padding: 12px;
+  padding: 12px 50px 12px 12px;
   position: relative;
   background: ${({ inView }) =>
     inView ? palette.highlight.lightblue1 : `none`};
@@ -177,8 +177,9 @@ export const Metric = styled.div<{ inView: boolean }>`
 type MetricNameProps = { isTitle?: boolean };
 
 export const MetricName = styled.div<MetricNameProps>`
-  ${({ isTitle }) =>
-    isTitle ? typography.sizeCSS.title : typography.sizeCSS.large}
+  ${typography.sizeCSS.large}
+  ${({ isTitle }) => isTitle && `font-size: 1.6rem;`}
+  padding: 10px 0;
 `;
 
 export const MetricDescription = styled.div`
@@ -523,7 +524,7 @@ export const DefinitionsDisplayContainer = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1 1 55%;
-  padding: 48px 12px 50px 126px;
+  padding: 48px 12px 50px 70px;
   overflow-y: scroll;
 
   @media only screen and (max-width: ${METRICS_VIEW_CONTAINER_BREAKPOINT}px) {

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -380,6 +380,12 @@ export const MetricConfigurationContainer = styled.div`
 
 export const MetricContextContainer = styled.div`
   display: block;
+  border-top: 1px solid ${palette.highlight.grey3};
+`;
+
+export const MetricContextHeader = styled.div`
+  ${typography.sizeCSS.large};
+  margin: 40px 0 20px 0;
 `;
 
 export const MetricContextItem = styled.div`
@@ -579,12 +585,12 @@ export const DefinitionItem = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 6px;
+  margin-bottom: 12px;
 `;
 
 export const DefinitionDisplayName = styled.div`
   ${typography.sizeCSS.medium}
-  margin-right: 8px;
+  margin-right: 20px;
 `;
 
 export const DefinitionSelection = styled.div`
@@ -598,6 +604,7 @@ export const DefinitionMiniButton = styled(RevertToDefaultButton)<{
 }>`
   width: unset;
   padding: 9px 16px;
+  transition: color 0.2s ease;
 
   ${({ selected }) =>
     selected &&

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -26,15 +26,12 @@ import { BinaryRadioGroupWrapper, Button } from "../Forms";
 const METRICS_VIEW_CONTAINER_BREAKPOINT = 1200;
 
 export const MetricsViewContainer = styled.div`
+  height: 100%;
   width: 100%;
   display: flex;
   flex-direction: column;
   align-items: flex-start;
-  overflow: hidden;
-
-  @media only screen and (max-width: ${METRICS_VIEW_CONTAINER_BREAKPOINT}px) {
-    overflow: unset;
-  }
+  overflow-y: hidden;
 `;
 
 export const MetricsViewControlPanel = styled.div`
@@ -43,7 +40,6 @@ export const MetricsViewControlPanel = styled.div`
   display: flex;
   flex-wrap: wrap;
   justify-content: space-between;
-  overflow-y: scroll;
 
   @media only screen and (max-width: ${METRICS_VIEW_CONTAINER_BREAKPOINT}px) {
     flex-direction: column;
@@ -79,6 +75,7 @@ export const PanelContainerRight = styled.div`
 `;
 
 export const MetricBoxBottomPaddingContainer = styled.div`
+  height: 100%;
   display: flex;
   flex-wrap: wrap;
   padding-bottom: 100px;
@@ -518,6 +515,7 @@ export const MetricConfigurationWrapper = styled.div`
 
   @media only screen and (max-width: ${METRICS_VIEW_CONTAINER_BREAKPOINT}px) {
     flex-direction: column;
+    overflow-y: scroll;
   }
 `;
 

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -218,21 +218,18 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
         {/* Display when user is viewing a dimension & there are no settings available */}
         {!activeSettings?.length && activeDimension && (
           <DefinitionsSubTitle>
-            This breakdown has no customizations available yet.
+            Technical Definitions are not available for this metric yet.
           </DefinitionsSubTitle>
         )}
       </DefinitionsDisplay>
 
       {/* Additional Context (only appears on overall metric settings and not individual dimension settings) */}
       {!activeDimension && (
-        <>
-          <DefinitionsSubTitle>Context</DefinitionsSubTitle>
-          <ContextConfiguration
-            metricKey={activeMetricKey}
-            contexts={contexts}
-            saveAndUpdateMetricSettings={saveAndUpdateMetricSettings}
-          />
-        </>
+        <ContextConfiguration
+          metricKey={activeMetricKey}
+          contexts={contexts}
+          saveAndUpdateMetricSettings={saveAndUpdateMetricSettings}
+        />
       )}
     </DefinitionsDisplayContainer>
   );

--- a/publisher/src/components/Settings/Settings.styles.tsx
+++ b/publisher/src/components/Settings/Settings.styles.tsx
@@ -29,7 +29,7 @@ export const SettingsContainer = styled.div`
   align-items: flex-start;
   padding: 48px 24px 0 24px;
   position: fixed;
-  overflow-y: scroll;
+  /* overflow-y: scroll; */
 `;
 
 export const ContentDisplay = styled.div`
@@ -38,7 +38,7 @@ export const ContentDisplay = styled.div`
   flex-direction: column;
   justify-content: flex-start;
   flex: 10 10 auto;
-  overflow-y: scroll;
+  /* overflow-y: scroll; */
 `;
 
 export const SettingsMenuContainer = styled.div`

--- a/publisher/src/components/Settings/Settings.styles.tsx
+++ b/publisher/src/components/Settings/Settings.styles.tsx
@@ -29,7 +29,6 @@ export const SettingsContainer = styled.div`
   align-items: flex-start;
   padding: 48px 24px 0 24px;
   position: fixed;
-  /* overflow-y: scroll; */
 `;
 
 export const ContentDisplay = styled.div`
@@ -38,7 +37,6 @@ export const ContentDisplay = styled.div`
   flex-direction: column;
   justify-content: flex-start;
   flex: 10 10 auto;
-  /* overflow-y: scroll; */
 `;
 
 export const SettingsMenuContainer = styled.div`
@@ -48,7 +46,7 @@ export const SettingsMenuContainer = styled.div`
   flex: 0 0 auto;
   flex-direction: column;
   gap: 16px;
-  margin-right: 100px;
+  margin-right: 70px;
 `;
 
 export const MenuItem = styled.div<{ selected?: boolean }>`


### PR DESCRIPTION
## Description of the change

Miscellaneous styling adjustments based on round 2 of playtesting feedbacks. 

General description of the changes:
- Adjusted the padding between the menu & the metric config main sections, and between the metric/breakdown selections area and the definitions area
- Reduced the font-size of the overall metric
- Made adjustments to prevent the arrow from squishing into the badge
- Fixed the multiple scrollbar issue
- Updated copy for metrics/breakdowns without definitions
- Slightly increased spacing between the definition items
- Added a slight transition easing the reveal of the default metric buttons when hovering over the `Choose to Default` button
- Added a border-top to the Context and increased the “Context” title font-size

Demo:


https://user-images.githubusercontent.com/59492998/198328231-39dc780c-3c39-4220-836c-39409433439f.mov



Easing Transition Demo:

https://user-images.githubusercontent.com/59492998/198143685-0164fa83-4a39-4830-bd1e-5cbefc3e4323.mov


Updated No Definitions Copy:

<img width="1728" alt="Screen Shot 2022-10-26 at 4 22 58 PM" src="https://user-images.githubusercontent.com/59492998/198143727-90ecd7f1-24ef-41ee-98d8-7d5d73e390fa.png">


## Related issues

Closes #120 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
