### PR TITLE
[Frontend][Publisher][Bug] Fix metric count in header inside review page

### DIFF
--- a/publisher/src/components/Reports/PublishConfirmation.tsx
+++ b/publisher/src/components/Reports/PublishConfirmation.tsx
@@ -220,7 +220,8 @@ const PublishConfirmation: React.FC<{
   useEffect(() => {
     const { metrics, isPublishable: publishable } =
       formStore.validateAndGetAllMetricFormValues(reportID);
-    setMetricsPreview(metrics);
+    const enabledMetrics = metrics.filter((metric) => metric.enabled);
+    setMetricsPreview(enabledMetrics);
     setIsPublishable(publishable);
   }, [formStore, reportID]);
 
@@ -251,25 +252,17 @@ const PublishConfirmation: React.FC<{
         </ConfirmationButtonsContainer>
       </DataUploadHeader>
       <ConfirmationDialogueWrapper>
-        <MetricsPreviewWrapper>
-          <Heading>
-            {metricsPreview && (
-              <>
-                Review <span>{metricsPreview.length}</span> Metrics
-              </>
-            )}
-          </Heading>
-          <Subheading>
-            {metricsPreview && (
-              <>
-                Before publishing, take a moment to review the changes. You must
-                resolve any errors before publishing; otherwise, you can save
-                this report and return at another time.
-              </>
-            )}
-          </Subheading>
-          {metricsPreview &&
-            metricsPreview.map((metric, i) => {
+        {metricsPreview && (
+          <MetricsPreviewWrapper>
+            <Heading>
+              Review <span>{metricsPreview.length}</span> Metrics
+            </Heading>
+            <Subheading>
+              Before publishing, take a moment to review the changes. You must
+              resolve any errors before publishing; otherwise, you can save this
+              report and return at another time.
+            </Subheading>
+            {metricsPreview.map((metric, i) => {
               return (
                 metric.enabled && (
                   <MetricsDisplay
@@ -281,7 +274,8 @@ const PublishConfirmation: React.FC<{
                 )
               );
             })}
-        </MetricsPreviewWrapper>
+          </MetricsPreviewWrapper>
+        )}
       </ConfirmationDialogueWrapper>
     </>
   );


### PR DESCRIPTION
## Description of the change

> Fix metrics count at header of review page (without disabled ones)

## Type: Bug

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Closes #145 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
