### PR TITLE
add month name to all annual frequencies

### DIFF
--- a/publisher/src/utils/dateUtils.ts
+++ b/publisher/src/utils/dateUtils.ts
@@ -74,7 +74,7 @@ export const printReportFrequency = (
   month: number,
   frequency: ReportFrequency
 ): string => {
-  if (frequency === "ANNUAL" && month !== 1) {
+  if (frequency === "ANNUAL") {
     return `${frequency.toLowerCase()} (${monthsByName[month - 1]})`;
   }
 


### PR DESCRIPTION
## Description of the change

This PR is a follow-up to playtesting. Now all annual frequencies will have the name of the month provided, not just fiscal years. 

<img width="1582" alt="Screen Shot 2022-11-18 at 2 53 54 PM" src="https://user-images.githubusercontent.com/19961693/202800600-1c5ec06d-4306-4677-a246-ad66e0441f83.png">

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
