### PR TITLE
display report creation error when there are overlapping report dates

### DIFF
--- a/publisher/src/components/Reports/CreateReport.tsx
+++ b/publisher/src/components/Reports/CreateReport.tsx
@@ -155,8 +155,12 @@ const CreateReport = () => {
         trackReportCreated(report.id, agency);
         return;
       }
-      if (response.status === 400) {
-        const responseJson = await response.json();
+      const responseJson = await response.json();
+      if (
+        responseJson.description.includes(
+          "A report of that date range has already been created."
+        )
+      ) {
         showToast(responseJson.description, false, "red");
         return;
       }


### PR DESCRIPTION
## Description of the change

When creating reports with the same start and end date, I was seeing a generic response. This PR makes a change in the FE where we now check what the description is before displaying the toast. We deprecated all api responses that were not 500 because only 500 responses show up in our logs. As a result, the check to see if the response code is 400 to display the toast with the specific error date error was always ignored.


https://user-images.githubusercontent.com/19961693/202267336-91582317-8d70-44ab-b519-a69f39e1aad9.mov


## Related issues

Closes #XXXX

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
