### PR TITLE
[Justice Counts] Fix data entry form bug when navigating back from publish confirm page

### DIFF
--- a/publisher/src/components/Reports/DataEntryForm.tsx
+++ b/publisher/src/components/Reports/DataEntryForm.tsx
@@ -179,11 +179,6 @@ const DataEntryForm: React.FC<{
     []
   );
 
-  useEffect(() => {
-    /** Runs validation of previously saved inputs on load */
-    formStore.validatePreviouslySavedInputs(reportID);
-  }, [formStore, reportID]);
-
   const saveUpdatedMetrics = async (metricKey?: string | undefined) => {
     const updatedMetrics = formStore.reportUpdatedValuesForBackend(
       reportID,

--- a/publisher/src/components/Reports/PublishConfirmation.tsx
+++ b/publisher/src/components/Reports/PublishConfirmation.tsx
@@ -28,7 +28,6 @@ import { useNavigate } from "react-router-dom";
 
 import { trackReportPublished } from "../../analytics";
 import { useStore } from "../../stores";
-import FormStore from "../../stores/FormStore";
 import { printReportTitle } from "../../utils";
 import logoImg from "../assets/jc-logo-vector.png";
 import errorIcon from "../assets/status-error-icon.png";
@@ -169,7 +168,7 @@ const MetricsDisplay: React.FC<{
 
 const PublishConfirmation: React.FC<{
   reportID: number;
-  checkMetricForErrors: (metricKey: string, formStore: FormStore) => boolean;
+  checkMetricForErrors: (metricKey: string) => boolean;
   toggleConfirmationDialogue: () => void;
 }> = ({ reportID, checkMetricForErrors, toggleConfirmationDialogue }) => {
   const [isPublishable, setIsPublishable] = useState(false);
@@ -275,7 +274,7 @@ const PublishConfirmation: React.FC<{
                   <MetricsDisplay
                     key={metric.key}
                     metric={metric}
-                    metricHasError={checkMetricForErrors(metric.key, formStore)}
+                    metricHasError={checkMetricForErrors(metric.key)}
                     index={i}
                   />
                 )

--- a/publisher/src/components/Reports/PublishConfirmationSummaryPanel.tsx
+++ b/publisher/src/components/Reports/PublishConfirmationSummaryPanel.tsx
@@ -20,7 +20,6 @@ import { observer } from "mobx-react-lite";
 import React from "react";
 
 import { useStore } from "../../stores";
-import FormStore from "../../stores/FormStore";
 import checkIcon from "../assets/check-icon.svg";
 import errorIcon from "../assets/status-error-icon.png";
 import { MetricsSectionTitle } from "../Forms";
@@ -61,7 +60,7 @@ const ReportStatusIconComponent: React.FC<{
 
 const PublishConfirmationSummaryPanel: React.FC<{
   reportID: number;
-  checkMetricForErrors: (metricKey: string, formStore: FormStore) => boolean;
+  checkMetricForErrors: (metricKey: string) => boolean;
 }> = ({ reportID, checkMetricForErrors }) => {
   const { formStore, reportStore } = useStore();
 
@@ -80,7 +79,7 @@ const PublishConfirmationSummaryPanel: React.FC<{
                 <MetricsSectionTitle>{system}</MetricsSectionTitle>
               )}
               {enabledMetrics.map((metric) => {
-                const foundErrors = checkMetricForErrors(metric.key, formStore);
+                const foundErrors = checkMetricForErrors(metric.key);
 
                 return (
                   <ReportStatusIconComponent

--- a/publisher/src/components/Reports/ReportDataEntry.tsx
+++ b/publisher/src/components/Reports/ReportDataEntry.tsx
@@ -29,7 +29,6 @@ import styled from "styled-components/macro";
 
 import { trackReportUnpublished } from "../../analytics";
 import { useStore } from "../../stores";
-import FormStore from "../../stores/FormStore";
 import { printReportTitle } from "../../utils";
 import { PageWrapper } from "../Forms";
 import { Loading } from "../Loading";
@@ -62,7 +61,7 @@ const ReportDataEntry = () => {
   >(undefined);
   const [showConfirmation, setShowConfirmation] = useState(false);
   const [showDataEntryHelpPage, setShowDataEntryHelpPage] = useState(false);
-  const { reportStore, userStore } = useStore();
+  const { formStore, reportStore, userStore } = useStore();
   const params = useParams();
   const reportID = Number(params.id);
   const reportOverview = reportStore.reportOverviews[reportID] as Report;
@@ -103,7 +102,7 @@ const ReportDataEntry = () => {
     }
   };
 
-  const checkMetricForErrors = (metricKey: string, formStore: FormStore) => {
+  const checkMetricForErrors = (metricKey: string) => {
     let foundErrors = false;
 
     if (formStore.metricsValues[reportID]?.[metricKey]?.error) {
@@ -154,6 +153,13 @@ const ReportDataEntry = () => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     []
   );
+
+  useEffect(() => {
+    /** Runs validation of previously saved inputs on load */
+    if (reportMetrics) {
+      formStore.validatePreviouslySavedInputs(reportID);
+    }
+  }, [reportMetrics]);
 
   const updateActiveMetric = (metricKey: string) => setActiveMetric(metricKey);
   const updateFieldDescription = (title?: string, description?: string) => {

--- a/publisher/src/components/Reports/ReportDataEntry.tsx
+++ b/publisher/src/components/Reports/ReportDataEntry.tsx
@@ -159,6 +159,7 @@ const ReportDataEntry = () => {
     if (reportMetrics) {
       formStore.validatePreviouslySavedInputs(reportID);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [reportMetrics]);
 
   const updateActiveMetric = (metricKey: string) => setActiveMetric(metricKey);

--- a/publisher/src/components/Reports/ReportSummaryPanel.tsx
+++ b/publisher/src/components/Reports/ReportSummaryPanel.tsx
@@ -26,7 +26,6 @@ import React from "react";
 import styled from "styled-components/macro";
 
 import { useStore } from "../../stores";
-import FormStore from "../../stores/FormStore";
 import {
   printCommaSeparatedList,
   printDateRangeFromMonthYear,
@@ -226,7 +225,7 @@ const ReportStatusIconComponent: React.FC<{
 const ReportSummaryPanel: React.FC<{
   reportID: number;
   activeMetric: string;
-  checkMetricForErrors: (metricKey: string, formStore: FormStore) => boolean;
+  checkMetricForErrors: (metricKey: string) => boolean;
   showDataEntryHelpPage: boolean;
   fieldDescription?: FieldDescriptionProps;
 }> = ({
@@ -262,7 +261,7 @@ const ReportSummaryPanel: React.FC<{
                 <MetricsSectionTitle>{system}</MetricsSectionTitle>
               ) : null}
               {enabledMetrics.map((metric) => {
-                const foundErrors = checkMetricForErrors(metric.key, formStore);
+                const foundErrors = checkMetricForErrors(metric.key);
 
                 return (
                   <ReportStatusIconComponent


### PR DESCRIPTION
## Description of the change

See video for reproducing the bug here: https://app.zenhub.com/workspaces/justice-counts--622109ea3bb6e0001d2d06ad/issues/recidiviz/recidiviz-data/16570

This bug is caused by `formStore.validatePreviouslySavedInputs` being called when the user is navigating from the Publish Confirm page back to the data entry page, which replaces all user inputs with what was originally fetched from the server when the data entry page was first loaded.

The `DataEntryForm` component gets unmounted and remounted when navigating to and away from the Publish Confirm page, which causes `formStore.validatePreviouslySavedInputs` to get triggered. I believe `formStore.validatePreviouslySavedInputs` is intended to be triggered once on loading the data entry page and not when navigating from Publish Confirm back to the Data Entry Form.

My solution is to move the `formStore.validatePreviouslySavedInputs` trigger out of the `DataEntryForm` component and into the parent `ReportDataEntry` component. The parent component is loaded once when the data entry page is loaded, and calls `formStore.validatePreviouslySavedInputs`. It doesn't get called again until the user navigates away from the data entry section entirely. 

## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Closes #152

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
