### PR TITLE
[Bug] Metric Configuration: MetricBoxes Taking Up Entire Height

### DIFF
--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -76,9 +76,8 @@ export const PanelContainerRight = styled.div`
 
 export const MetricBoxBottomPaddingContainer = styled.div`
   height: 100%;
-  display: flex;
-  flex-wrap: wrap;
-  padding-bottom: 100px;
+  width: 100%;
+  padding-bottom: 150px;
   overflow-y: scroll;
 `;
 
@@ -109,6 +108,11 @@ export const MetricBoxContainer = styled.div<MetricBoxContainerProps>`
     max-width: unset;
     flex: unset;
   }
+`;
+
+export const MetricBoxContainerWrapper = styled.div`
+  display: flex;
+  flex-wrap: wrap;
 `;
 
 export const MetricViewBoxContainer = styled(MetricBoxContainer)<{

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -41,6 +41,7 @@ import {
   Metric,
   MetricBox,
   MetricBoxBottomPaddingContainer,
+  MetricBoxContainerWrapper,
   MetricConfigurationDisplay,
   MetricConfigurationWrapper,
   MetricDefinitions,
@@ -525,17 +526,19 @@ export const MetricConfiguration: React.FC<{
           {/* List Of Metrics */}
           {filteredMetricSettings && !activeMetricKey && (
             <MetricBoxBottomPaddingContainer>
-              {Object.values(filteredMetricSettings).map((metric) => (
-                <MetricBox
-                  key={metric.key}
-                  metricKey={metric.key}
-                  displayName={metric.display_name}
-                  frequency={metric.frequency as ReportFrequency}
-                  description={metric.description}
-                  enabled={metric.enabled}
-                  setActiveMetricKey={setActiveMetricKey}
-                />
-              ))}
+              <MetricBoxContainerWrapper>
+                {Object.values(filteredMetricSettings).map((metric) => (
+                  <MetricBox
+                    key={metric.key}
+                    metricKey={metric.key}
+                    displayName={metric.display_name}
+                    frequency={metric.frequency as ReportFrequency}
+                    description={metric.description}
+                    enabled={metric.enabled}
+                    setActiveMetricKey={setActiveMetricKey}
+                  />
+                ))}
+              </MetricBoxContainerWrapper>
             </MetricBoxBottomPaddingContainer>
           )}
 


### PR DESCRIPTION
## Description of the change

Fixing the visual bug below where the MetricBoxes were taking up the entire height when there are 2 or less boxes. Did a manual test of each tab and other agencies and it no longer persists.

Before:
<img width="1728" alt="Screen Shot 2022-10-31 at 10 33 16 AM" src="https://user-images.githubusercontent.com/59492998/199055358-e6ad5cb6-d257-4556-b07a-15fd4594b6c2.png">

After:
<img width="1728" alt="Screen Shot 2022-10-31 at 11 06 27 AM" src="https://user-images.githubusercontent.com/59492998/199055379-47abddac-458d-4e2e-ad03-eea9e8cfda41.png">



## Related issues

Closes #125 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
