### PR TITLE
Race & Ethnicity: Logic & Functionality (2/2)

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -140,6 +140,8 @@ export interface MetricDisaggregationDimensions {
   enabled?: boolean;
   settings?: MetricConfigurationSettings[];
   display_name?: string;
+  race?: string;
+  ethnicity?: string;
 }
 
 export interface CreateReportFormValuesType extends Record<string, unknown> {

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -38,6 +38,7 @@ import {
   MetricConfigurationContainer,
   MetricDisaggregations,
   MetricOnOffWrapper,
+  RACE_ETHNICITY_DISAGGREGATION_KEY,
   RaceEthnicitiesGrid,
   RadioButtonGroupWrapper,
   Subheader,
@@ -227,7 +228,8 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
 
             <Disaggregation>
               {/* Dimension Fields (Enable/Disable) */}
-              {activeDisaggregationKey === "global/race_and_ethnicity" ? (
+              {/* Race & Ethnicities Grid (when active disaggregation is Race / Ethnicity) */}
+              {activeDisaggregationKey === RACE_ETHNICITY_DISAGGREGATION_KEY ? (
                 <RaceEthnicitiesGrid />
               ) : (
                 activeDimensionKeys?.map((dimensionKey) => {

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -622,7 +622,7 @@ export const DefinitionMiniButton = styled(RevertToDefaultButton)<{
         opacity: 0.9;
       }
 
-      &:nth-child(3) {
+      &:last-child {
         background: ${palette.solid.blue};
 
         &:hover {

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -40,6 +40,7 @@ import {
   MetricName,
   MetricsViewContainer,
   MetricsViewControlPanel,
+  RACE_ETHNICITY_DISAGGREGATION_KEY,
   RaceEthnicitiesForm,
   StickyHeader,
 } from ".";
@@ -194,7 +195,8 @@ export const MetricConfiguration: React.FC = observer(() => {
               </MetricConfigurationDisplay>
 
               {/* Metric/Dimension Definitions (Includes/Excludes) & Context */}
-              {activeDisaggregationKey === "global/race_and_ethnicity" &&
+              {/* Race/Ethnicities (when active disaggregation is Race / Ethnicities) */}
+              {activeDisaggregationKey === RACE_ETHNICITY_DISAGGREGATION_KEY &&
               activeDimensionKey ? (
                 <RaceEthnicitiesForm />
               ) : (

--- a/publisher/src/components/MetricConfiguration/RaceEthnicitiesForm.tsx
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicitiesForm.tsx
@@ -217,6 +217,10 @@ export const RaceEthnicitiesForm = observer(() => {
                       );
 
                       if (switchedGridStateUpdatedDimensions) {
+                        /** Add the updated dimension from disabling the Unknown race to the switchedGridStateUpdatedDimensions */
+                        switchedGridStateUpdatedDimensions.disaggregations[0].dimensions.push(
+                          ...updatedDimensions.disaggregations[0].dimensions
+                        );
                         return saveMetricSettings(
                           switchedGridStateUpdatedDimensions
                         );

--- a/publisher/src/components/MetricConfiguration/RaceEthnicitiesGrid.tsx
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicitiesGrid.tsx
@@ -15,8 +15,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+import { observer } from "mobx-react-lite";
 import React from "react";
 
+import { useStore } from "../../stores";
 import { ReactComponent as RightArrowIcon } from "../assets/right-arrow.svg";
 import {
   CalloutBox,
@@ -32,10 +34,12 @@ import {
   RaceEthnicitiesBreakdownContainer,
   RaceEthnicitiesRow,
   RaceEthnicitiesTable,
-  races,
 } from ".";
 
-export const RaceEthnicitiesGrid = () => {
+export const RaceEthnicitiesGrid: React.FC = observer(() => {
+  const { metricConfigStore } = useStore();
+  const { ethnicitiesByRace } = metricConfigStore;
+
   return (
     <RaceEthnicitiesBreakdownContainer>
       <CalloutBox>
@@ -43,7 +47,6 @@ export const RaceEthnicitiesGrid = () => {
           Answer the questions on the <span>Race and Ethnicity</span> form; the
           grid below will reflect your responses.
         </Description>
-
         <RightArrowIcon />
       </CalloutBox>
 
@@ -60,17 +63,20 @@ export const RaceEthnicitiesGrid = () => {
       </GridHeaderContainer>
 
       <RaceEthnicitiesTable>
-        {races.map((race, index) => (
+        {Object.entries(ethnicitiesByRace).map(([race, ethnicities]) => (
           <RaceEthnicitiesRow key={race}>
             <RaceCell>{race}</RaceCell>
             <EthnicitiesRow>
-              <EthnicityCell enabled={index % 1 === 0} />
-              <EthnicityCell />
-              <EthnicityCell />
+              {Object.values(ethnicities).map((ethnicity) => (
+                <EthnicityCell
+                  key={ethnicity.key}
+                  enabled={ethnicity.enabled}
+                />
+              ))}
             </EthnicitiesRow>
           </RaceEthnicitiesRow>
         ))}
       </RaceEthnicitiesTable>
     </RaceEthnicitiesBreakdownContainer>
   );
-};
+});

--- a/publisher/src/components/MetricConfiguration/RaceEthnicitiesGridStates.ts
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicitiesGridStates.ts
@@ -1,0 +1,172 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2022 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+export type StateKeys = keyof typeof raceEthnicityGridStates;
+
+export type RaceEthnicitiesGridStates = {
+  [state: string]: {
+    [race: string]: {
+      [ethnicity: string]: boolean;
+    };
+  };
+};
+
+/**
+ * Race x Ethnicity Grid States represent the maximum set of dimensions (of the 24 available
+ * Race & Ethnicity dimensions) a user can enter data for or disable/enable.
+ *
+ * There are 3 states that a user can fall under based on the following conditions:
+ * State 1 (`CAN_SPECIFY_ETHNICITY`): They record & can report each ethnicity per race (Hispanic/Latino, Not Hispanic/Latino, Unknown Ethnicity)
+ * State 2 (`NO_ETHNICITY_HISPANIC_AS_RACE`): They cannot record/report each ethnicity and record Hispanic/Latino as a Race
+ * State 3 (`NO_ETHNICITY_HISPANIC_NOT_SPECIFIED`): They cannot record/report each ethnicity and DO NOT record Hispanic/Latino as a Race
+ *
+ * This object serves as a truth table of the 3 states. The boolean represents whether or not that
+ * particular dimension is available to the user to enter data for or disable/enable.
+ *
+ * @example
+ * State 1 has all 24 available dimensions (Race x All 3 Ethnicities)
+ * State 2 has only 9 available dimensions (Race x Not Hispanic/Latino Ethnicity, Unknown Race x Hispanic/Latino Ethnicity) - the other 15 dimensions are disabled.
+ * State 3 has only 8 available dimensions (Race x Unknown Ethnicity) - the other 16 dimensions are disabled.
+ */
+export const raceEthnicityGridStates = {
+  CAN_SPECIFY_ETHNICITY: {
+    "American Indian / Alaskan Native": {
+      Hispanic: true,
+      "Not Hispanic": true,
+      "Unknown Ethnicity": true,
+    },
+    Asian: {
+      Hispanic: true,
+      "Not Hispanic": true,
+      "Unknown Ethnicity": true,
+    },
+    Black: {
+      Hispanic: true,
+      "Not Hispanic": true,
+      "Unknown Ethnicity": true,
+    },
+    "More than one race": {
+      Hispanic: true,
+      "Not Hispanic": true,
+      "Unknown Ethnicity": true,
+    },
+    "Native Hawaiian / Pacific Islander": {
+      Hispanic: true,
+      "Not Hispanic": true,
+      "Unknown Ethnicity": true,
+    },
+    White: {
+      Hispanic: true,
+      "Not Hispanic": true,
+      "Unknown Ethnicity": true,
+    },
+    Other: {
+      Hispanic: true,
+      "Not Hispanic": true,
+      "Unknown Ethnicity": true,
+    },
+    Unknown: {
+      Hispanic: true,
+      "Not Hispanic": true,
+      "Unknown Ethnicity": true,
+    },
+  },
+  NO_ETHNICITY_HISPANIC_AS_RACE: {
+    "American Indian / Alaskan Native": {
+      Hispanic: false,
+      "Not Hispanic": true,
+      "Unknown Ethnicity": false,
+    },
+    Asian: {
+      Hispanic: false,
+      "Not Hispanic": true,
+      "Unknown Ethnicity": false,
+    },
+    Black: {
+      Hispanic: false,
+      "Not Hispanic": true,
+      "Unknown Ethnicity": false,
+    },
+    "More than one race": {
+      Hispanic: false,
+      "Not Hispanic": true,
+      "Unknown Ethnicity": false,
+    },
+    "Native Hawaiian / Pacific Islander": {
+      Hispanic: false,
+      "Not Hispanic": true,
+      "Unknown Ethnicity": false,
+    },
+    White: {
+      Hispanic: false,
+      "Not Hispanic": true,
+      "Unknown Ethnicity": false,
+    },
+    Other: {
+      Hispanic: false,
+      "Not Hispanic": true,
+      "Unknown Ethnicity": false,
+    },
+    Unknown: {
+      Hispanic: true,
+      "Not Hispanic": true,
+      "Unknown Ethnicity": false,
+    },
+  },
+  NO_ETHNICITY_HISPANIC_NOT_SPECIFIED: {
+    "American Indian / Alaskan Native": {
+      Hispanic: false,
+      "Not Hispanic": false,
+      "Unknown Ethnicity": true,
+    },
+    Asian: {
+      Hispanic: false,
+      "Not Hispanic": false,
+      "Unknown Ethnicity": true,
+    },
+    Black: {
+      Hispanic: false,
+      "Not Hispanic": false,
+      "Unknown Ethnicity": true,
+    },
+    "More than one race": {
+      Hispanic: false,
+      "Not Hispanic": false,
+      "Unknown Ethnicity": true,
+    },
+    "Native Hawaiian / Pacific Islander": {
+      Hispanic: false,
+      "Not Hispanic": false,
+      "Unknown Ethnicity": true,
+    },
+    White: {
+      Hispanic: false,
+      "Not Hispanic": false,
+      "Unknown Ethnicity": true,
+    },
+    Other: {
+      Hispanic: false,
+      "Not Hispanic": false,
+      "Unknown Ethnicity": true,
+    },
+    Unknown: {
+      Hispanic: false,
+      "Not Hispanic": false,
+      "Unknown Ethnicity": true,
+    },
+  },
+};

--- a/publisher/src/components/MetricConfiguration/constants.ts
+++ b/publisher/src/components/MetricConfiguration/constants.ts
@@ -15,15 +15,4 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-export * from "./Configuration";
-export * from "./constants";
-export * from "./ContextConfiguration";
-export * from "./MetricBox";
-export * from "./MetricConfiguration";
-export * from "./MetricConfiguration.styles";
-export * from "./MetricDefinitions";
-export * from "./RaceEthnicities.styles";
-export * from "./RaceEthnicitiesForm";
-export * from "./RaceEthnicitiesGrid";
-export * from "./RaceEthnicitiesGridStates";
-export * from "./types";
+export const RACE_ETHNICITY_DISAGGREGATION_KEY = "global/race_and_ethnicity";

--- a/publisher/src/components/MetricConfiguration/types.ts
+++ b/publisher/src/components/MetricConfiguration/types.ts
@@ -21,18 +21,6 @@ export const metricConfigurationSettingsOptions = ["N/A", "No", "Yes"] as const;
 export type MetricConfigurationSettingsOptions =
   typeof metricConfigurationSettingsOptions[number];
 
-export const races = [
-  "American Indian / Alaskan",
-  "Asian",
-  "Black",
-  "Native Hawaiian / Pacific Islander",
-  "White",
-  "More than one race",
-  "Other",
-  "Unknown",
-] as const;
-export type Races = typeof races[number];
-
 export type MetricSettings = {
   key: string;
   enabled?: boolean;
@@ -54,3 +42,32 @@ export type MetricSettings = {
     }[];
   }[];
 };
+
+export type UpdatedDimension = {
+  key: string;
+  label: string;
+  enabled: boolean;
+};
+
+export type UpdatedDisaggregation = {
+  key: string;
+  disaggregations: {
+    key: string;
+    dimensions: UpdatedDimension[];
+  }[];
+};
+
+export const races = [
+  "American Indian / Alaskan Native",
+  "Asian",
+  "Black",
+  "Native Hawaiian / Pacific Islander",
+  "White",
+  "More than one race",
+  "Other",
+  "Unknown",
+] as const;
+export type Races = typeof races[number];
+
+export const ethnicities = ["Hispanic", "Not Hispanic", "Unknown Ethnicity"];
+export type Ethnicities = typeof ethnicities[number];

--- a/publisher/src/components/MetricConfiguration/types.ts
+++ b/publisher/src/components/MetricConfiguration/types.ts
@@ -47,6 +47,8 @@ export type UpdatedDimension = {
   key: string;
   label: string;
   enabled: boolean;
+  race: Races;
+  ethnicity: Ethnicities;
 };
 
 export type UpdatedDisaggregation = {
@@ -69,5 +71,9 @@ export const races = [
 ] as const;
 export type Races = typeof races[number];
 
-export const ethnicities = ["Hispanic", "Not Hispanic", "Unknown Ethnicity"];
+export const ethnicities = [
+  "Hispanic",
+  "Not Hispanic",
+  "Unknown Ethnicity",
+] as const;
 export type Ethnicities = typeof ethnicities[number];

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -690,10 +690,12 @@ class MetricConfigStore {
       this.activeSystem,
       this.activeMetricKey
     );
-    const dimensions = Object.values(
-      this.dimensions[systemMetricKey][RACE_ETHNICITY_DISAGGREGATION_KEY]
-    ) as UpdatedDimension[];
-    const ethnicitiesByRaceMap = dimensions.reduce(
+    const raceEthnicitiesDimensions =
+      this.dimensions[systemMetricKey][RACE_ETHNICITY_DISAGGREGATION_KEY];
+    const dimensions =
+      raceEthnicitiesDimensions &&
+      (Object.values(raceEthnicitiesDimensions) as UpdatedDimension[]);
+    const ethnicitiesByRaceMap = dimensions?.reduce(
       (acc, dimension) => {
         acc[dimension.race] = {
           ...acc[dimension.race],
@@ -709,7 +711,7 @@ class MetricConfigStore {
       }
     );
 
-    return ethnicitiesByRaceMap;
+    return ethnicitiesByRaceMap || {};
   }
 
   updateAllRaceEthnicitiesToDefaultState = (
@@ -736,6 +738,18 @@ class MetricConfigStore {
     if (unknownRaceDisabled && state === "NO_ETHNICITY_HISPANIC_AS_RACE") {
       this.ethnicitiesByRace.Unknown.Hispanic.enabled = true;
       this.ethnicitiesByRace.Unknown["Not Hispanic"].enabled = true;
+      updatedDimensions.push(
+        ...[
+          {
+            ...this.ethnicitiesByRace.Unknown.Hispanic,
+            enabled: true,
+          },
+          {
+            ...this.ethnicitiesByRace.Unknown["Not Hispanic"],
+            enabled: true,
+          },
+        ]
+      );
       sanitizedState = state;
     }
 


### PR DESCRIPTION
## Description of the change

Implements the required functionality of R&E components according to the updated specification for Race and Ethnicity.

A brief description of the 3 core states users can find themselves in--

There are 3 distinct states (outlined below) that dictate the maximum available dimensions (of the 24 race & ethnicity dimensions) a user can enable/disable. 

### ******************************************State 1: Can Report Ethnicity******************************************

- Answered “Yes” to this question (**Does your case management system allow you to specify an individual’s ethnicity (Hispanic, Non-Hispanic, or Unknown) for this metric?**)
- User can report all 24 dimensions and can choose to disable a race if they are unable to report it
    - Turning off a single race is equivalent to turning off 3 dimensions because a single race has 3 ethnicities (HISPANIC/LATINO, NOT HISPANIC LATINO, UNKNOWN ETHNICITY)

### ******State 2: Cannot Report Ethnicity & Records Hispanic/Latino as Race******

- Answered “No” to this question (**Does your case management system allow you to specify an individual’s ethnicity (Hispanic, Non-Hispanic, or Unknown) for this metric?**)
- Answered “Yes” to (**Which of the following categories does that case management system capture for race?** > **Hispanic/Latino**)
- User can report 9 dimensions [Unknown Race x Hispanic/Latino ethnicity] and [All Races x Not Hispanic/Latino ethnicity]
- Note: if user disables the Unknown Race (equivalent to turning off 2 dimensions:  [**Unknown Race** x **Hispanic/Latino ethnicity**] AND [**Unknown Race** x **Not Hispanic/Latino ethnicity**]) after specifying “No” that they ******Cannot Report Ethnicity,****** then we automatically end up in **************State 3************** because this implies the user is not recording Hispanic/Latino as a race.

### ******State 3: Cannot Report Ethnicity & Does NOT Record Hispanic/Latino as Race******

- Answered “No” to this question (**Does your case management system allow you to specify an individual’s ethnicity (Hispanic, Non-Hispanic, or Unknown) for this metric?**)
- Answered “No” to (**Which of the following categories does that case management system capture for race?** > **Hispanic/Latino**)
- User can report 8 dimensions [All Races x Unknown Ethnicity]

---

### Demo:

https://user-images.githubusercontent.com/59492998/200963006-1699e901-c5b2-465e-bbaf-092e4b19381d.mov

---

### Quick notes for review ease:

  - All of the core functionality of this feature lives in the `MetricConfigStore`, `RaceEthnicities` and `RaceEthnicitiesBreakdown` components. 

  - Everything in the `MetricConfiguration` and `Configuration` conditionally renders the Race/Ethnicities components

  - The `RaceEthnicitiesGridStates` is an object that houses the different grid state truth tables. 

  - The rest are either styling adjustments, typings and adding a constant.

## Related issues

Closes #138 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
