### PR TITLE
revert eslint rule to disable requiring react in jsx scope

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -3,7 +3,5 @@ module.exports = {
   plugins: ["header"],
   rules: {
     "header/header": [2, "../license-header.js"],
-    "react/jsx-uses-react": "off",
-    "react/react-in-jsx-scope": "off",
   },
 };

--- a/agency-dashboard/src/AgencyOverview.test.tsx
+++ b/agency-dashboard/src/AgencyOverview.test.tsx
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 import { render, screen } from "@testing-library/react";
+import React from "react";
 import { MemoryRouter } from "react-router-dom";
 
 import AgencyOverview from "./AgencyOverview";

--- a/agency-dashboard/src/AgencyOverview.tsx
+++ b/agency-dashboard/src/AgencyOverview.tsx
@@ -17,7 +17,7 @@
 
 import { showToast } from "@justice-counts/common/components/Toast";
 import { observer } from "mobx-react-lite";
-import { useEffect } from "react";
+import React, { useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { MetricCategory } from "./AgencyOverview.styles";

--- a/agency-dashboard/src/App.tsx
+++ b/agency-dashboard/src/App.tsx
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+import React from "react";
 import { Route, Routes } from "react-router-dom";
 
 import AgencyOverview from "./AgencyOverview";

--- a/agency-dashboard/src/DashboardView.test.tsx
+++ b/agency-dashboard/src/DashboardView.test.tsx
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 import { render, screen } from "@testing-library/react";
+import React from "react";
 import { MemoryRouter } from "react-router-dom";
 
 import DashboardView from "./DashboardView";


### PR DESCRIPTION
## Description of the change

This PR reverts the configuration change made [here](https://github.com/Recidiviz/justice-counts/pull/111)

When we turn off `react/react-in-jsx-scope`, the eslint rule doesn't seem to stay off for some reason. If I start `yarn dev` in a new tab, usually we get no errors, but when modifying a file and recompiling, we start getting `react/react-in-jsx-scope` errors again. I'm at a loss as to why this is happening, and by now we've reimported React in most of our files to get around this issue. 

So this PR just reinstates these rules.

## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Closes #XXXX

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
