### PR TITLE
Metric Configuration Store: Refactor & Connect UI Components to the Store (2/2)

### DIFF
--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -87,6 +87,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
       Object.keys(
         dimensions[systemMetricKey][activeDisaggregationKey]
       )) as string[];
+
     const metricDisplayName = metrics[systemMetricKey]?.label;
 
     const metricEnabled = Boolean(metrics[systemMetricKey]?.enabled);

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -68,7 +68,6 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
     saveAndUpdateMetricSettings,
   }): JSX.Element => {
     const { metricConfigStore } = useStore();
-
     const { activeMetricKey } = metricConfigStore;
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       metricConfigStore.activeMetricKey as string,

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -70,8 +70,8 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
     const { metricConfigStore } = useStore();
     const { activeMetricKey } = metricConfigStore;
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
-      metricConfigStore.activeMetricKey as string,
-      metricConfigStore.activeSystem as string
+      metricConfigStore.activeSystem as string,
+      metricConfigStore.activeMetricKey as string
     );
     const metricDisplayName = metricConfigStore.metrics[systemMetricKey]?.label;
     const metricEnabled = Boolean(

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -38,7 +38,6 @@ import {
   MetricConfigurationContainer,
   MetricDisaggregations,
   MetricOnOffWrapper,
-  MetricSettings,
   RadioButtonGroupWrapper,
   Subheader,
 } from ".";
@@ -52,7 +51,6 @@ type MetricConfigurationProps = {
   setActiveDisaggregationKey: React.Dispatch<
     React.SetStateAction<string | undefined>
   >;
-  saveUpdatedMetricSettings: (updatedSetting: MetricSettings) => void;
 };
 
 export const Configuration: React.FC<MetricConfigurationProps> = observer(
@@ -61,7 +59,6 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
     setActiveDimensionKey,
     activeDisaggregationKey,
     setActiveDisaggregationKey,
-    saveUpdatedMetricSettings,
   }): JSX.Element => {
     const { metricConfigStore } = useStore();
     const {
@@ -74,6 +71,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
       updateMetricEnabledStatus,
       updateDisaggregationEnabledStatus,
       updateDimensionEnabledStatus,
+      saveMetricSettings,
     } = metricConfigStore;
 
     const systemMetricKey = getActiveSystemMetricKey();
@@ -129,7 +127,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                   activeMetricKey as string,
                   true
                 );
-                saveUpdatedMetricSettings(updatedSetting);
+                saveMetricSettings(updatedSetting);
               }}
             />
             <BinaryRadioButton
@@ -145,7 +143,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                   activeMetricKey as string,
                   false
                 );
-                saveUpdatedMetricSettings(updatedSetting);
+                saveMetricSettings(updatedSetting);
               }}
             />
           </RadioButtonGroupWrapper>
@@ -204,7 +202,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                                   disaggregationKey,
                                   !currentDisaggregation.enabled
                                 );
-                              saveUpdatedMetricSettings(updatedSetting);
+                              saveMetricSettings(updatedSetting);
                             }}
                           />
                           <BlueCheckIcon
@@ -254,7 +252,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                             dimensionKey,
                             !currentDimension.enabled
                           );
-                          saveUpdatedMetricSettings(updatedSetting);
+                          saveMetricSettings(updatedSetting);
                         }}
                       />
                       <BlueCheckIcon

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -150,7 +150,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
         </MetricOnOffWrapper>
 
         {/* Breakdowns */}
