### PR TITLE
include FY/CY details for annual reports

### DIFF
--- a/publisher/src/components/Reports/CreateReport.test.tsx
+++ b/publisher/src/components/Reports/CreateReport.test.tsx
@@ -83,7 +83,7 @@ test("displayed created reports", async () => {
     });
   });
 
-  const annualReport2020 = screen.getByText(/Annual Report 2020/i);
+  const annualReport2020 = screen.getByText(/Annual Report FY2020-2021/i);
   const editor2 = screen.getByText(/Editor #2/i);
 
   expect(annualReport2020).toBeInTheDocument();

--- a/publisher/src/pages/Reports.tsx
+++ b/publisher/src/pages/Reports.tsx
@@ -51,6 +51,7 @@ import {
   normalizeString,
   printCommaSeparatedList,
   printElapsedDaysMonthsYearsSinceDate,
+  printReportFrequency,
   printReportTitle,
   removeSnakeCase,
 } from "../utils";
@@ -217,7 +218,9 @@ const Reports: React.FC = () => {
                   </Cell>
 
                   {/* Status */}
-                  <Cell capitalize>{report.frequency.toLowerCase()}</Cell>
+                  <Cell capitalize>
+                    {printReportFrequency(report.month, report.frequency)}
+                  </Cell>
 
                   {/* Editors */}
                   <Cell

--- a/publisher/src/stores/ReportStore.test.tsx
+++ b/publisher/src/stores/ReportStore.test.tsx
@@ -102,7 +102,9 @@ test("displayed reports", async () => {
   // Arbitrary report dates included in mockJSON
   const april2022 = await screen.findByText(/April 2022/i);
   const december2020 = await screen.findByText(/December 2020/i);
-  const annualReport2019 = await screen.findByText(/Annual Report 2019/i);
+  const annualReport2019 = await screen.findByText(
+    /Annual Report FY2019-2020/i
+  );
   expect(april2022).toBeInTheDocument();
   expect(december2020).toBeInTheDocument();
   expect(annualReport2019).toBeInTheDocument();

--- a/publisher/src/utils/dateUtils.ts
+++ b/publisher/src/utils/dateUtils.ts
@@ -44,8 +44,9 @@ export const printDateAsMonthYear = (month: number, year: number): string => {
 };
 
 /**
- * @returns either "Annual Report [YEAR]" or "[MONTH] [YEAR]" as a string depending on frequency
- * @example "Annual Report 2022" or "March 2022"
+ * @returns either "Annual Report CY[YEAR]", "Annual Report FY[YEAR]-[YEAR+1]" or "[MONTH] [YEAR]"
+ * as a string depending on frequency.
+ * @example "Annual Report CY2022" "Annual Report FY2022-2023" or "March 2022"
  */
 export const printReportTitle = (
   month: number,
@@ -53,10 +54,31 @@ export const printReportTitle = (
   frequency: ReportFrequency
 ): string => {
   if (frequency === "ANNUAL") {
-    return `Annual Report ${year}`;
+    if (month === 1) {
+      // CY stands for Calendar Year
+      return `Annual Report CY${year}`;
+    }
+    // FY stands for Fiscal Year
+    return `Annual Report FY${year}-${year + 1}`;
   }
 
   return printDateAsMonthYear(month, year);
+};
+
+/**
+ * @returns either "Annual", "Annual ([MONTH])" or "Monthly"
+ * as a string depending on frequency
+ * @example "Annual" "Annual (October)" or "March 2022"
+ */
+export const printReportFrequency = (
+  month: number,
+  frequency: ReportFrequency
+): string => {
+  if (frequency === "ANNUAL" && month !== 1) {
+    return `${frequency.toLowerCase()} (${monthsByName[month]})`;
+  }
+
+  return frequency.toLowerCase();
 };
 
 /**


### PR DESCRIPTION
## Description of the change

This PR adds details about if the annual report represents a calendar or fiscal year in the reports overview page.

<img width="1728" alt="Screen Shot 2022-11-15 at 1 29 26 PM" src="https://user-images.githubusercontent.com/19961693/202008913-869afd04-c6df-4b60-b42b-2e93fd9e2128.png">

## Related issues

Related to #16219

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