-        {activeDisaggregationKey && (
+        {activeDisaggregationKey && activeDisaggregationKeys?.length > 0 && (
           <MetricDisaggregations enabled={metricEnabled}>
             <BreakdownHeader>Breakdowns</BreakdownHeader>
             <Subheader>

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -82,11 +82,11 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
       disaggregations[systemMetricKey] &&
       Object.keys(disaggregations[systemMetricKey]);
 
-    const activeDimensionKeys = (activeDisaggregationKey &&
-      dimensions[systemMetricKey]?.[activeDisaggregationKey] &&
-      Object.keys(
-        dimensions[systemMetricKey][activeDisaggregationKey]
-      )) as string[];
+    const activeDimensionKeys =
+      activeDisaggregationKey &&
+      dimensions[systemMetricKey]?.[activeDisaggregationKey]
+        ? Object.keys(dimensions[systemMetricKey][activeDisaggregationKey])
+        : [];
 
     const metricDisplayName = metrics[systemMetricKey]?.label;
 

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -122,12 +122,14 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
               value="yes"
               checked={metricEnabled}
               onChange={() => {
-                const updatedSetting = updateMetricEnabledStatus(
-                  activeSystem,
-                  activeMetricKey as string,
-                  true
-                );
-                if (updatedSetting) saveMetricSettings(updatedSetting);
+                if (activeSystem && activeMetricKey) {
+                  const updatedSetting = updateMetricEnabledStatus(
+                    activeSystem,
+                    activeMetricKey,
+                    true
+                  );
+                  saveMetricSettings(updatedSetting);
+                }
               }}
             />
             <BinaryRadioButton
@@ -138,12 +140,14 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
               value="no"
               checked={!metricEnabled}
               onChange={() => {
-                const updatedSetting = updateMetricEnabledStatus(
-                  activeSystem,
-                  activeMetricKey as string,
-                  false
-                );
-                if (updatedSetting) saveMetricSettings(updatedSetting);
+                if (activeSystem && activeMetricKey) {
+                  const updatedSetting = updateMetricEnabledStatus(
+                    activeSystem,
+                    activeMetricKey,
+                    false
+                  );
+                  saveMetricSettings(updatedSetting);
+                }
               }}
             />
           </RadioButtonGroupWrapper>
@@ -195,15 +199,16 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                             type="checkbox"
                             checked={currentDisaggregation.enabled}
                             onChange={() => {
-                              const updatedSetting =
-                                updateDisaggregationEnabledStatus(
-                                  activeSystem,
-                                  activeMetricKey,
-                                  disaggregationKey,
-                                  !currentDisaggregation.enabled
-                                );
-                              if (updatedSetting)
+                              if (activeSystem && activeMetricKey) {
+                                const updatedSetting =
+                                  updateDisaggregationEnabledStatus(
+                                    activeSystem,
+                                    activeMetricKey,
+                                    disaggregationKey,
+                                    !currentDisaggregation.enabled
+                                  );
                                 saveMetricSettings(updatedSetting);
+                              }
                             }}
                           />
                           <BlueCheckIcon
@@ -244,15 +249,16 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                           currentDimension.enabled
                         }
                         onChange={() => {
-                          const updatedSetting = updateDimensionEnabledStatus(
-                            activeSystem,
-                            activeMetricKey,
-                            activeDisaggregationKey,
-                            dimensionKey,
-                            !currentDimension.enabled
-                          );
-                          if (updatedSetting)
+                          if (activeSystem && activeMetricKey) {
+                            const updatedSetting = updateDimensionEnabledStatus(
+                              activeSystem,
+                              activeMetricKey,
+                              activeDisaggregationKey,
+                              dimensionKey,
+                              !currentDimension.enabled
+                            );
                             saveMetricSettings(updatedSetting);
+                          }
                         }}
                       />
                       <BlueCheckIcon

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -123,11 +123,11 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
               checked={metricEnabled}
               onChange={() => {
                 const updatedSetting = updateMetricEnabledStatus(
-                  activeSystem as string,
+                  activeSystem,
                   activeMetricKey as string,
                   true
                 );
-                saveMetricSettings(updatedSetting);
+                if (updatedSetting) saveMetricSettings(updatedSetting);
               }}
             />
             <BinaryRadioButton
@@ -139,11 +139,11 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
               checked={!metricEnabled}
               onChange={() => {
                 const updatedSetting = updateMetricEnabledStatus(
-                  activeSystem as string,
+                  activeSystem,
                   activeMetricKey as string,
                   false
                 );
-                saveMetricSettings(updatedSetting);
+                if (updatedSetting) saveMetricSettings(updatedSetting);
               }}
             />
           </RadioButtonGroupWrapper>
@@ -197,12 +197,13 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                             onChange={() => {
                               const updatedSetting =
                                 updateDisaggregationEnabledStatus(
-                                  activeSystem as string,
-                                  activeMetricKey as string,
+                                  activeSystem,
+                                  activeMetricKey,
                                   disaggregationKey,
                                   !currentDisaggregation.enabled
                                 );
-                              saveMetricSettings(updatedSetting);
+                              if (updatedSetting)
+                                saveMetricSettings(updatedSetting);
                             }}
                           />
                           <BlueCheckIcon
@@ -222,13 +223,11 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
               {/* Dimension Fields (Enable/Disable) */}
               {activeDimensionKeys?.map((dimensionKey) => {
                 const currentDisaggregation =
-                  disaggregations[systemMetricKey][
-                    activeDisaggregationKey as string
-                  ];
+                  disaggregations[systemMetricKey][activeDisaggregationKey];
                 const currentDimension =
-                  dimensions[systemMetricKey][
-                    activeDisaggregationKey as string
-                  ][dimensionKey];
+                  dimensions[systemMetricKey][activeDisaggregationKey][
+                    dimensionKey
+                  ];
 
                 return (
                   <Dimension
@@ -246,13 +245,14 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                         }
                         onChange={() => {
                           const updatedSetting = updateDimensionEnabledStatus(
-                            activeSystem as string,
-                            activeMetricKey as string,
-                            activeDisaggregationKey as string,
+                            activeSystem,
+                            activeMetricKey,
+                            activeDisaggregationKey,
                             dimensionKey,
                             !currentDimension.enabled
                           );
-                          saveMetricSettings(updatedSetting);
+                          if (updatedSetting)
+                            saveMetricSettings(updatedSetting);
                         }}
                       />
                       <BlueCheckIcon

--- a/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
@@ -15,9 +15,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { DebouncedFunc } from "lodash";
+import { debounce } from "lodash";
 import { observer } from "mobx-react-lite";
-import React from "react";
+import React, { useRef } from "react";
 
 import { useStore } from "../../stores";
 import {
@@ -40,13 +40,10 @@ import {
 
 type MetricContextConfigurationProps = {
   saveUpdatedMetricSettings: (updatedSetting: MetricSettings) => void;
-  debouncedSave: DebouncedFunc<
-    (updatedSetting: MetricSettings) => Promise<void>
-  >;
 };
 
 export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
-  observer(({ saveUpdatedMetricSettings, debouncedSave }) => {
+  observer(({ saveUpdatedMetricSettings }) => {
     const { metricConfigStore } = useStore();
     const {
       activeMetricKey,
@@ -60,6 +57,10 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
     const activeContextKeys =
       (contexts[systemMetricKey] && Object.keys(contexts[systemMetricKey])) ||
       [];
+
+    const debouncedSave = useRef(
+      debounce(saveUpdatedMetricSettings, 1500)
+    ).current;
 
     return (
       <MetricContextContainer>

--- a/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
@@ -15,12 +15,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { MetricContext } from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
 import React from "react";
 
 import { useStore } from "../../stores";
-import MetricConfigStore from "../../stores/MetricConfigStore";
 import {
   BinaryRadioButton,
   BinaryRadioGroupClearButton,
@@ -49,15 +47,17 @@ type MetricContextConfigurationProps = {
 export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
   observer(({ saveAndUpdateMetricSettings }) => {
     const { metricConfigStore } = useStore();
+    const {
+      activeMetricKey,
+      activeSystem,
+      contexts,
+      updateContextValue,
+      getActiveSystemMetricKey,
+    } = metricConfigStore;
 
-    const { activeMetricKey } = metricConfigStore;
-    const systemMetricKey = MetricConfigStore.getSystemMetricKey(
-      metricConfigStore.activeSystem as string,
-      activeMetricKey as string
-    );
+    const systemMetricKey = getActiveSystemMetricKey();
     const activeContextKeys =
-      (metricConfigStore.contexts[systemMetricKey] &&
-        Object.keys(metricConfigStore.contexts[systemMetricKey])) ||
+      (contexts[systemMetricKey] && Object.keys(contexts[systemMetricKey])) ||
       [];
 
     return (
@@ -70,11 +70,11 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
         </Subheader>
 
         {activeContextKeys.map((contextKey) => {
-          const currentContext =
-            metricConfigStore.contexts[systemMetricKey][contextKey];
+          const currentContext = contexts[systemMetricKey][contextKey];
 
           return (
             <MetricContextItem key={contextKey}>
+              {/* Binary Context Questions */}
               {currentContext.type === "BOOLEAN" && (
                 <>
                   <Label noBottomMargin>{currentContext.display_name}</Label>
@@ -87,14 +87,13 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
                       value="yes"
                       checked={currentContext.value === "yes"}
                       onChange={() => {
-                        const updatedSetting =
-                          metricConfigStore.updateContextValue(
-                            metricConfigStore.activeSystem as string,
-                            metricConfigStore.activeMetricKey as string,
-                            contextKey,
-                            currentContext.type as MetricContext["type"],
-                            "yes"
-                          );
+                        const updatedSetting = updateContextValue(
+                          activeSystem as string,
+                          activeMetricKey as string,
+                          contextKey,
+                          currentContext.type,
+                          "yes"
+                        );
                         saveAndUpdateMetricSettings(updatedSetting);
                       }}
                     />
@@ -106,28 +105,26 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
                       value="no"
                       checked={currentContext.value === "no"}
                       onChange={() => {
-                        const updatedSetting =
-                          metricConfigStore.updateContextValue(
-                            metricConfigStore.activeSystem as string,
-                            metricConfigStore.activeMetricKey as string,
-                            contextKey,
-                            currentContext.type as MetricContext["type"],
-                            "no"
-                          );
+                        const updatedSetting = updateContextValue(
+                          activeSystem as string,
+                          activeMetricKey as string,
+                          contextKey,
+                          currentContext.type,
+                          "no"
+                        );
                         saveAndUpdateMetricSettings(updatedSetting);
                       }}
                     />
                   </RadioButtonGroupWrapper>
                   <BinaryRadioGroupClearButton
                     onClick={() => {
-                      const updatedSetting =
-                        metricConfigStore.updateContextValue(
-                          metricConfigStore.activeSystem as string,
-                          metricConfigStore.activeMetricKey as string,
-                          contextKey,
-                          currentContext.type as MetricContext["type"],
-                          ""
-                        );
+                      const updatedSetting = updateContextValue(
+                        activeSystem as string,
+                        activeMetricKey as string,
+                        contextKey,
+                        currentContext.type,
+                        ""
+                      );
                       saveAndUpdateMetricSettings(updatedSetting);
                     }}
                   >
@@ -136,6 +133,7 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
                 </>
               )}
 
+              {/* Text Field Context Questions */}
               {(currentContext.type === "TEXT" ||
                 currentContext.type === "NUMBER") && (
                 <>
@@ -149,20 +147,20 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
                     multiline={currentContext.type === "TEXT"}
                     error={currentContext.error}
                     onChange={(e) => {
-                      const updatedSetting =
-                        metricConfigStore.updateContextValue(
-                          metricConfigStore.activeSystem as string,
-                          metricConfigStore.activeMetricKey as string,
-                          contextKey,
-                          currentContext.type as MetricContext["type"],
-                          e.currentTarget.value
-                        );
+                      const updatedSetting = updateContextValue(
+                        activeSystem as string,
+                        activeMetricKey as string,
+                        contextKey,
+                        currentContext.type,
+                        e.currentTarget.value
+                      );
                       saveAndUpdateMetricSettings(updatedSetting, true);
                     }}
                   />
                 </>
               )}
 
+              {/* Multiple Choice Context Questions */}
               {currentContext.type === "MULTIPLE_CHOICE" && (
                 <BinaryRadioGroupContainer key={contextKey}>
                   <BinaryRadioGroupQuestion>
@@ -180,14 +178,13 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
                         value={option}
                         checked={currentContext.value === option}
                         onChange={() => {
-                          const updatedSetting =
-                            metricConfigStore.updateContextValue(
-                              metricConfigStore.activeSystem as string,
-                              metricConfigStore.activeMetricKey as string,
-                              contextKey,
-                              currentContext.type as MetricContext["type"],
-                              option
-                            );
+                          const updatedSetting = updateContextValue(
+                            activeSystem as string,
+                            activeMetricKey as string,
+                            contextKey,
+                            currentContext.type,
+                            option
+                          );
                           saveAndUpdateMetricSettings(updatedSetting);
                         }}
                       />
@@ -196,14 +193,13 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
 
                   <BinaryRadioGroupClearButton
                     onClick={() => {
-                      const updatedSetting =
-                        metricConfigStore.updateContextValue(
-                          metricConfigStore.activeSystem as string,
-                          metricConfigStore.activeMetricKey as string,
-                          contextKey,
-                          currentContext.type as MetricContext["type"],
-                          ""
-                        );
+                      const updatedSetting = updateContextValue(
+                        activeSystem as string,
+                        activeMetricKey as string,
+                        contextKey,
+                        currentContext.type,
+                        ""
+                      );
                       saveAndUpdateMetricSettings(updatedSetting);
                     }}
                   >

--- a/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+import { DebouncedFunc } from "lodash";
 import { observer } from "mobx-react-lite";
 import React from "react";
 
@@ -38,14 +39,14 @@ import {
 } from ".";
 
 type MetricContextConfigurationProps = {
-  saveAndUpdateMetricSettings: (
-    updatedSetting: MetricSettings,
-    debounce?: boolean
-  ) => void;
+  saveUpdatedMetricSettings: (updatedSetting: MetricSettings) => void;
+  debouncedSave: DebouncedFunc<
+    (updatedSetting: MetricSettings) => Promise<void>
+  >;
 };
 
 export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
-  observer(({ saveAndUpdateMetricSettings }) => {
+  observer(({ saveUpdatedMetricSettings, debouncedSave }) => {
     const { metricConfigStore } = useStore();
     const {
       activeMetricKey,
@@ -94,7 +95,7 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
                           currentContext.type,
                           "yes"
                         );
-                        saveAndUpdateMetricSettings(updatedSetting);
+                        saveUpdatedMetricSettings(updatedSetting);
                       }}
                     />
                     <BinaryRadioButton
@@ -112,7 +113,7 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
                           currentContext.type,
                           "no"
                         );
-                        saveAndUpdateMetricSettings(updatedSetting);
+                        saveUpdatedMetricSettings(updatedSetting);
                       }}
                     />
                   </RadioButtonGroupWrapper>
@@ -125,7 +126,7 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
                         currentContext.type,
                         ""
                       );
-                      saveAndUpdateMetricSettings(updatedSetting);
+                      saveUpdatedMetricSettings(updatedSetting);
                     }}
                   >
                     Clear Input
@@ -154,7 +155,7 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
                         currentContext.type,
                         e.currentTarget.value
                       );
-                      saveAndUpdateMetricSettings(updatedSetting, true);
+                      debouncedSave(updatedSetting);
                     }}
                   />
                 </>
@@ -185,7 +186,7 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
                             currentContext.type,
                             option
                           );
-                          saveAndUpdateMetricSettings(updatedSetting);
+                          saveUpdatedMetricSettings(updatedSetting);
                         }}
                       />
                     ))}
@@ -200,7 +201,7 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
                         currentContext.type,
                         ""
                       );
-                      saveAndUpdateMetricSettings(updatedSetting);
+                      saveUpdatedMetricSettings(updatedSetting);
                     }}
                   >
                     Clear Input

--- a/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
@@ -36,182 +36,233 @@ import {
   RadioButtonGroupWrapper,
   Subheader,
 } from ".";
+import { observer } from "mobx-react-lite";
+import MetricConfigStore from "../../stores/MetricConfigStore";
+import { useStore } from "../../stores";
 
 type MetricContextConfigurationProps = {
-  metricKey: string;
-  contexts: MetricContext[];
   saveAndUpdateMetricSettings: (
     updatedSetting: MetricSettings,
     debounce?: boolean
   ) => void;
 };
 
-export const ContextConfiguration: React.FC<
-  MetricContextConfigurationProps
-> = ({ metricKey, contexts, saveAndUpdateMetricSettings }) => {
-  const [contextErrors, setContextErrors] = useState<{
-    [key: string]: FormError;
-  }>();
+export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
+  observer(({ saveAndUpdateMetricSettings }) => {
+    // const [contextErrors, setContextErrors] = useState<{
+    //   [key: string]: FormError;
+    // }>();
 
-  const contextNumberValidation = (key: string, value: string) => {
-    const cleanValue = removeCommaSpaceAndTrim(value);
+    // const contextNumberValidation = (key: string, value: string) => {
+    //   const cleanValue = removeCommaSpaceAndTrim(value);
 
-    if (!isPositiveNumber(cleanValue) && cleanValue !== "") {
-      setContextErrors({
-        [key]: {
-          message: "Please enter a valid number.",
-        },
-      });
+    //   if (!isPositiveNumber(cleanValue) && cleanValue !== "") {
+    //     setContextErrors({
+    //       [key]: {
+    //         message: "Please enter a valid number.",
+    //       },
+    //     });
 
-      return false;
-    }
+    //     return false;
+    //   }
 
-    setContextErrors((prev) => {
-      const otherContextErrors = { ...prev };
-      delete otherContextErrors[key];
+    //   setContextErrors((prev) => {
+    //     const otherContextErrors = { ...prev };
+    //     delete otherContextErrors[key];
 
-      return otherContextErrors;
-    });
-    return true;
-  };
+    //     return otherContextErrors;
+    //   });
+    //   return true;
+    // };
 
-  useEffect(() => {
-    if (contexts) {
-      contexts.forEach((context) => {
-        if (context.type === "NUMBER") {
-          contextNumberValidation(context.key, (context.value || "") as string);
-        }
-      });
-    }
-  }, [contexts]);
+    // useEffect(() => {
+    //   if (contexts) {
+    //     contexts.forEach((context) => {
+    //       if (context.type === "NUMBER") {
+    //         contextNumberValidation(context.key, (context.value || "") as string);
+    //       }
+    //     });
+    //   }
+    // }, [contexts]);
+    const { metricConfigStore } = useStore();
+    const { activeMetricKey } = metricConfigStore;
+    const systemMetricKey = MetricConfigStore.getSystemMetricKey(
+      activeMetricKey as string,
+      metricConfigStore.activeSystem as string
+    );
+    const activeContextKeys =
+      (metricConfigStore.contexts[systemMetricKey] &&
+        Object.keys(metricConfigStore.contexts[systemMetricKey])) ||
+      [];
 
-  return (
-    <MetricContextContainer>
-      <MetricContextHeader>Context</MetricContextHeader>
-      <Subheader>
-        Anything entered here will appear as the default value for all reports.
-        If you are entering data for a particular month, you can still replace
-        this as necessary.
-      </Subheader>
+    return (
+      <MetricContextContainer>
+        <MetricContextHeader>Context</MetricContextHeader>
+        <Subheader>
+          Anything entered here will appear as the default value for all
+          reports. If you are entering data for a particular month, you can
+          still replace this as necessary.
+        </Subheader>
 
-      {contexts?.map((context) => (
-        <MetricContextItem key={context.key}>
-          {context.type === "BOOLEAN" && (
-            <>
-              <Label noBottomMargin>{context.display_name}</Label>
-              <RadioButtonGroupWrapper>
-                <BinaryRadioButton
-                  type="radio"
-                  id={`${context.key}-yes`}
-                  name={context.key}
-                  label="Yes"
-                  value="yes"
-                  checked={context.value === "yes"}
-                  onChange={() =>
-                    saveAndUpdateMetricSettings({
-                      key: metricKey,
-                      contexts: [{ key: context.key, value: "yes" }],
-                    })
-                  }
-                />
-                <BinaryRadioButton
-                  type="radio"
-                  id={`${context.key}-no`}
-                  name={context.key}
-                  label="No"
-                  value="no"
-                  checked={context.value === "no"}
-                  onChange={() =>
-                    saveAndUpdateMetricSettings({
-                      key: metricKey,
-                      contexts: [{ key: context.key, value: "no" }],
-                    })
-                  }
-                />
-              </RadioButtonGroupWrapper>
-              <BinaryRadioGroupClearButton
-                onClick={() =>
-                  saveAndUpdateMetricSettings({
-                    key: metricKey,
-                    contexts: [{ key: context.key, value: "" }],
-                  })
-                }
-              >
-                Clear Input
-              </BinaryRadioGroupClearButton>
-            </>
-          )}
+        {activeContextKeys.map((contextKey) => {
+          const currentContext =
+            metricConfigStore.contexts[systemMetricKey][contextKey];
 
-          {(context.type === "TEXT" || context.type === "NUMBER") && (
-            <>
-              <Label>{context.display_name}</Label>
-              <TextInput
-                type="text"
-                name={context.key}
-                id={context.key}
-                label=""
-                value={(context.value || "") as string}
-                multiline={context.type === "TEXT"}
-                error={contextErrors?.[context.key]}
-                onChange={(e) => {
-                  if (context.type === "NUMBER") {
-                    contextNumberValidation(context.key, e.currentTarget.value);
-                  }
+          return (
+            <MetricContextItem key={contextKey}>
+              {currentContext.type === "BOOLEAN" && (
+                <>
+                  <Label noBottomMargin>{currentContext.display_name}</Label>
+                  <RadioButtonGroupWrapper>
+                    <BinaryRadioButton
+                      type="radio"
+                      id={`${contextKey}-yes`}
+                      name={contextKey}
+                      label="Yes"
+                      value="yes"
+                      checked={currentContext.value === "yes"}
+                      onChange={() => {
+                        // saveAndUpdateMetricSettings({
+                        //   key: metricKey,
+                        //   contexts: [{ key: contextKey, value: "yes" }],
+                        // });
 
-                  saveAndUpdateMetricSettings(
-                    {
-                      key: metricKey,
-                      contexts: [
-                        { key: context.key, value: e.currentTarget.value },
-                      ],
-                    },
-                    true
-                  );
-                }}
-              />
-            </>
-          )}
+                        const updatedSetting =
+                          metricConfigStore.updateContextValue(
+                            metricConfigStore.activeSystem as string,
+                            metricConfigStore.activeMetricKey as string,
+                            contextKey,
+                            currentContext.type as MetricContext["type"],
+                            "yes"
+                          );
+                        saveAndUpdateMetricSettings(updatedSetting);
+                      }}
+                    />
+                    <BinaryRadioButton
+                      type="radio"
+                      id={`${contextKey}-no`}
+                      name={contextKey}
+                      label="No"
+                      value="no"
+                      checked={currentContext.value === "no"}
+                      onChange={() => {
+                        const updatedSetting =
+                          metricConfigStore.updateContextValue(
+                            metricConfigStore.activeSystem as string,
+                            metricConfigStore.activeMetricKey as string,
+                            contextKey,
+                            currentContext.type as MetricContext["type"],
+                            "no"
+                          );
+                        saveAndUpdateMetricSettings(updatedSetting);
+                      }}
+                    />
+                  </RadioButtonGroupWrapper>
+                  <BinaryRadioGroupClearButton
+                    onClick={() => {
+                      const updatedSetting =
+                        metricConfigStore.updateContextValue(
+                          metricConfigStore.activeSystem as string,
+                          metricConfigStore.activeMetricKey as string,
+                          contextKey,
+                          currentContext.type as MetricContext["type"],
+                          ""
+                        );
+                      saveAndUpdateMetricSettings(updatedSetting);
+                    }}
+                  >
+                    Clear Input
+                  </BinaryRadioGroupClearButton>
+                </>
+              )}
 
-          {context.type === "MULTIPLE_CHOICE" && (
-            <BinaryRadioGroupContainer key={context.key}>
-              <BinaryRadioGroupQuestion>
-                {context.display_name}
-              </BinaryRadioGroupQuestion>
-
-              <MultipleChoiceWrapper>
-                {context.multiple_choice_options?.map((option) => (
-                  <BinaryRadioButton
-                    type="radio"
-                    key={option}
-                    id={`${context.key}-${option}`}
-                    name={`${context.key}`}
-                    label={option}
-                    value={option}
-                    checked={context.value === option}
-                    onChange={() =>
-                      saveAndUpdateMetricSettings({
-                        key: metricKey,
-                        contexts: [{ key: context.key, value: option }],
-                      })
-                    }
+              {(currentContext.type === "TEXT" ||
+                currentContext.type === "NUMBER") && (
+                <>
+                  <Label>{currentContext.display_name}</Label>
+                  <TextInput
+                    type="text"
+                    name={contextKey}
+                    id={contextKey}
+                    label=""
+                    value={(currentContext.value || "") as string}
+                    multiline={currentContext.type === "TEXT"}
+                    error={currentContext.error}
+                    onChange={(e) => {
+                      const updatedSetting =
+                        metricConfigStore.updateContextValue(
+                          metricConfigStore.activeSystem as string,
+                          metricConfigStore.activeMetricKey as string,
+                          contextKey,
+                          currentContext.type as MetricContext["type"],
+                          e.currentTarget.value
+                        );
+                      saveAndUpdateMetricSettings(updatedSetting, true);
+                    }}
                   />
-                ))}
-              </MultipleChoiceWrapper>
+                </>
+              )}
 
-              <BinaryRadioGroupClearButton
-                onClick={() =>
-                  saveAndUpdateMetricSettings({
-                    key: metricKey,
-                    contexts: [{ key: context.key, value: "" }],
-                  })
-                }
-              >
-                Clear Input
-              </BinaryRadioGroupClearButton>
-            </BinaryRadioGroupContainer>
-          )}
-        </MetricContextItem>
-      ))}
-    </MetricContextContainer>
-  );
-};
+              {currentContext.type === "MULTIPLE_CHOICE" && (
+                <BinaryRadioGroupContainer key={contextKey}>
+                  <BinaryRadioGroupQuestion>
+                    {currentContext.display_name}
+                  </BinaryRadioGroupQuestion>
+
+                  <MultipleChoiceWrapper>
+                    {currentContext.multiple_choice_options?.map((option) => (
+                      <BinaryRadioButton
+                        type="radio"
+                        key={option}
+                        id={`${contextKey}-${option}`}
+                        name={`${contextKey}`}
+                        label={option}
+                        value={option}
+                        checked={currentContext.value === option}
+                        onChange={() => {
+                          // saveAndUpdateMetricSettings({
+                          //   key: metricKey,
+                          //   contexts: [{ key: contextKey, value: option }],
+                          // });
+
+                          const updatedSetting =
+                            metricConfigStore.updateContextValue(
+                              metricConfigStore.activeSystem as string,
+                              metricConfigStore.activeMetricKey as string,
+                              contextKey,
+                              currentContext.type as MetricContext["type"],
+                              option
+                            );
+                          saveAndUpdateMetricSettings(updatedSetting);
+                        }}
+                      />
+                    ))}
+                  </MultipleChoiceWrapper>
+
+                  <BinaryRadioGroupClearButton
+                    onClick={() => {
+                      // saveAndUpdateMetricSettings({
+                      //   key: metricKey,
+                      //   contexts: [{ key: contextKey, value: "" }],
+                      // });
+                      const updatedSetting =
+                        metricConfigStore.updateContextValue(
+                          metricConfigStore.activeSystem as string,
+                          metricConfigStore.activeMetricKey as string,
+                          contextKey,
+                          currentContext.type as MetricContext["type"],
+                          ""
+                        );
+                      saveAndUpdateMetricSettings(updatedSetting);
+                    }}
+                  >
+                    Clear Input
+                  </BinaryRadioGroupClearButton>
+                </BinaryRadioGroupContainer>
+              )}
+            </MetricContextItem>
+          );
+        })}
+      </MetricContextContainer>
+    );
+  });

--- a/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
@@ -15,10 +15,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { FormError, MetricContext } from "@justice-counts/common/types";
-import React, { useEffect, useState } from "react";
+import { MetricContext } from "@justice-counts/common/types";
+import { observer } from "mobx-react-lite";
+import React from "react";
 
-import { isPositiveNumber, removeCommaSpaceAndTrim } from "../../utils";
+import { useStore } from "../../stores";
+import MetricConfigStore from "../../stores/MetricConfigStore";
 import {
   BinaryRadioButton,
   BinaryRadioGroupClearButton,
@@ -36,9 +38,6 @@ import {
   RadioButtonGroupWrapper,
   Subheader,
 } from ".";
-import { observer } from "mobx-react-lite";
-import MetricConfigStore from "../../stores/MetricConfigStore";
-import { useStore } from "../../stores";
 
 type MetricContextConfigurationProps = {
   saveAndUpdateMetricSettings: (
@@ -49,42 +48,8 @@ type MetricContextConfigurationProps = {
 
 export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
   observer(({ saveAndUpdateMetricSettings }) => {
-    // const [contextErrors, setContextErrors] = useState<{
-    //   [key: string]: FormError;
-    // }>();
-
-    // const contextNumberValidation = (key: string, value: string) => {
-    //   const cleanValue = removeCommaSpaceAndTrim(value);
-
-    //   if (!isPositiveNumber(cleanValue) && cleanValue !== "") {
-    //     setContextErrors({
-    //       [key]: {
-    //         message: "Please enter a valid number.",
-    //       },
-    //     });
-
-    //     return false;
-    //   }
-
-    //   setContextErrors((prev) => {
-    //     const otherContextErrors = { ...prev };
-    //     delete otherContextErrors[key];
-
-    //     return otherContextErrors;
-    //   });
-    //   return true;
-    // };
-
-    // useEffect(() => {
-    //   if (contexts) {
-    //     contexts.forEach((context) => {
-    //       if (context.type === "NUMBER") {
-    //         contextNumberValidation(context.key, (context.value || "") as string);
-    //       }
-    //     });
-    //   }
-    // }, [contexts]);
     const { metricConfigStore } = useStore();
+
     const { activeMetricKey } = metricConfigStore;
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       activeMetricKey as string,
@@ -122,11 +87,6 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
                       value="yes"
                       checked={currentContext.value === "yes"}
                       onChange={() => {
-                        // saveAndUpdateMetricSettings({
-                        //   key: metricKey,
-                        //   contexts: [{ key: contextKey, value: "yes" }],
-                        // });
-
                         const updatedSetting =
                           metricConfigStore.updateContextValue(
                             metricConfigStore.activeSystem as string,
@@ -220,11 +180,6 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
                         value={option}
                         checked={currentContext.value === option}
                         onChange={() => {
-                          // saveAndUpdateMetricSettings({
-                          //   key: metricKey,
-                          //   contexts: [{ key: contextKey, value: option }],
-                          // });
-
                           const updatedSetting =
                             metricConfigStore.updateContextValue(
                               metricConfigStore.activeSystem as string,
@@ -241,10 +196,6 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
 
                   <BinaryRadioGroupClearButton
                     onClick={() => {
-                      // saveAndUpdateMetricSettings({
-                      //   key: metricKey,
-                      //   contexts: [{ key: contextKey, value: "" }],
-                      // });
                       const updatedSetting =
                         metricConfigStore.updateContextValue(
                           metricConfigStore.activeSystem as string,

--- a/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
@@ -81,14 +81,16 @@ export const ContextConfiguration: React.FC = observer(() => {
                     value="yes"
                     checked={currentContext.value === "yes"}
                     onChange={() => {
-                      const updatedSetting = updateContextValue(
-                        activeSystem,
-                        activeMetricKey,
-                        contextKey,
-                        currentContext.type,
-                        "yes"
-                      );
-                      if (updatedSetting) saveMetricSettings(updatedSetting);
+                      if (activeSystem && activeMetricKey) {
+                        const updatedSetting = updateContextValue(
+                          activeSystem,
+                          activeMetricKey,
+                          contextKey,
+                          currentContext.type,
+                          "yes"
+                        );
+                        saveMetricSettings(updatedSetting);
+                      }
                     }}
                   />
                   <BinaryRadioButton
@@ -99,27 +101,31 @@ export const ContextConfiguration: React.FC = observer(() => {
                     value="no"
                     checked={currentContext.value === "no"}
                     onChange={() => {
-                      const updatedSetting = updateContextValue(
-                        activeSystem,
-                        activeMetricKey,
-                        contextKey,
-                        currentContext.type,
-                        "no"
-                      );
-                      if (updatedSetting) saveMetricSettings(updatedSetting);
+                      if (activeSystem && activeMetricKey) {
+                        const updatedSetting = updateContextValue(
+                          activeSystem,
+                          activeMetricKey,
+                          contextKey,
+                          currentContext.type,
+                          "no"
+                        );
+                        saveMetricSettings(updatedSetting);
+                      }
                     }}
                   />
                 </RadioButtonGroupWrapper>
                 <BinaryRadioGroupClearButton
                   onClick={() => {
-                    const updatedSetting = updateContextValue(
-                      activeSystem,
-                      activeMetricKey,
-                      contextKey,
-                      currentContext.type,
-                      ""
-                    );
-                    if (updatedSetting) saveMetricSettings(updatedSetting);
+                    if (activeSystem && activeMetricKey) {
+                      const updatedSetting = updateContextValue(
+                        activeSystem,
+                        activeMetricKey,
+                        contextKey,
+                        currentContext.type,
+                        ""
+                      );
+                      saveMetricSettings(updatedSetting);
+                    }
                   }}
                 >
                   Clear Input
@@ -141,14 +147,16 @@ export const ContextConfiguration: React.FC = observer(() => {
                   multiline={currentContext.type === "TEXT"}
                   error={currentContext.error}
                   onChange={(e) => {
-                    const updatedSetting = updateContextValue(
-                      activeSystem,
-                      activeMetricKey,
-                      contextKey,
-                      currentContext.type,
-                      e.currentTarget.value
-                    );
-                    if (updatedSetting) debouncedSave(updatedSetting);
+                    if (activeSystem && activeMetricKey) {
+                      const updatedSetting = updateContextValue(
+                        activeSystem,
+                        activeMetricKey,
+                        contextKey,
+                        currentContext.type,
+                        e.currentTarget.value
+                      );
+                      debouncedSave(updatedSetting);
+                    }
                   }}
                 />
               </>
@@ -172,14 +180,16 @@ export const ContextConfiguration: React.FC = observer(() => {
                       value={option}
                       checked={currentContext.value === option}
                       onChange={() => {
-                        const updatedSetting = updateContextValue(
-                          activeSystem,
-                          activeMetricKey,
-                          contextKey,
-                          currentContext.type,
-                          option
-                        );
-                        if (updatedSetting) saveMetricSettings(updatedSetting);
+                        if (activeSystem && activeMetricKey) {
+                          const updatedSetting = updateContextValue(
+                            activeSystem,
+                            activeMetricKey,
+                            contextKey,
+                            currentContext.type,
+                            option
+                          );
+                          saveMetricSettings(updatedSetting);
+                        }
                       }}
                     />
                   ))}
@@ -187,14 +197,16 @@ export const ContextConfiguration: React.FC = observer(() => {
 
                 <BinaryRadioGroupClearButton
                   onClick={() => {
-                    const updatedSetting = updateContextValue(
-                      activeSystem,
-                      activeMetricKey,
-                      contextKey,
-                      currentContext.type,
-                      ""
-                    );
-                    if (updatedSetting) saveMetricSettings(updatedSetting);
+                    if (activeSystem && activeMetricKey) {
+                      const updatedSetting = updateContextValue(
+                        activeSystem,
+                        activeMetricKey,
+                        contextKey,
+                        currentContext.type,
+                        ""
+                      );
+                      saveMetricSettings(updatedSetting);
+                    }
                   }}
                 >
                   Clear Input

--- a/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
@@ -32,7 +32,6 @@ import {
   MetricContextHeader,
   MetricContextItem,
   MetricSettings,
-  MetricSettingsUpdateOptions,
   MultipleChoiceWrapper,
   RadioButtonGroupWrapper,
   Subheader,
@@ -42,7 +41,6 @@ type MetricContextConfigurationProps = {
   metricKey: string;
   contexts: MetricContext[];
   saveAndUpdateMetricSettings: (
-    typeOfUpdate: MetricSettingsUpdateOptions,
     updatedSetting: MetricSettings,
     debounce?: boolean
   ) => void;
@@ -110,7 +108,7 @@ export const ContextConfiguration: React.FC<
                   value="yes"
                   checked={context.value === "yes"}
                   onChange={() =>
-                    saveAndUpdateMetricSettings("CONTEXT", {
+                    saveAndUpdateMetricSettings({
                       key: metricKey,
                       contexts: [{ key: context.key, value: "yes" }],
                     })
@@ -124,7 +122,7 @@ export const ContextConfiguration: React.FC<
                   value="no"
                   checked={context.value === "no"}
                   onChange={() =>
-                    saveAndUpdateMetricSettings("CONTEXT", {
+                    saveAndUpdateMetricSettings({
                       key: metricKey,
                       contexts: [{ key: context.key, value: "no" }],
                     })
@@ -133,7 +131,7 @@ export const ContextConfiguration: React.FC<
               </RadioButtonGroupWrapper>
               <BinaryRadioGroupClearButton
                 onClick={() =>
-                  saveAndUpdateMetricSettings("CONTEXT", {
+                  saveAndUpdateMetricSettings({
                     key: metricKey,
                     contexts: [{ key: context.key, value: "" }],
                   })
@@ -161,7 +159,6 @@ export const ContextConfiguration: React.FC<
                   }
 
                   saveAndUpdateMetricSettings(
-                    "CONTEXT",
                     {
                       key: metricKey,
                       contexts: [
@@ -192,7 +189,7 @@ export const ContextConfiguration: React.FC<
                     value={option}
                     checked={context.value === option}
                     onChange={() =>
-                      saveAndUpdateMetricSettings("CONTEXT", {
+                      saveAndUpdateMetricSettings({
                         key: metricKey,
                         contexts: [{ key: context.key, value: option }],
                       })
@@ -203,7 +200,7 @@ export const ContextConfiguration: React.FC<
 
               <BinaryRadioGroupClearButton
                 onClick={() =>
-                  saveAndUpdateMetricSettings("CONTEXT", {
+                  saveAndUpdateMetricSettings({
                     key: metricKey,
                     contexts: [{ key: context.key, value: "" }],
                   })

--- a/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
@@ -52,8 +52,8 @@ export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
 
     const { activeMetricKey } = metricConfigStore;
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
-      activeMetricKey as string,
-      metricConfigStore.activeSystem as string
+      metricConfigStore.activeSystem as string,
+      activeMetricKey as string
     );
     const activeContextKeys =
       (metricConfigStore.contexts[systemMetricKey] &&

--- a/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
@@ -32,186 +32,178 @@ import {
   MetricContextContainer,
   MetricContextHeader,
   MetricContextItem,
-  MetricSettings,
   MultipleChoiceWrapper,
   RadioButtonGroupWrapper,
   Subheader,
 } from ".";
 
-type MetricContextConfigurationProps = {
-  saveUpdatedMetricSettings: (updatedSetting: MetricSettings) => void;
-};
+export const ContextConfiguration: React.FC = observer(() => {
+  const { metricConfigStore } = useStore();
+  const {
+    activeMetricKey,
+    activeSystem,
+    contexts,
+    updateContextValue,
+    getActiveSystemMetricKey,
+    saveMetricSettings,
+  } = metricConfigStore;
 
-export const ContextConfiguration: React.FC<MetricContextConfigurationProps> =
-  observer(({ saveUpdatedMetricSettings }) => {
-    const { metricConfigStore } = useStore();
-    const {
-      activeMetricKey,
-      activeSystem,
-      contexts,
-      updateContextValue,
-      getActiveSystemMetricKey,
-    } = metricConfigStore;
+  const systemMetricKey = getActiveSystemMetricKey();
+  const activeContextKeys =
+    (contexts[systemMetricKey] && Object.keys(contexts[systemMetricKey])) || [];
 
-    const systemMetricKey = getActiveSystemMetricKey();
-    const activeContextKeys =
-      (contexts[systemMetricKey] && Object.keys(contexts[systemMetricKey])) ||
-      [];
+  const debouncedSave = useRef(debounce(saveMetricSettings, 1500)).current;
 
-    const debouncedSave = useRef(
-      debounce(saveUpdatedMetricSettings, 1500)
-    ).current;
+  return (
+    <MetricContextContainer>
+      <MetricContextHeader>Context</MetricContextHeader>
+      <Subheader>
+        Anything entered here will appear as the default value for all reports.
+        If you are entering data for a particular month, you can still replace
+        this as necessary.
+      </Subheader>
 
-    return (
-      <MetricContextContainer>
-        <MetricContextHeader>Context</MetricContextHeader>
-        <Subheader>
-          Anything entered here will appear as the default value for all
-          reports. If you are entering data for a particular month, you can
-          still replace this as necessary.
-        </Subheader>
+      {activeContextKeys.map((contextKey) => {
+        const currentContext = contexts[systemMetricKey][contextKey];
 
-        {activeContextKeys.map((contextKey) => {
-          const currentContext = contexts[systemMetricKey][contextKey];
-
-          return (
-            <MetricContextItem key={contextKey}>
-              {/* Binary Context Questions */}
-              {currentContext.type === "BOOLEAN" && (
-                <>
-                  <Label noBottomMargin>{currentContext.display_name}</Label>
-                  <RadioButtonGroupWrapper>
-                    <BinaryRadioButton
-                      type="radio"
-                      id={`${contextKey}-yes`}
-                      name={contextKey}
-                      label="Yes"
-                      value="yes"
-                      checked={currentContext.value === "yes"}
-                      onChange={() => {
-                        const updatedSetting = updateContextValue(
-                          activeSystem as string,
-                          activeMetricKey as string,
-                          contextKey,
-                          currentContext.type,
-                          "yes"
-                        );
-                        saveUpdatedMetricSettings(updatedSetting);
-                      }}
-                    />
-                    <BinaryRadioButton
-                      type="radio"
-                      id={`${contextKey}-no`}
-                      name={contextKey}
-                      label="No"
-                      value="no"
-                      checked={currentContext.value === "no"}
-                      onChange={() => {
-                        const updatedSetting = updateContextValue(
-                          activeSystem as string,
-                          activeMetricKey as string,
-                          contextKey,
-                          currentContext.type,
-                          "no"
-                        );
-                        saveUpdatedMetricSettings(updatedSetting);
-                      }}
-                    />
-                  </RadioButtonGroupWrapper>
-                  <BinaryRadioGroupClearButton
-                    onClick={() => {
-                      const updatedSetting = updateContextValue(
-                        activeSystem as string,
-                        activeMetricKey as string,
-                        contextKey,
-                        currentContext.type,
-                        ""
-                      );
-                      saveUpdatedMetricSettings(updatedSetting);
-                    }}
-                  >
-                    Clear Input
-                  </BinaryRadioGroupClearButton>
-                </>
-              )}
-
-              {/* Text Field Context Questions */}
-              {(currentContext.type === "TEXT" ||
-                currentContext.type === "NUMBER") && (
-                <>
-                  <Label>{currentContext.display_name}</Label>
-                  <TextInput
-                    type="text"
+        return (
+          <MetricContextItem key={contextKey}>
+            {/* Binary Context Questions */}
+            {currentContext.type === "BOOLEAN" && (
+              <>
+                <Label noBottomMargin>{currentContext.display_name}</Label>
+                <RadioButtonGroupWrapper>
+                  <BinaryRadioButton
+                    type="radio"
+                    id={`${contextKey}-yes`}
                     name={contextKey}
-                    id={contextKey}
-                    label=""
-                    value={(currentContext.value || "") as string}
-                    multiline={currentContext.type === "TEXT"}
-                    error={currentContext.error}
-                    onChange={(e) => {
+                    label="Yes"
+                    value="yes"
+                    checked={currentContext.value === "yes"}
+                    onChange={() => {
                       const updatedSetting = updateContextValue(
                         activeSystem as string,
                         activeMetricKey as string,
                         contextKey,
                         currentContext.type,
-                        e.currentTarget.value
+                        "yes"
                       );
-                      debouncedSave(updatedSetting);
+                      saveMetricSettings(updatedSetting);
                     }}
                   />
-                </>
-              )}
-
-              {/* Multiple Choice Context Questions */}
-              {currentContext.type === "MULTIPLE_CHOICE" && (
-                <BinaryRadioGroupContainer key={contextKey}>
-                  <BinaryRadioGroupQuestion>
-                    {currentContext.display_name}
-                  </BinaryRadioGroupQuestion>
-
-                  <MultipleChoiceWrapper>
-                    {currentContext.multiple_choice_options?.map((option) => (
-                      <BinaryRadioButton
-                        type="radio"
-                        key={option}
-                        id={`${contextKey}-${option}`}
-                        name={`${contextKey}`}
-                        label={option}
-                        value={option}
-                        checked={currentContext.value === option}
-                        onChange={() => {
-                          const updatedSetting = updateContextValue(
-                            activeSystem as string,
-                            activeMetricKey as string,
-                            contextKey,
-                            currentContext.type,
-                            option
-                          );
-                          saveUpdatedMetricSettings(updatedSetting);
-                        }}
-                      />
-                    ))}
-                  </MultipleChoiceWrapper>
-
-                  <BinaryRadioGroupClearButton
-                    onClick={() => {
+                  <BinaryRadioButton
+                    type="radio"
+                    id={`${contextKey}-no`}
+                    name={contextKey}
+                    label="No"
+                    value="no"
+                    checked={currentContext.value === "no"}
+                    onChange={() => {
                       const updatedSetting = updateContextValue(
                         activeSystem as string,
                         activeMetricKey as string,
                         contextKey,
                         currentContext.type,
-                        ""
+                        "no"
                       );
-                      saveUpdatedMetricSettings(updatedSetting);
+                      saveMetricSettings(updatedSetting);
                     }}
-                  >
-                    Clear Input
-                  </BinaryRadioGroupClearButton>
-                </BinaryRadioGroupContainer>
-              )}
-            </MetricContextItem>
-          );
-        })}
-      </MetricContextContainer>
-    );
-  });
+                  />
+                </RadioButtonGroupWrapper>
+                <BinaryRadioGroupClearButton
+                  onClick={() => {
+                    const updatedSetting = updateContextValue(
+                      activeSystem as string,
+                      activeMetricKey as string,
+                      contextKey,
+                      currentContext.type,
+                      ""
+                    );
+                    saveMetricSettings(updatedSetting);
+                  }}
+                >
+                  Clear Input
+                </BinaryRadioGroupClearButton>
+              </>
+            )}
+
+            {/* Text Field Context Questions */}
+            {(currentContext.type === "TEXT" ||
+              currentContext.type === "NUMBER") && (
+              <>
+                <Label>{currentContext.display_name}</Label>
+                <TextInput
+                  type="text"
+                  name={contextKey}
+                  id={contextKey}
+                  label=""
+                  value={(currentContext.value || "") as string}
+                  multiline={currentContext.type === "TEXT"}
+                  error={currentContext.error}
+                  onChange={(e) => {
+                    const updatedSetting = updateContextValue(
+                      activeSystem as string,
+                      activeMetricKey as string,
+                      contextKey,
+                      currentContext.type,
+                      e.currentTarget.value
+                    );
+                    debouncedSave(updatedSetting);
+                  }}
+                />
+              </>
+            )}
+
+            {/* Multiple Choice Context Questions */}
+            {currentContext.type === "MULTIPLE_CHOICE" && (
+              <BinaryRadioGroupContainer key={contextKey}>
+                <BinaryRadioGroupQuestion>
+                  {currentContext.display_name}
+                </BinaryRadioGroupQuestion>
+
+                <MultipleChoiceWrapper>
+                  {currentContext.multiple_choice_options?.map((option) => (
+                    <BinaryRadioButton
+                      type="radio"
+                      key={option}
+                      id={`${contextKey}-${option}`}
+                      name={`${contextKey}`}
+                      label={option}
+                      value={option}
+                      checked={currentContext.value === option}
+                      onChange={() => {
+                        const updatedSetting = updateContextValue(
+                          activeSystem as string,
+                          activeMetricKey as string,
+                          contextKey,
+                          currentContext.type,
+                          option
+                        );
+                        saveMetricSettings(updatedSetting);
+                      }}
+                    />
+                  ))}
+                </MultipleChoiceWrapper>
+
+                <BinaryRadioGroupClearButton
+                  onClick={() => {
+                    const updatedSetting = updateContextValue(
+                      activeSystem as string,
+                      activeMetricKey as string,
+                      contextKey,
+                      currentContext.type,
+                      ""
+                    );
+                    saveMetricSettings(updatedSetting);
+                  }}
+                >
+                  Clear Input
+                </BinaryRadioGroupClearButton>
+              </BinaryRadioGroupContainer>
+            )}
+          </MetricContextItem>
+        );
+      })}
+    </MetricContextContainer>
+  );
+});

--- a/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/ContextConfiguration.tsx
@@ -82,13 +82,13 @@ export const ContextConfiguration: React.FC = observer(() => {
                     checked={currentContext.value === "yes"}
                     onChange={() => {
                       const updatedSetting = updateContextValue(
-                        activeSystem as string,
-                        activeMetricKey as string,
+                        activeSystem,
+                        activeMetricKey,
                         contextKey,
                         currentContext.type,
                         "yes"
                       );
-                      saveMetricSettings(updatedSetting);
+                      if (updatedSetting) saveMetricSettings(updatedSetting);
                     }}
                   />
                   <BinaryRadioButton
@@ -100,26 +100,26 @@ export const ContextConfiguration: React.FC = observer(() => {
                     checked={currentContext.value === "no"}
                     onChange={() => {
                       const updatedSetting = updateContextValue(
-                        activeSystem as string,
-                        activeMetricKey as string,
+                        activeSystem,
+                        activeMetricKey,
                         contextKey,
                         currentContext.type,
                         "no"
                       );
-                      saveMetricSettings(updatedSetting);
+                      if (updatedSetting) saveMetricSettings(updatedSetting);
                     }}
                   />
                 </RadioButtonGroupWrapper>
                 <BinaryRadioGroupClearButton
                   onClick={() => {
                     const updatedSetting = updateContextValue(
-                      activeSystem as string,
-                      activeMetricKey as string,
+                      activeSystem,
+                      activeMetricKey,
                       contextKey,
                       currentContext.type,
                       ""
                     );
-                    saveMetricSettings(updatedSetting);
+                    if (updatedSetting) saveMetricSettings(updatedSetting);
                   }}
                 >
                   Clear Input
@@ -142,13 +142,13 @@ export const ContextConfiguration: React.FC = observer(() => {
                   error={currentContext.error}
                   onChange={(e) => {
                     const updatedSetting = updateContextValue(
-                      activeSystem as string,
-                      activeMetricKey as string,
+                      activeSystem,
+                      activeMetricKey,
                       contextKey,
                       currentContext.type,
                       e.currentTarget.value
                     );
-                    debouncedSave(updatedSetting);
+                    if (updatedSetting) debouncedSave(updatedSetting);
                   }}
                 />
               </>
@@ -173,13 +173,13 @@ export const ContextConfiguration: React.FC = observer(() => {
                       checked={currentContext.value === option}
                       onChange={() => {
                         const updatedSetting = updateContextValue(
-                          activeSystem as string,
-                          activeMetricKey as string,
+                          activeSystem,
+                          activeMetricKey,
                           contextKey,
                           currentContext.type,
                           option
                         );
-                        saveMetricSettings(updatedSetting);
+                        if (updatedSetting) saveMetricSettings(updatedSetting);
                       }}
                     />
                   ))}
@@ -188,13 +188,13 @@ export const ContextConfiguration: React.FC = observer(() => {
                 <BinaryRadioGroupClearButton
                   onClick={() => {
                     const updatedSetting = updateContextValue(
-                      activeSystem as string,
-                      activeMetricKey as string,
+                      activeSystem,
+                      activeMetricKey,
                       contextKey,
                       currentContext.type,
                       ""
                     );
-                    saveMetricSettings(updatedSetting);
+                    if (updatedSetting) saveMetricSettings(updatedSetting);
                   }}
                 >
                   Clear Input

--- a/publisher/src/components/MetricConfiguration/MetricBox.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricBox.tsx
@@ -45,10 +45,11 @@ export const MetricBox: React.FC<MetricBoxProps> = observer(
     enabled,
   }): JSX.Element => {
     const { metricConfigStore } = useStore();
+    const { updateActiveMetricKey } = metricConfigStore;
 
     return (
       <MetricBoxContainer
-        onClick={() => metricConfigStore.updateActiveMetricKey(metricKey)}
+        onClick={() => updateActiveMetricKey(metricKey)}
         enabled={enabled}
       >
         <MetricName>{displayName}</MetricName>

--- a/publisher/src/components/MetricConfiguration/MetricBox.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricBox.tsx
@@ -16,8 +16,10 @@
 // =============================================================================
 
 import { ReportFrequency } from "@justice-counts/common/types";
+import { observer } from "mobx-react-lite";
 import React from "react";
 
+import { useStore } from "../../stores";
 import { Badge } from "../Badge";
 import {
   MetricBoxContainer,
@@ -32,29 +34,35 @@ type MetricBoxProps = {
   frequency: ReportFrequency;
   description: string;
   enabled?: boolean;
-  setActiveMetricKey: React.Dispatch<React.SetStateAction<string | undefined>>;
 };
 
-export const MetricBox: React.FC<MetricBoxProps> = ({
-  metricKey,
-  displayName,
-  frequency,
-  description,
-  enabled,
-  setActiveMetricKey,
-}): JSX.Element => {
-  return (
-    <MetricBoxContainer
-      onClick={() => setActiveMetricKey(metricKey)}
-      enabled={enabled}
-    >
-      <MetricName>{displayName}</MetricName>
-      <MetricDescription>{description}</MetricDescription>
-      <MetricNameBadgeWrapper>
-        <Badge color={!enabled ? "GREY" : "GREEN"} disabled={!enabled} noMargin>
-          {!enabled ? "Inactive" : frequency.toLowerCase()}
-        </Badge>
-      </MetricNameBadgeWrapper>
-    </MetricBoxContainer>
-  );
-};
+export const MetricBox: React.FC<MetricBoxProps> = observer(
+  ({
+    metricKey,
+    displayName,
+    frequency,
+    description,
+    enabled,
+  }): JSX.Element => {
+    const { metricConfigStore } = useStore();
+
+    return (
+      <MetricBoxContainer
+        onClick={() => metricConfigStore.updateActiveMetricKey(metricKey)}
+        enabled={enabled}
+      >
+        <MetricName>{displayName}</MetricName>
+        <MetricDescription>{description}</MetricDescription>
+        <MetricNameBadgeWrapper>
+          <Badge
+            color={!enabled ? "GREY" : "GREEN"}
+            disabled={!enabled}
+            noMargin
+          >
+            {!enabled ? "Inactive" : frequency.toLowerCase()}
+          </Badge>
+        </MetricNameBadgeWrapper>
+      </MetricBoxContainer>
+    );
+  }
+);

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { showToast } from "@justice-counts/common/components/Toast";
 import { ReportFrequency } from "@justice-counts/common/types";
 import { reaction, when } from "mobx";
 import { observer } from "mobx-react-lite";
@@ -39,7 +38,6 @@ import {
   MetricDefinitions,
   MetricDetailsDisplay,
   MetricName,
-  MetricSettings,
   MetricsViewContainer,
   MetricsViewControlPanel,
   StickyHeader,
@@ -56,7 +54,6 @@ export const MetricConfiguration: React.FC = observer(() => {
     getMetricsBySystem,
     updateActiveSystem,
     updateActiveMetricKey,
-    saveMetricSettings,
   } = metricConfigStore;
 
   const systemMetricKey = getActiveSystemMetricKey();
@@ -66,15 +63,6 @@ export const MetricConfiguration: React.FC = observer(() => {
   const [activeDimensionKey, setActiveDimensionKey] = useState<string>();
   const [activeDisaggregationKey, setActiveDisaggregationKey] =
     useState<string>();
-
-  const saveUpdatedMetricSettings = async (updatedSetting: MetricSettings) => {
-    const response = (await saveMetricSettings([updatedSetting])) as Response;
-    if (response.status === 200) {
-      showToast(`Settings saved.`, true, "grey", 4000);
-    } else {
-      showToast(`Failed to save.`, true, "red", 4000);
-    }
-  };
 
   const initializeMetricConfiguration = async () => {
     const response = await initializeMetricConfigStoreValues();
@@ -200,7 +188,6 @@ export const MetricConfiguration: React.FC = observer(() => {
                     setActiveDimensionKey={setActiveDimensionKey}
                     activeDisaggregationKey={activeDisaggregationKey}
                     setActiveDisaggregationKey={setActiveDisaggregationKey}
-                    saveUpdatedMetricSettings={saveUpdatedMetricSettings}
                   />
                 </MetricDetailsDisplay>
               </MetricConfigurationDisplay>
@@ -209,7 +196,6 @@ export const MetricConfiguration: React.FC = observer(() => {
               <MetricDefinitions
                 activeDimensionKey={activeDimensionKey}
                 activeDisaggregationKey={activeDisaggregationKey}
-                saveUpdatedMetricSettings={saveUpdatedMetricSettings}
               />
             </MetricConfigurationWrapper>
           )}

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -21,10 +21,9 @@ import {
   MetricContext,
   ReportFrequency,
 } from "@justice-counts/common/types";
-import { debounce as _debounce } from "lodash";
 import { reaction, when } from "mobx";
 import { observer } from "mobx-react-lite";
-import React, { useEffect, useRef, useState } from "react";
+import React, { useEffect, useState } from "react";
 
 import { useStore } from "../../stores";
 import { removeSnakeCase } from "../../utils";
@@ -101,10 +100,6 @@ export const MetricConfiguration: React.FC = observer(() => {
       showToast(`Failed to save.`, true, "red", 4000);
     }
   };
-
-  const debouncedSave = useRef(
-    _debounce(saveUpdatedMetricSettings, 1500)
-  ).current;
 
   useEffect(
     () =>
@@ -241,7 +236,6 @@ export const MetricConfiguration: React.FC = observer(() => {
                 activeDimensionKey={activeDimensionKey}
                 activeDisaggregationKey={activeDisaggregationKey}
                 saveUpdatedMetricSettings={saveUpdatedMetricSettings}
-                debouncedSave={debouncedSave}
               />
             </MetricConfigurationWrapper>
           )}

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -18,6 +18,7 @@
 import { showToast } from "@justice-counts/common/components/Toast";
 import {
   MetricConfigurationSettings,
+  MetricContext,
   ReportFrequency,
 } from "@justice-counts/common/types";
 import { debounce as _debounce } from "lodash";
@@ -55,7 +56,7 @@ export type MetricSettings = {
   settings?: MetricConfigurationSettings[];
   contexts?: {
     key: string;
-    value: string;
+    value: MetricContext["value"];
   }[];
   disaggregations?: {
     key: string;
@@ -240,21 +241,12 @@ export const MetricConfiguration: React.FC<{}> = observer(() => {
                 </MetricDetailsDisplay>
               </MetricConfigurationDisplay>
 
-              {/* Metric/Dimension Definitions (Includes/Excludes) */}
-              {/* <MetricDefinitions
-                activeMetricKey={metricConfigStore.activeMetricKey}
-                activeMetric={
-                  // filteredMetricSettings[metricConfigStore.activeMetricKey]
-                  {}
-                }
+              {/* Metric/Dimension Definitions (Includes/Excludes) & Context */}
+              <MetricDefinitions
                 activeDimensionKey={activeDimensionKey}
                 activeDisaggregationKey={activeDisaggregationKey}
-                contexts={
-                  // metricSettings[metricConfigStore.activeMetricKey]?.contexts
-                  {}
-                }
                 saveAndUpdateMetricSettings={saveAndUpdateMetricSettings}
-              /> */}
+              />
             </MetricConfigurationWrapper>
           )}
         </MetricsViewControlPanel>

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -69,7 +69,7 @@ export type MetricSettings = {
   }[];
 };
 
-export const MetricConfiguration: React.FC<{}> = observer(() => {
+export const MetricConfiguration: React.FC = observer(() => {
   const { userStore, metricConfigStore } = useStore();
   const currentSystemMetricKey = MetricConfigStore.getSystemMetricKey(
     metricConfigStore.activeMetricKey || "",

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -101,6 +101,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
     const [showDefaultSettings, setShowDefaultSettings] = useState(false);
 
     const revertToAndSaveDefaultValues = () => {
+      /** Create array of default settings and update settings (to default value) in the store */
       const defaultSettings = activeSettingsKeys.map((settingKey) => {
         let currentSettingDefaultValue;
 
@@ -134,11 +135,9 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
         );
 
         return { key: settingKey, included: currentSettingDefaultValue };
-      }) as {
-        key: string;
-        included: MetricConfigurationSettingsOptions;
-      }[];
+      }) as MetricSettings["settings"];
 
+      /** Save default settings array */
       if (isMetricDefinitionSettings) {
         const updatedSetting = {
           key: activeMetricKey as string,
@@ -183,6 +182,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
                 </span>
               </DefinitionsDescription>
 
+              {/* Revert To Default Definition Settings */}
               <RevertToDefaultButton
                 onClick={() => {
                   setShowDefaultSettings(false);
@@ -196,6 +196,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
                 Choose Default Definition
               </RevertToDefaultButton>
 
+              {/* Definition Settings (Includes/Excludes) */}
               <Definitions>
                 {activeSettingsKeys?.map((settingKey) => {
                   const currentSetting = (

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -39,15 +39,10 @@ import {
 type MetricDefinitionsProps = {
   activeDimensionKey: string | undefined;
   activeDisaggregationKey: string | undefined;
-  saveUpdatedMetricSettings: (updatedSetting: MetricSettings) => void;
 };
 
 export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
-  ({
-    activeDimensionKey,
-    activeDisaggregationKey,
-    saveUpdatedMetricSettings,
-  }) => {
+  ({ activeDimensionKey, activeDisaggregationKey }) => {
     const { metricConfigStore } = useStore();
     const {
       activeMetricKey,
@@ -59,6 +54,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
       getActiveSystemMetricKey,
       updateMetricDefinitionSetting,
       updateDimensionDefinitionSetting,
+      saveMetricSettings,
     } = metricConfigStore;
 
     const systemMetricKey = getActiveSystemMetricKey();
@@ -143,7 +139,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
           key: activeMetricKey as string,
           settings: defaultSettings,
         };
-        return saveUpdatedMetricSettings(updatedSetting);
+        return saveMetricSettings(updatedSetting);
       }
 
       const updatedSetting = {
@@ -160,7 +156,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
           },
         ],
       };
-      saveUpdatedMetricSettings(updatedSetting);
+      saveMetricSettings(updatedSetting);
     };
 
     return (
@@ -238,9 +234,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
                                       settingKey,
                                       option
                                     );
-                                  return saveUpdatedMetricSettings(
-                                    updatedSettings
-                                  );
+                                  return saveMetricSettings(updatedSettings);
                                 }
 
                                 const updatedSettings =
@@ -252,7 +246,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
                                     settingKey,
                                     option
                                   );
-                                saveUpdatedMetricSettings(updatedSettings);
+                                saveMetricSettings(updatedSettings);
                               }}
                             >
                               {option}
@@ -276,11 +270,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
         </DefinitionsDisplay>
 
         {/* Additional Context (only appears on overall metric settings and not individual dimension settings) */}
-        {!activeDimensionKey && (
-          <ContextConfiguration
-            saveUpdatedMetricSettings={saveUpdatedMetricSettings}
-          />
-        )}
+        {!activeDimensionKey && <ContextConfiguration />}
       </DefinitionsDisplayContainer>
     );
   }

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { MetricConfigurationSettingsOptions } from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
 import React, { Fragment, useState } from "react";
 
@@ -32,6 +31,8 @@ import {
   DefinitionSelection,
   DefinitionsSubTitle,
   DefinitionsTitle,
+  MetricConfigurationSettingsOptions,
+  metricConfigurationSettingsOptions,
   MetricSettings,
   RevertToDefaultButton,
 } from ".";
@@ -87,12 +88,6 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
     const activeSettingsKeys = isMetricDefinitionSettings
       ? metricDefinitionSettingsKeys
       : dimensionDefinitionSettingsKeys;
-
-    const selectionOptions: MetricConfigurationSettingsOptions[] = [
-      "N/A",
-      "No",
-      "Yes",
-    ];
 
     const [showDefaultSettings, setShowDefaultSettings] = useState(false);
 
@@ -216,7 +211,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
                       </DefinitionDisplayName>
 
                       <DefinitionSelection>
-                        {selectionOptions.map((option) => (
+                        {metricConfigurationSettingsOptions.map((option) => (
                           <Fragment key={option}>
                             <DefinitionMiniButton
                               selected={

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -16,7 +16,6 @@
 // =============================================================================
 
 import { MetricConfigurationSettingsOptions } from "@justice-counts/common/types";
-import { DebouncedFunc } from "lodash";
 import { observer } from "mobx-react-lite";
 import React, { Fragment, useState } from "react";
 
@@ -41,9 +40,6 @@ type MetricDefinitionsProps = {
   activeDimensionKey: string | undefined;
   activeDisaggregationKey: string | undefined;
   saveUpdatedMetricSettings: (updatedSetting: MetricSettings) => void;
-  debouncedSave: DebouncedFunc<
-    (updatedSetting: MetricSettings) => Promise<void>
-  >;
 };
 
 export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
@@ -51,7 +47,6 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
     activeDimensionKey,
     activeDisaggregationKey,
     saveUpdatedMetricSettings,
-    debouncedSave,
   }) => {
     const { metricConfigStore } = useStore();
     const {
@@ -283,7 +278,6 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
         {!activeDimensionKey && (
           <ContextConfiguration
             saveUpdatedMetricSettings={saveUpdatedMetricSettings}
-            debouncedSave={debouncedSave}
           />
         )}
       </DefinitionsDisplayContainer>

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -22,6 +22,7 @@ import {
   MetricDisaggregationDimensions,
   MetricDisaggregations,
 } from "@justice-counts/common/types";
+import { observer } from "mobx-react-lite";
 import React, { Fragment, useState } from "react";
 
 import {
@@ -39,6 +40,7 @@ import {
   MetricSettings,
   RevertToDefaultButton,
 } from ".";
+import { useStore } from "../../stores";
 
 type MetricDefinitionsProps = {
   activeDimensionKey: string | undefined;
@@ -49,170 +51,177 @@ type MetricDefinitionsProps = {
   ) => void;
 };
 
-export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
-  activeDimensionKey,
-  activeDisaggregationKey,
-  saveAndUpdateMetricSettings,
-}) => {
-  const [showDefaultSettings, setShowDefaultSettings] = useState(false);
+export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
+  ({
+    activeDimensionKey,
+    activeDisaggregationKey,
+    saveAndUpdateMetricSettings,
+  }) => {
+    const { metricConfigStore } = useStore();
 
-  const selectionOptions: MetricConfigurationSettingsOptions[] = [
-    "N/A",
-    "No",
-    "Yes",
-  ];
-  const activeDimensionOrMetric: MetricDisaggregationDimensions | Metric =
-    activeDimension || activeMetric;
+    const selectionOptions: MetricConfigurationSettingsOptions[] = [
+      "N/A",
+      "No",
+      "Yes",
+    ];
 
-  const isMetricSettings = (
-    dimensionOrMetric: MetricDisaggregationDimensions | Metric
-  ): dimensionOrMetric is Metric => {
-    return (dimensionOrMetric as Metric)?.display_name !== undefined;
-  };
+    const [showDefaultSettings, setShowDefaultSettings] = useState(false);
 
-  const activeSettings = isMetricSettings(activeDimensionOrMetric)
-    ? activeMetric.settings
-    : activeDimension?.settings;
-  const defaultSettings = activeSettings?.map((setting) => ({
-    ...setting,
-    included: setting.default,
-  }));
+    // const activeDimensionOrMetric: MetricDisaggregationDimensions | Metric =
+    //   activeDimension || activeMetric;
 
-  const revertToDefaultValues = () => {
-    if (isMetricSettings(activeDimensionOrMetric)) {
-      return saveAndUpdateMetricSettings({
-        key: activeMetricKey,
-        settings: defaultSettings,
-      });
-    }
+    // const isMetricSettings = (
+    //   dimensionOrMetric: MetricDisaggregationDimensions | Metric
+    // ): dimensionOrMetric is Metric => {
+    //   return (dimensionOrMetric as Metric)?.display_name !== undefined;
+    // };
 
-    if (activeDisaggregation && activeDimension) {
-      saveAndUpdateMetricSettings({
-        key: activeMetricKey,
-        disaggregations: [
-          {
-            key: activeDisaggregation.key,
-            dimensions: [
-              {
-                key: activeDimension.key,
-                settings: defaultSettings,
-              },
-            ],
-          },
-        ],
-      });
-    }
-  };
+    // const activeSettings = isMetricSettings(activeDimensionOrMetric)
+    //   ? activeMetric.settings
+    //   : activeDimension?.settings;
+    // const defaultSettings = activeSettings?.map((setting) => ({
+    //   ...setting,
+    //   included: setting.default,
+    // }));
 
-  return (
-    <DefinitionsDisplayContainer>
-      <DefinitionsDisplay>
-        <DefinitionsTitle>
-          {isMetricSettings(activeDimensionOrMetric)
-            ? activeDimensionOrMetric?.display_name
-            : activeDimensionOrMetric?.label}
-        </DefinitionsTitle>
+    // const revertToDefaultValues = () => {
+    //   if (isMetricSettings(activeDimensionOrMetric)) {
+    //     return saveAndUpdateMetricSettings({
+    //       key: activeMetricKey,
+    //       settings: defaultSettings,
+    //     });
+    //   }
 
-        {Boolean(activeSettings?.length) && (
-          <>
-            <DefinitionsSubTitle>Definitions</DefinitionsSubTitle>
-            <DefinitionsDescription>
-              Indicate which of the following categories your agency considers
-              to be part of this metric or breakdown.
-              <span>
-                You are NOT required to gather data for these specific
-                categories.
-              </span>
-            </DefinitionsDescription>
+    //   if (activeDisaggregation && activeDimension) {
+    //     saveAndUpdateMetricSettings({
+    //       key: activeMetricKey,
+    //       disaggregations: [
+    //         {
+    //           key: activeDisaggregation.key,
+    //           dimensions: [
+    //             {
+    //               key: activeDimension.key,
+    //               settings: defaultSettings,
+    //             },
+    //           ],
+    //         },
+    //       ],
+    //     });
+    //   }
+    // };
 
-            <RevertToDefaultButton
-              onClick={() => {
-                setShowDefaultSettings(false);
-                revertToDefaultValues();
-              }}
-              onMouseEnter={() =>
-                !showDefaultSettings && setShowDefaultSettings(true)
-              }
-              onMouseLeave={() => setShowDefaultSettings(false)}
-            >
-              Choose Default Definition
-            </RevertToDefaultButton>
+    return (
+      <DefinitionsDisplayContainer>
+        <DefinitionsDisplay>
+          <DefinitionsTitle>
+            {/* {isMetricSettings(activeDimensionOrMetric)
+              ? activeDimensionOrMetric?.display_name
+              : activeDimensionOrMetric?.label} */}
+          </DefinitionsTitle>
 
-            <Definitions>
-              {(showDefaultSettings ? defaultSettings : activeSettings)?.map(
-                (setting) => (
-                  <DefinitionItem key={setting.key}>
-                    <DefinitionDisplayName>
-                      {setting.label}
-                    </DefinitionDisplayName>
+          {Boolean(activeSettings?.length) && (
+            <>
+              <DefinitionsSubTitle>Definitions</DefinitionsSubTitle>
+              <DefinitionsDescription>
+                Indicate which of the following categories your agency considers
+                to be part of this metric or breakdown.
+                <span>
+                  You are NOT required to gather data for these specific
+                  categories.
+                </span>
+              </DefinitionsDescription>
 
-                    <DefinitionSelection>
-                      {selectionOptions.map((option) => (
-                        <Fragment key={option}>
-                          <DefinitionMiniButton
-                            selected={setting.included === option}
-                            showDefault={showDefaultSettings}
-                            onClick={() => {
-                              if (isMetricSettings(activeDimensionOrMetric)) {
-                                return saveAndUpdateMetricSettings({
-                                  key: activeMetricKey,
-                                  settings: [{ ...setting, included: option }],
-                                });
-                              }
+              <RevertToDefaultButton
+                onClick={() => {
+                  setShowDefaultSettings(false);
+                  revertToDefaultValues();
+                }}
+                onMouseEnter={() =>
+                  !showDefaultSettings && setShowDefaultSettings(true)
+                }
+                onMouseLeave={() => setShowDefaultSettings(false)}
+              >
+                Choose Default Definition
+              </RevertToDefaultButton>
 
-                              const activeDimensionKey =
-                                activeDimensionOrMetric.key;
+              <Definitions>
+                {(showDefaultSettings ? defaultSettings : activeSettings)?.map(
+                  (setting) => (
+                    <DefinitionItem key={setting.key}>
+                      <DefinitionDisplayName>
+                        {setting.label}
+                      </DefinitionDisplayName>
 
-                              return (
-                                activeDisaggregation &&
-                                saveAndUpdateMetricSettings({
-                                  key: activeMetricKey,
-                                  disaggregations: [
-                                    {
-                                      key: activeDisaggregation.key,
-                                      dimensions: [
-                                        {
-                                          key: activeDimensionKey,
-                                          settings: [
-                                            {
-                                              ...setting,
-                                              included: option,
-                                            },
-                                          ],
-                                        },
-                                      ],
-                                    },
-                                  ],
-                                })
-                              );
-                            }}
-                          >
-                            {option}
-                          </DefinitionMiniButton>
-                        </Fragment>
-                      ))}
-                    </DefinitionSelection>
-                  </DefinitionItem>
-                )
-              )}
-            </Definitions>
-          </>
+                      <DefinitionSelection>
+                        {selectionOptions.map((option) => (
+                          <Fragment key={option}>
+                            <DefinitionMiniButton
+                              selected={setting.included === option}
+                              showDefault={showDefaultSettings}
+                              onClick={() => {
+                                if (isMetricSettings(activeDimensionOrMetric)) {
+                                  return saveAndUpdateMetricSettings({
+                                    key: activeMetricKey,
+                                    settings: [
+                                      { ...setting, included: option },
+                                    ],
+                                  });
+                                }
+
+                                const activeDimensionKey =
+                                  activeDimensionOrMetric.key;
+
+                                return (
+                                  activeDisaggregation &&
+                                  saveAndUpdateMetricSettings({
+                                    key: activeMetricKey,
+                                    disaggregations: [
+                                      {
+                                        key: activeDisaggregation.key,
+                                        dimensions: [
+                                          {
+                                            key: activeDimensionKey,
+                                            settings: [
+                                              {
+                                                ...setting,
+                                                included: option,
+                                              },
+                                            ],
+                                          },
+                                        ],
+                                      },
+                                    ],
+                                  })
+                                );
+                              }}
+                            >
+                              {option}
+                            </DefinitionMiniButton>
+                          </Fragment>
+                        ))}
+                      </DefinitionSelection>
+                    </DefinitionItem>
+                  )
+                )}
+              </Definitions>
+            </>
+          )}
+
+          {/* Display when user is viewing a dimension & there are no settings available */}
+          {!activeSettings?.length && activeDimension && (
+            <DefinitionsSubTitle>
+              Technical Definitions are not available for this metric yet.
+            </DefinitionsSubTitle>
+          )}
+        </DefinitionsDisplay>
+
+        {/* Additional Context (only appears on overall metric settings and not individual dimension settings) */}
+        {!activeDimension && (
+          <ContextConfiguration
+            saveAndUpdateMetricSettings={saveAndUpdateMetricSettings}
+          />
         )}
-
-        {/* Display when user is viewing a dimension & there are no settings available */}
-        {!activeSettings?.length && activeDimension && (
-          <DefinitionsSubTitle>
-            Technical Definitions are not available for this metric yet.
-          </DefinitionsSubTitle>
-        )}
-      </DefinitionsDisplay>
-
-      {/* Additional Context (only appears on overall metric settings and not individual dimension settings) */}
-      {!activeDimension && (
-        <ContextConfiguration
-          saveAndUpdateMetricSettings={saveAndUpdateMetricSettings}
-        />
-      )}
-    </DefinitionsDisplayContainer>
-  );
-};
+      </DefinitionsDisplayContainer>
+    );
+  }
+);

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import { MetricConfigurationSettingsOptions } from "@justice-counts/common/types";
+import { DebouncedFunc } from "lodash";
 import { observer } from "mobx-react-lite";
 import React, { Fragment, useState } from "react";
 
@@ -40,17 +41,18 @@ import {
 type MetricDefinitionsProps = {
   activeDimensionKey: string | undefined;
   activeDisaggregationKey: string | undefined;
-  saveAndUpdateMetricSettings: (
-    updatedSetting: MetricSettings,
-    debounce?: boolean
-  ) => void;
+  saveUpdatedMetricSettings: (updatedSetting: MetricSettings) => void;
+  debouncedSave: DebouncedFunc<
+    (updatedSetting: MetricSettings) => Promise<void>
+  >;
 };
 
 export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
   ({
     activeDimensionKey,
     activeDisaggregationKey,
-    saveAndUpdateMetricSettings,
+    saveUpdatedMetricSettings,
+    debouncedSave,
   }) => {
     const { metricConfigStore } = useStore();
 
@@ -138,13 +140,13 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
       }[];
 
       if (isMetricDefinitionSettings) {
-        return saveAndUpdateMetricSettings({
+        return saveUpdatedMetricSettings({
           key: metricConfigStore.activeMetricKey as string,
           settings: defaultSettings,
         });
       }
 
-      saveAndUpdateMetricSettings({
+      saveUpdatedMetricSettings({
         key: metricConfigStore.activeMetricKey as string,
         disaggregations: [
           {
@@ -237,7 +239,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
                                       settingKey,
                                       option
                                     );
-                                  return saveAndUpdateMetricSettings(
+                                  return saveUpdatedMetricSettings(
                                     updatedSettings
                                   );
                                 }
@@ -251,7 +253,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
                                     settingKey,
                                     option
                                   );
-                                saveAndUpdateMetricSettings(updatedSettings);
+                                saveUpdatedMetricSettings(updatedSettings);
                               }}
                             >
                               {option}
@@ -277,7 +279,8 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
         {/* Additional Context (only appears on overall metric settings and not individual dimension settings) */}
         {!activeDimensionKey && (
           <ContextConfiguration
-            saveAndUpdateMetricSettings={saveAndUpdateMetricSettings}
+            saveUpdatedMetricSettings={saveUpdatedMetricSettings}
+            debouncedSave={debouncedSave}
           />
         )}
       </DefinitionsDisplayContainer>

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -41,11 +41,8 @@ import {
 } from ".";
 
 type MetricDefinitionsProps = {
-  activeMetricKey: string;
-  activeMetric: Metric;
-  activeDimension?: MetricDisaggregationDimensions | undefined;
-  activeDisaggregation: MetricDisaggregations | undefined;
-  contexts: MetricContext[];
+  activeDimensionKey: string | undefined;
+  activeDisaggregationKey: string | undefined;
   saveAndUpdateMetricSettings: (
     updatedSetting: MetricSettings,
     debounce?: boolean
@@ -53,11 +50,8 @@ type MetricDefinitionsProps = {
 };
 
 export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
-  activeMetricKey,
-  activeMetric,
-  activeDimension,
-  activeDisaggregation,
-  contexts,
+  activeDimensionKey,
+  activeDisaggregationKey,
   saveAndUpdateMetricSettings,
 }) => {
   const [showDefaultSettings, setShowDefaultSettings] = useState(false);
@@ -214,13 +208,11 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
       </DefinitionsDisplay>
 
       {/* Additional Context (only appears on overall metric settings and not individual dimension settings) */}
-      {/* {!activeDimension && (
+      {!activeDimension && (
         <ContextConfiguration
-          metricKey={activeMetricKey}
-          contexts={contexts}
           saveAndUpdateMetricSettings={saveAndUpdateMetricSettings}
         />
-      )} */}
+      )}
     </DefinitionsDisplayContainer>
   );
 };

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -106,8 +106,8 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
             metricDefinitionSettings[systemMetricKey][settingKey].default;
 
           updateMetricDefinitionSetting(
-            activeSystem as string,
-            activeMetricKey as string,
+            activeSystem,
+            activeMetricKey,
             settingKey,
             currentSettingDefaultValue as MetricConfigurationSettingsOptions
           );
@@ -122,8 +122,8 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
           ][settingKey].default;
 
         updateDimensionDefinitionSetting(
-          activeSystem as string,
-          activeMetricKey as string,
+          activeSystem,
+          activeMetricKey,
           activeDisaggregationKey as string,
           activeDimensionKey,
           settingKey,
@@ -227,26 +227,30 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
                               showDefault={showDefaultSettings}
                               onClick={() => {
                                 if (isMetricDefinitionSettings) {
-                                  const updatedSettings =
+                                  const updatedSetting =
                                     updateMetricDefinitionSetting(
-                                      activeSystem as string,
-                                      activeMetricKey as string,
+                                      activeSystem,
+                                      activeMetricKey,
                                       settingKey,
                                       option
                                     );
-                                  return saveMetricSettings(updatedSettings);
+                                  return (
+                                    updatedSetting &&
+                                    saveMetricSettings(updatedSetting)
+                                  );
                                 }
 
-                                const updatedSettings =
+                                const updatedSetting =
                                   updateDimensionDefinitionSetting(
-                                    activeSystem as string,
-                                    activeMetricKey as string,
+                                    activeSystem,
+                                    activeMetricKey,
                                     activeDisaggregationKey as string,
                                     activeDimensionKey,
                                     settingKey,
                                     option
                                   );
-                                saveMetricSettings(updatedSettings);
+                                if (updatedSetting)
+                                  saveMetricSettings(updatedSetting);
                               }}
                             >
                               {option}

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -37,7 +37,6 @@ import {
   DefinitionsSubTitle,
   DefinitionsTitle,
   MetricSettings,
-  MetricSettingsUpdateOptions,
   RevertToDefaultButton,
 } from ".";
 
@@ -48,7 +47,6 @@ type MetricDefinitionsProps = {
   activeDisaggregation: MetricDisaggregations | undefined;
   contexts: MetricContext[];
   saveAndUpdateMetricSettings: (
-    typeOfUpdate: MetricSettingsUpdateOptions,
     updatedSetting: MetricSettings,
     debounce?: boolean
   ) => void;
@@ -75,7 +73,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
   const isMetricSettings = (
     dimensionOrMetric: MetricDisaggregationDimensions | Metric
   ): dimensionOrMetric is Metric => {
-    return (dimensionOrMetric as Metric).display_name !== undefined;
+    return (dimensionOrMetric as Metric)?.display_name !== undefined;
   };
 
   const activeSettings = isMetricSettings(activeDimensionOrMetric)
@@ -88,14 +86,14 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
 
   const revertToDefaultValues = () => {
     if (isMetricSettings(activeDimensionOrMetric)) {
-      return saveAndUpdateMetricSettings("METRIC_SETTING", {
+      return saveAndUpdateMetricSettings({
         key: activeMetricKey,
         settings: defaultSettings,
       });
     }
 
     if (activeDisaggregation && activeDimension) {
-      saveAndUpdateMetricSettings("DIMENSION_SETTING", {
+      saveAndUpdateMetricSettings({
         key: activeMetricKey,
         disaggregations: [
           {
@@ -117,8 +115,8 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
       <DefinitionsDisplay>
         <DefinitionsTitle>
           {isMetricSettings(activeDimensionOrMetric)
-            ? activeDimensionOrMetric.display_name
-            : activeDimensionOrMetric.label}
+            ? activeDimensionOrMetric?.display_name
+            : activeDimensionOrMetric?.label}
         </DefinitionsTitle>
 
         {Boolean(activeSettings?.length) && (
@@ -162,15 +160,10 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
                             showDefault={showDefaultSettings}
                             onClick={() => {
                               if (isMetricSettings(activeDimensionOrMetric)) {
-                                return saveAndUpdateMetricSettings(
-                                  "METRIC_SETTING",
-                                  {
-                                    key: activeMetricKey,
-                                    settings: [
-                                      { ...setting, included: option },
-                                    ],
-                                  }
-                                );
+                                return saveAndUpdateMetricSettings({
+                                  key: activeMetricKey,
+                                  settings: [{ ...setting, included: option }],
+                                });
                               }
 
                               const activeDimensionKey =
@@ -178,28 +171,25 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
 
                               return (
                                 activeDisaggregation &&
-                                saveAndUpdateMetricSettings(
-                                  "DIMENSION_SETTING",
-                                  {
-                                    key: activeMetricKey,
-                                    disaggregations: [
-                                      {
-                                        key: activeDisaggregation.key,
-                                        dimensions: [
-                                          {
-                                            key: activeDimensionKey,
-                                            settings: [
-                                              {
-                                                ...setting,
-                                                included: option,
-                                              },
-                                            ],
-                                          },
-                                        ],
-                                      },
-                                    ],
-                                  }
-                                )
+                                saveAndUpdateMetricSettings({
+                                  key: activeMetricKey,
+                                  disaggregations: [
+                                    {
+                                      key: activeDisaggregation.key,
+                                      dimensions: [
+                                        {
+                                          key: activeDimensionKey,
+                                          settings: [
+                                            {
+                                              ...setting,
+                                              included: option,
+                                            },
+                                          ],
+                                        },
+                                      ],
+                                    },
+                                  ],
+                                })
                               );
                             }}
                           >
@@ -224,13 +214,13 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = ({
       </DefinitionsDisplay>
 
       {/* Additional Context (only appears on overall metric settings and not individual dimension settings) */}
-      {!activeDimension && (
+      {/* {!activeDimension && (
         <ContextConfiguration
           metricKey={activeMetricKey}
           contexts={contexts}
           saveAndUpdateMetricSettings={saveAndUpdateMetricSettings}
         />
-      )}
+      )} */}
     </DefinitionsDisplayContainer>
   );
 };

--- a/publisher/src/components/MetricConfiguration/MetricsView.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricsView.tsx
@@ -34,13 +34,16 @@ import {
   MetricName,
   MetricNameBadgeToggleWrapper,
   MetricNameBadgeWrapper,
-  MetricSettingsObj,
   MetricsViewContainer,
   MetricsViewControlPanelOverflowHidden,
   MetricViewBoxContainer,
   PanelContainerLeft,
   PanelContainerRight,
 } from ".";
+
+type MetricSettingsObj = {
+  [key: string]: Metric;
+};
 
 type MetricBoxProps = {
   metricKey: string;

--- a/publisher/src/components/MetricConfiguration/types.ts
+++ b/publisher/src/components/MetricConfiguration/types.ts
@@ -15,10 +15,29 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-export * from "./Configuration";
-export * from "./ContextConfiguration";
-export * from "./MetricBox";
-export * from "./MetricConfiguration";
-export * from "./MetricConfiguration.styles";
-export * from "./MetricDefinitions";
-export * from "./types";
+import {
+  MetricConfigurationSettingsOptions,
+  MetricContext,
+} from "@justice-counts/common/types";
+
+export type MetricSettings = {
+  key: string;
+  enabled?: boolean;
+  settings?: { key: string; included: MetricConfigurationSettingsOptions }[];
+  contexts?: {
+    key: string;
+    value: MetricContext["value"];
+  }[];
+  disaggregations?: {
+    key: string;
+    enabled?: boolean;
+    dimensions?: {
+      key: string;
+      enabled?: boolean;
+      settings?: {
+        key: string;
+        included: MetricConfigurationSettingsOptions;
+      }[];
+    }[];
+  }[];
+};

--- a/publisher/src/components/MetricConfiguration/types.ts
+++ b/publisher/src/components/MetricConfiguration/types.ts
@@ -15,10 +15,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import {
-  MetricConfigurationSettingsOptions,
-  MetricContext,
-} from "@justice-counts/common/types";
+import { MetricContext } from "@justice-counts/common/types";
+
+export const metricConfigurationSettingsOptions = ["Yes", "No", "N/A"] as const;
+export type MetricConfigurationSettingsOptions =
+  typeof metricConfigurationSettingsOptions[number];
 
 export type MetricSettings = {
   key: string;

--- a/publisher/src/components/MetricConfiguration/types.ts
+++ b/publisher/src/components/MetricConfiguration/types.ts
@@ -17,7 +17,7 @@
 
 import { MetricContext } from "@justice-counts/common/types";
 
-export const metricConfigurationSettingsOptions = ["Yes", "No", "N/A"] as const;
+export const metricConfigurationSettingsOptions = ["N/A", "No", "Yes"] as const;
 export type MetricConfigurationSettingsOptions =
   typeof metricConfigurationSettingsOptions[number];
 

--- a/publisher/src/components/Settings/SettingsMenu.tsx
+++ b/publisher/src/components/Settings/SettingsMenu.tsx
@@ -15,13 +15,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+import { observer } from "mobx-react-lite";
 import React, { Fragment } from "react";
 
-import {
-  ListOfMetricsForNavigation,
-  MenuOptions,
-  menuOptions,
-} from "../../pages/Settings";
+import { MenuOptions, menuOptions } from "../../pages/Settings";
+import { useStore } from "../../stores";
 import {
   MenuItem,
   MetricsListContainer,
@@ -32,16 +30,9 @@ import {
 export const SettingsMenu: React.FC<{
   activeMenuItem: MenuOptions;
   goToMenuItem: (destination: MenuOptions) => void;
-  activeMetricKey: string | undefined;
-  setActiveMetricKey: React.Dispatch<React.SetStateAction<string | undefined>>;
-  listOfMetrics: ListOfMetricsForNavigation[] | undefined;
-}> = ({
-  activeMenuItem,
-  goToMenuItem,
-  activeMetricKey,
-  setActiveMetricKey,
-  listOfMetrics,
-}) => {
+}> = observer(({ activeMenuItem, goToMenuItem }) => {
+  const { metricConfigStore } = useStore();
+
   return (
     <SettingsMenuContainer>
       {menuOptions.map((option) => (
@@ -52,7 +43,7 @@ export const SettingsMenu: React.FC<{
               goToMenuItem(option);
 
               if (option === "Metric Configuration") {
-                setActiveMetricKey(undefined);
+                metricConfigStore.updateActiveMetricKey(undefined);
               }
             }}
           >
@@ -63,22 +54,29 @@ export const SettingsMenu: React.FC<{
               selected and allows users to toggle between metrics) */}
           {option === "Metric Configuration" &&
             activeMenuItem === "Metric Configuration" &&
-            activeMetricKey &&
-            listOfMetrics && (
+            metricConfigStore.activeMetricKey && (
               <MetricsListContainer>
-                {listOfMetrics.map((metric) => (
-                  <MetricsListItem
-                    key={metric.key}
-                    activeSection={metric.key === activeMetricKey}
-                    onClick={() => setActiveMetricKey(metric.key)}
-                  >
-                    {metric.display_name}
-                  </MetricsListItem>
-                ))}
+                {metricConfigStore
+                  .getMetricsBySystem(metricConfigStore.activeSystem)
+                  ?.map(({ key, metric }) => {
+                    return (
+                      <MetricsListItem
+                        key={key}
+                        activeSection={
+                          key === metricConfigStore.activeMetricKey
+                        }
+                        onClick={() =>
+                          metricConfigStore.updateActiveMetricKey(key)
+                        }
+                      >
+                        {metric.label}
+                      </MetricsListItem>
+                    );
+                  })}
               </MetricsListContainer>
             )}
         </Fragment>
       ))}
     </SettingsMenuContainer>
   );
-};
+});

--- a/publisher/src/components/Settings/SettingsMenu.tsx
+++ b/publisher/src/components/Settings/SettingsMenu.tsx
@@ -32,6 +32,12 @@ export const SettingsMenu: React.FC<{
   goToMenuItem: (destination: MenuOptions) => void;
 }> = observer(({ activeMenuItem, goToMenuItem }) => {
   const { metricConfigStore } = useStore();
+  const {
+    activeMetricKey,
+    activeSystem,
+    getMetricsBySystem,
+    updateActiveMetricKey,
+  } = metricConfigStore;
 
   return (
     <SettingsMenuContainer>
@@ -43,7 +49,7 @@ export const SettingsMenu: React.FC<{
               goToMenuItem(option);
 
               if (option === "Metric Configuration") {
-                metricConfigStore.updateActiveMetricKey(undefined);
+                updateActiveMetricKey(undefined);
               }
             }}
           >
@@ -54,25 +60,19 @@ export const SettingsMenu: React.FC<{
               selected and allows users to toggle between metrics) */}
           {option === "Metric Configuration" &&
             activeMenuItem === "Metric Configuration" &&
-            metricConfigStore.activeMetricKey && (
+            activeMetricKey && (
               <MetricsListContainer>
-                {metricConfigStore
-                  .getMetricsBySystem(metricConfigStore.activeSystem)
-                  ?.map(({ key, metric }) => {
-                    return (
-                      <MetricsListItem
-                        key={key}
-                        activeSection={
-                          key === metricConfigStore.activeMetricKey
-                        }
-                        onClick={() =>
-                          metricConfigStore.updateActiveMetricKey(key)
-                        }
-                      >
-                        {metric.label}
-                      </MetricsListItem>
-                    );
-                  })}
+                {getMetricsBySystem(activeSystem)?.map(({ key, metric }) => {
+                  return (
+                    <MetricsListItem
+                      key={key}
+                      activeSection={key === activeMetricKey}
+                      onClick={() => updateActiveMetricKey(key)}
+                    >
+                      {metric.label}
+                    </MetricsListItem>
+                  );
+                })}
               </MetricsListContainer>
             )}
         </Fragment>

--- a/publisher/src/pages/Settings.tsx
+++ b/publisher/src/pages/Settings.tsx
@@ -46,31 +46,17 @@ const Settings = () => {
   const goToMenuItem = (destination: MenuOptions) =>
     setActiveMenuItem(destination);
 
-  /** State specific to Metrics Configuration & Settings Menu */
-  const [listOfMetrics, setListOfMetrics] =
-    useState<ListOfMetricsForNavigation[]>();
-  const [activeMetricKey, setActiveMetricKey] = useState<string | undefined>();
-
   return (
     <SettingsContainer>
       <SettingsMenu
         activeMenuItem={activeMenuItem}
         goToMenuItem={goToMenuItem}
-        activeMetricKey={activeMetricKey}
-        setActiveMetricKey={setActiveMetricKey}
-        listOfMetrics={listOfMetrics}
       />
 
       <ContentDisplay>
         {activeMenuItem === "Your Account" && <AccountSettings />}
         {activeMenuItem === "Uploaded Files" && <UploadedFiles />}
-        {activeMenuItem === "Metric Configuration" && (
-          <MetricConfiguration
-            activeMetricKey={activeMetricKey}
-            setActiveMetricKey={setActiveMetricKey}
-            setListOfMetrics={setListOfMetrics}
-          />
-        )}
+        {activeMenuItem === "Metric Configuration" && <MetricConfiguration />}
       </ContentDisplay>
     </SettingsContainer>
   );

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -118,16 +118,19 @@ class MetricConfigStore {
     this.contexts = {};
   }
 
-  static getSystemMetricKey(system: string, metricKey: string) {
+  static getSystemMetricKey(system: string, metricKey: string): string {
     return `${system.toUpperCase()}-${metricKey}`;
   }
 
-  static splitSystemMetricKey(systemMetricKey: string) {
+  static splitSystemMetricKey(systemMetricKey: string): {
+    system: string;
+    metricKey: string;
+  } {
     const [system, metricKey] = systemMetricKey.split("-");
     return { system, metricKey };
   }
 
-  getActiveSystemMetricKey() {
+  getActiveSystemMetricKey(): string {
     return `${this.activeSystem?.toUpperCase()}-${this.activeMetricKey}`;
   }
 
@@ -167,7 +170,7 @@ class MetricConfigStore {
     }
   }
 
-  async getMetricSettings() {
+  async getMetricSettings(): Promise<Metric[]> {
     const { currentAgency } = this.userStore;
 
     if (currentAgency === undefined) {
@@ -190,7 +193,9 @@ class MetricConfigStore {
     return metrics;
   }
 
-  async saveMetricSettings(updatedMetricSettings: MetricSettings[]) {
+  async saveMetricSettings(
+    updatedMetricSettings: MetricSettings[]
+  ): Promise<Response> {
     const { currentAgency } = this.userStore;
 
     if (currentAgency === undefined) {
@@ -212,7 +217,7 @@ class MetricConfigStore {
     return response;
   }
 
-  async initializeMetricConfigStoreValues() {
+  async initializeMetricConfigStoreValues(): Promise<void | Error> {
     try {
       const metrics = await this.getMetricSettings();
 
@@ -306,7 +311,7 @@ class MetricConfigStore {
     metricKey: string,
     enabledStatus: boolean,
     metadata?: { [key: string]: string }
-  ) {
+  ): MetricSettings {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -341,7 +346,7 @@ class MetricConfigStore {
     settingKey: string,
     settingValue: MetricConfigurationSettingsOptions,
     metadata?: { [key: string]: string }
-  ) {
+  ): MetricSettings {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -380,7 +385,7 @@ class MetricConfigStore {
     disaggregationKey: string,
     enabledStatus: boolean,
     metadata?: { [key: string]: string }
-  ) {
+  ): MetricSettings {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -437,7 +442,7 @@ class MetricConfigStore {
     dimensionKey: string,
     enabledStatus: boolean,
     metadata?: { [key: string]: string }
-  ) {
+  ): MetricSettings {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -515,7 +520,7 @@ class MetricConfigStore {
     settingKey: string,
     settingValue: MetricConfigurationSettingsOptions,
     metadata?: { [key: string]: string }
-  ) {
+  ): MetricSettings {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -592,7 +597,7 @@ class MetricConfigStore {
     contextType: MetricContext["type"] | undefined,
     value: MetricContext["value"],
     metadata?: { [key: string]: string | string[] | MetricContext["type"] }
-  ) {
+  ): MetricSettings {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -127,6 +127,10 @@ class MetricConfigStore {
     return { system, metricKey };
   }
 
+  getActiveSystemMetricKey() {
+    return `${this.activeSystem?.toUpperCase()}-${this.activeMetricKey}`;
+  }
+
   updateActiveSystem(systemName: AgencySystems | undefined) {
     this.activeSystem = systemName;
   }
@@ -585,7 +589,7 @@ class MetricConfigStore {
     system: string,
     metricKey: string,
     contextKey: string,
-    contextType: MetricContext["type"],
+    contextType: MetricContext["type"] | undefined,
     value: MetricContext["value"],
     metadata?: { [key: string]: string | string[] | MetricContext["type"] }
   ) {

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -20,13 +20,15 @@ import {
   AgencySystems,
   FormError,
   Metric,
-  MetricConfigurationSettingsOptions,
   MetricContext,
   ReportFrequency,
 } from "@justice-counts/common/types";
 import { makeAutoObservable, runInAction } from "mobx";
 
-import { MetricSettings } from "../components/MetricConfiguration";
+import {
+  MetricConfigurationSettingsOptions,
+  MetricSettings,
+} from "../components/MetricConfiguration";
 import { isPositiveNumber, removeCommaSpaceAndTrim } from "../utils";
 import API from "./API";
 import UserStore from "./UserStore";

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -61,6 +61,9 @@ class MetricConfigStore {
       [contextKey: string]: {
         value?: MetricContext["value"];
         error?: FormError;
+        display_name?: string;
+        type?: MetricContext["type"];
+        multiple_choice_options?: string[];
       };
     };
   };
@@ -272,7 +275,12 @@ class MetricConfigStore {
             metric.key,
             context.key,
             context.type,
-            context.value
+            context.value,
+            {
+              display_name: context.display_name as string,
+              type: context.type,
+              multiple_choice_options: context.multiple_choice_options,
+            }
           );
         });
       });
@@ -547,7 +555,8 @@ class MetricConfigStore {
     metricKey: string,
     contextKey: string,
     contextType: MetricContext["type"],
-    value: MetricContext["value"]
+    value: MetricContext["value"],
+    metadata?: { [key: string]: string | string[] | MetricContext["type"] }
   ) {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       metricKey,
@@ -562,6 +571,16 @@ class MetricConfigStore {
       this.contexts[systemMetricKey][contextKey] = {};
     }
 
+    /** If provided, add metadata required for rendering */
+    if (metadata) {
+      this.contexts[systemMetricKey][contextKey].display_name =
+        metadata.display_name as string;
+      this.contexts[systemMetricKey][contextKey].type =
+        metadata.type as MetricContext["type"];
+      this.contexts[systemMetricKey][contextKey].multiple_choice_options =
+        metadata.multiple_choice_options as string[];
+    }
+
     /** Update value */
     this.contexts[systemMetricKey][contextKey].value = value;
 
@@ -573,10 +592,7 @@ class MetricConfigStore {
         this.contexts[systemMetricKey][contextKey].error = {
           message: "Please enter a valid number.",
         };
-        return;
-      }
-
-      if (this.contexts[systemMetricKey][contextKey].error) {
+      } else if (this.contexts[systemMetricKey][contextKey].error) {
         delete this.contexts[systemMetricKey][contextKey].error;
       }
     }

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -227,7 +227,10 @@ class MetricConfigStore {
 
       runInAction(() => {
         metrics.forEach((metric) => {
-          const normalizedMetricSystemName = metric.system.replaceAll(" ", "_");
+          const normalizedMetricSystemName = metric.system.replaceAll(
+            " ",
+            "_"
+          ) as AgencySystems;
 
           /** Initialize Metrics Status (Enabled/Disabled) */
           this.updateMetricEnabledStatus(
@@ -311,11 +314,13 @@ class MetricConfigStore {
   };
 
   updateMetricEnabledStatus = (
-    system: string,
-    metricKey: string,
+    system: AgencySystems | undefined,
+    metricKey: string | undefined,
     enabledStatus: boolean,
     metadata?: { [key: string]: string }
-  ): MetricSettings => {
+  ): MetricSettings | undefined => {
+    if (!system || !metricKey) return;
+
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -345,12 +350,14 @@ class MetricConfigStore {
   };
 
   updateMetricDefinitionSetting = (
-    system: string,
-    metricKey: string,
+    system: AgencySystems | undefined,
+    metricKey: string | undefined,
     settingKey: string,
     settingValue: MetricConfigurationSettingsOptions,
     metadata?: { [key: string]: string }
-  ): MetricSettings => {
+  ): MetricSettings | undefined => {
+    if (!system || !metricKey) return;
+
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -384,12 +391,14 @@ class MetricConfigStore {
   };
 
   updateDisaggregationEnabledStatus = (
-    system: string,
-    metricKey: string,
+    system: AgencySystems | undefined,
+    metricKey: string | undefined,
     disaggregationKey: string,
     enabledStatus: boolean,
     metadata?: { [key: string]: string }
-  ): MetricSettings => {
+  ): MetricSettings | undefined => {
+    if (!system || !metricKey) return;
+
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -440,13 +449,15 @@ class MetricConfigStore {
   };
 
   updateDimensionEnabledStatus = (
-    system: string,
-    metricKey: string,
+    system: AgencySystems | undefined,
+    metricKey: string | undefined,
     disaggregationKey: string,
     dimensionKey: string,
     enabledStatus: boolean,
     metadata?: { [key: string]: string }
-  ): MetricSettings => {
+  ): MetricSettings | undefined => {
+    if (!system || !metricKey) return;
+
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -516,14 +527,16 @@ class MetricConfigStore {
   };
 
   updateDimensionDefinitionSetting = (
-    system: string,
-    metricKey: string,
+    system: AgencySystems | undefined,
+    metricKey: string | undefined,
     disaggregationKey: string,
     dimensionKey: string,
     settingKey: string,
     settingValue: MetricConfigurationSettingsOptions,
     metadata?: { [key: string]: string }
-  ): MetricSettings => {
+  ): MetricSettings | undefined => {
+    if (!system || !metricKey) return;
+
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -594,13 +607,15 @@ class MetricConfigStore {
   };
 
   updateContextValue = (
-    system: string,
-    metricKey: string,
+    system: AgencySystems | undefined,
+    metricKey: string | undefined,
     contextKey: string,
     contextType: MetricContext["type"] | undefined,
     value: MetricContext["value"],
     metadata?: { [key: string]: string | string[] | MetricContext["type"] }
-  ): MetricSettings => {
+  ): MetricSettings | undefined => {
+    if (!system || !metricKey) return;
+
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+import { showToast } from "@justice-counts/common/components/Toast";
 import {
   AgencySystems,
   FormError,
@@ -195,7 +196,7 @@ class MetricConfigStore {
   };
 
   saveMetricSettings = async (
-    updatedMetricSettings: MetricSettings[]
+    updatedMetricSettings: MetricSettings
   ): Promise<Response> => {
     const { currentAgency } = this.userStore;
 
@@ -207,14 +208,16 @@ class MetricConfigStore {
 
     const response = (await this.api.request({
       path: `/api/agencies/${currentAgency.id}/metrics`,
-      body: { metrics: updatedMetricSettings },
+      body: { metrics: [updatedMetricSettings] },
       method: "PUT",
     })) as Response;
 
     if (response.status !== 200) {
+      showToast(`Failed to save.`, true, "red", 4000);
       throw new Error("There was an issue updating the metric settings.");
     }
 
+    showToast(`Settings saved.`, true, "grey", 4000);
     return response;
   };
 

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -470,7 +470,6 @@ class MetricConfigStore {
      * When last dimension is disabled, the disaggregation is disabled
      * When all dimensions are off, and one dimension is re-enabled, the disaggregation is enabled
      */
-
     if (!metadata) {
       const isLastDimensionDisabled =
         enabledStatus === false &&

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -110,6 +110,7 @@ class MetricConfigStore {
     this.api = api;
     this.userStore = userStore;
     this.activeMetricKey = undefined;
+    this.activeSystem = undefined;
     this.metrics = {};
     this.metricDefinitionSettings = {};
     this.disaggregations = {};
@@ -130,19 +131,19 @@ class MetricConfigStore {
     return { system, metricKey };
   }
 
-  getActiveSystemMetricKey(): string {
+  getActiveSystemMetricKey = (): string => {
     return `${this.activeSystem?.toUpperCase()}-${this.activeMetricKey}`;
-  }
+  };
 
-  updateActiveSystem(systemName: AgencySystems | undefined) {
+  updateActiveSystem = (systemName: AgencySystems | undefined) => {
     this.activeSystem = systemName;
-  }
+  };
 
-  updateActiveMetricKey(metricKey: string | undefined) {
+  updateActiveMetricKey = (metricKey: string | undefined) => {
     this.activeMetricKey = metricKey;
-  }
+  };
 
-  getMetricsBySystem(systemName: AgencySystems | undefined) {
+  getMetricsBySystem = (systemName: AgencySystems | undefined) => {
     if (systemName) {
       const metrics = Object.entries(this.metrics).reduce(
         (filteredMetrics, [systemMetricKey, metric]) => {
@@ -168,9 +169,9 @@ class MetricConfigStore {
 
       return metrics;
     }
-  }
+  };
 
-  async getMetricSettings(): Promise<Metric[]> {
+  getMetricSettings = async (): Promise<Metric[]> => {
     const { currentAgency } = this.userStore;
 
     if (currentAgency === undefined) {
@@ -191,11 +192,11 @@ class MetricConfigStore {
     const metrics: Metric[] = await response.json();
 
     return metrics;
-  }
+  };
 
-  async saveMetricSettings(
+  saveMetricSettings = async (
     updatedMetricSettings: MetricSettings[]
-  ): Promise<Response> {
+  ): Promise<Response> => {
     const { currentAgency } = this.userStore;
 
     if (currentAgency === undefined) {
@@ -215,9 +216,9 @@ class MetricConfigStore {
     }
 
     return response;
-  }
+  };
 
-  async initializeMetricConfigStoreValues(): Promise<void | Error> {
+  initializeMetricConfigStoreValues = async (): Promise<void | Error> => {
     try {
       const metrics = await this.getMetricSettings();
 
@@ -304,14 +305,14 @@ class MetricConfigStore {
     } catch (error) {
       return new Error(error as string);
     }
-  }
+  };
 
-  updateMetricEnabledStatus(
+  updateMetricEnabledStatus = (
     system: string,
     metricKey: string,
     enabledStatus: boolean,
     metadata?: { [key: string]: string }
-  ): MetricSettings {
+  ): MetricSettings => {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -338,15 +339,15 @@ class MetricConfigStore {
       key: metricKey,
       enabled: enabledStatus,
     };
-  }
+  };
 
-  updateMetricDefinitionSetting(
+  updateMetricDefinitionSetting = (
     system: string,
     metricKey: string,
     settingKey: string,
     settingValue: MetricConfigurationSettingsOptions,
     metadata?: { [key: string]: string }
-  ): MetricSettings {
+  ): MetricSettings => {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -377,15 +378,15 @@ class MetricConfigStore {
       key: metricKey,
       settings: [{ key: settingKey, included: settingValue }],
     };
-  }
+  };
 
-  updateDisaggregationEnabledStatus(
+  updateDisaggregationEnabledStatus = (
     system: string,
     metricKey: string,
     disaggregationKey: string,
     enabledStatus: boolean,
     metadata?: { [key: string]: string }
-  ): MetricSettings {
+  ): MetricSettings => {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -433,16 +434,16 @@ class MetricConfigStore {
         },
       ],
     };
-  }
+  };
 
-  updateDimensionEnabledStatus(
+  updateDimensionEnabledStatus = (
     system: string,
     metricKey: string,
     disaggregationKey: string,
     dimensionKey: string,
     enabledStatus: boolean,
     metadata?: { [key: string]: string }
-  ): MetricSettings {
+  ): MetricSettings => {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -510,9 +511,9 @@ class MetricConfigStore {
         },
       ],
     };
-  }
+  };
 
-  updateDimensionDefinitionSetting(
+  updateDimensionDefinitionSetting = (
     system: string,
     metricKey: string,
     disaggregationKey: string,
@@ -520,7 +521,7 @@ class MetricConfigStore {
     settingKey: string,
     settingValue: MetricConfigurationSettingsOptions,
     metadata?: { [key: string]: string }
-  ): MetricSettings {
+  ): MetricSettings => {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -588,16 +589,16 @@ class MetricConfigStore {
         },
       ],
     };
-  }
+  };
 
-  updateContextValue(
+  updateContextValue = (
     system: string,
     metricKey: string,
     contextKey: string,
     contextType: MetricContext["type"] | undefined,
     value: MetricContext["value"],
     metadata?: { [key: string]: string | string[] | MetricContext["type"] }
-  ): MetricSettings {
+  ): MetricSettings => {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -625,7 +626,7 @@ class MetricConfigStore {
     this.contexts[systemMetricKey][contextKey].value = value;
 
     /** Context Validation for NUMBER type contexts */
-    if (contextType === "NUMBER") {
+    if (contextType === "NUMBER" && value) {
       const cleanValue = removeCommaSpaceAndTrim(value as string);
 
       if (!isPositiveNumber(cleanValue) && cleanValue !== "") {
@@ -642,7 +643,7 @@ class MetricConfigStore {
       key: metricKey,
       contexts: [{ key: contextKey, value }],
     };
-  }
+  };
 }
 
 export default MetricConfigStore;

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -316,13 +316,11 @@ class MetricConfigStore {
   };
 
   updateMetricEnabledStatus = (
-    system: AgencySystems | undefined,
-    metricKey: string | undefined,
+    system: AgencySystems,
+    metricKey: string,
     enabledStatus: boolean,
     metadata?: { [key: string]: string }
-  ): MetricSettings | undefined => {
-    if (!system || !metricKey) return;
-
+  ): MetricSettings => {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -352,14 +350,12 @@ class MetricConfigStore {
   };
 
   updateMetricDefinitionSetting = (
-    system: AgencySystems | undefined,
-    metricKey: string | undefined,
+    system: AgencySystems,
+    metricKey: string,
     settingKey: string,
     settingValue: MetricConfigurationSettingsOptions,
     metadata?: { [key: string]: string }
-  ): MetricSettings | undefined => {
-    if (!system || !metricKey) return;
-
+  ): MetricSettings => {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -393,14 +389,12 @@ class MetricConfigStore {
   };
 
   updateDisaggregationEnabledStatus = (
-    system: AgencySystems | undefined,
-    metricKey: string | undefined,
+    system: AgencySystems,
+    metricKey: string,
     disaggregationKey: string,
     enabledStatus: boolean,
     metadata?: { [key: string]: string }
-  ): MetricSettings | undefined => {
-    if (!system || !metricKey) return;
-
+  ): MetricSettings => {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -451,15 +445,13 @@ class MetricConfigStore {
   };
 
   updateDimensionEnabledStatus = (
-    system: AgencySystems | undefined,
-    metricKey: string | undefined,
+    system: AgencySystems,
+    metricKey: string,
     disaggregationKey: string,
     dimensionKey: string,
     enabledStatus: boolean,
     metadata?: { [key: string]: string }
-  ): MetricSettings | undefined => {
-    if (!system || !metricKey) return;
-
+  ): MetricSettings => {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -529,16 +521,14 @@ class MetricConfigStore {
   };
 
   updateDimensionDefinitionSetting = (
-    system: AgencySystems | undefined,
-    metricKey: string | undefined,
+    system: AgencySystems,
+    metricKey: string,
     disaggregationKey: string,
     dimensionKey: string,
     settingKey: string,
     settingValue: MetricConfigurationSettingsOptions,
     metadata?: { [key: string]: string }
-  ): MetricSettings | undefined => {
-    if (!system || !metricKey) return;
-
+  ): MetricSettings => {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -609,15 +599,13 @@ class MetricConfigStore {
   };
 
   updateContextValue = (
-    system: AgencySystems | undefined,
-    metricKey: string | undefined,
+    system: AgencySystems,
+    metricKey: string,
     contextKey: string,
     contextType: MetricContext["type"] | undefined,
     value: MetricContext["value"],
     metadata?: { [key: string]: string | string[] | MetricContext["type"] }
-  ): MetricSettings | undefined => {
-    if (!system || !metricKey) return;
-
+  ): MetricSettings => {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey


### PR DESCRIPTION
## Description of the change

Equip with a new mobx data store, this PR refactors and connects all Metric Configuration & related UI components to the store. This should be a no-op refactor with regards to behavior (everything here should behave exactly the same as it does in staging). 

## Related issues

Closes #134 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
