### PR TITLE
update metric settings badges to reflect custom reporting frequency

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -106,6 +106,7 @@ export interface Metric {
   enabled?: boolean;
   settings?: MetricConfigurationSettings[];
   frequency?: ReportFrequency;
+  custom_frequency?: ReportFrequency;
 }
 
 export interface MetricDefinition {

--- a/publisher/src/components/MetricConfiguration/MetricBox.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricBox.tsx
@@ -32,6 +32,7 @@ type MetricBoxProps = {
   metricKey: string;
   displayName: string;
   frequency: ReportFrequency;
+  customFrequency: ReportFrequency;
   description: string;
   enabled?: boolean;
 };
@@ -41,6 +42,7 @@ export const MetricBox: React.FC<MetricBoxProps> = observer(
     metricKey,
     displayName,
     frequency,
+    customFrequency,
     description,
     enabled,
   }): JSX.Element => {
@@ -50,7 +52,9 @@ export const MetricBox: React.FC<MetricBoxProps> = observer(
     const handleMetricBoxClick = () => {
       setSettingsSearchParams({ ...settingsSearchParams, metric: metricKey });
     };
-
+    const displayFrequency = customFrequency
+      ? customFrequency.toLowerCase()
+      : frequency.toLowerCase();
     return (
       <MetricBoxContainer onClick={handleMetricBoxClick} enabled={enabled}>
         <MetricName>{displayName}</MetricName>
@@ -61,7 +65,7 @@ export const MetricBox: React.FC<MetricBoxProps> = observer(
             disabled={!enabled}
             noMargin
           >
-            {!enabled ? "Inactive" : frequency.toLowerCase()}
+            {!enabled ? "Inactive" : displayFrequency}
           </Badge>
         </MetricNameBadgeWrapper>
       </MetricBoxContainer>

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -192,6 +192,9 @@ export const MetricConfiguration: React.FC = observer(() => {
                       metricKey={key}
                       displayName={metric.label as string}
                       frequency={metric.frequency as ReportFrequency}
+                      customFrequency={
+                        metric.customFrequency as ReportFrequency
+                      }
                       description={metric.description as string}
                       enabled={metric.enabled}
                     />
@@ -222,7 +225,11 @@ export const MetricConfiguration: React.FC = observer(() => {
                     {metrics[systemMetricKey]?.label}
                   </MetricName>
                   <Badge color="GREEN" noMargin>
-                    {metrics[systemMetricKey]?.frequency?.toLowerCase()}
+                    {metrics[systemMetricKey]?.customFrequency
+                      ? metrics[
+                          systemMetricKey
+                        ]?.customFrequency?.toLocaleLowerCase()
+                      : metrics[systemMetricKey]?.frequency?.toLowerCase()}
                   </Badge>
                   <RightArrowIcon />
                 </Metric>

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -56,6 +56,7 @@ class MetricConfigStore {
       label?: string;
       description?: Metric["description"];
       frequency?: Metric["frequency"];
+      customFrequency?: Metric["custom_frequency"];
     };
   };
 
@@ -165,6 +166,7 @@ class MetricConfigStore {
             label?: string;
             description?: Metric["description"];
             frequency?: Metric["frequency"];
+            customFrequency?: Metric["custom_frequency"];
           };
         }[]
       );
@@ -242,6 +244,7 @@ class MetricConfigStore {
               label: metric.label,
               description: metric.description,
               frequency: metric.frequency || "",
+              customFrequency: metric.custom_frequency || "",
             }
           );
 
@@ -346,6 +349,8 @@ class MetricConfigStore {
       this.metrics[systemMetricKey].description = metadata.description;
       this.metrics[systemMetricKey].frequency =
         metadata.frequency as ReportFrequency;
+      this.metrics[systemMetricKey].customFrequency =
+        metadata.customFrequency as ReportFrequency;
     }
 
     /** Update value */


### PR DESCRIPTION
## Description of the change

This PR updates the badges used in the metric settings pages so that they reflect the custom reporting frequency of a metric if the custom frequency is not `undefined`.

The default reporting frequency for `Civilians Complaints Sustained` is annual, but a custom reporting frequency has been added such that it is now reported monthly. 

<img width="905" alt="Screen Shot 2022-11-21 at 2 05 31 PM" src="https://user-images.githubusercontent.com/19961693/203148686-a40e3894-4274-4e11-b105-6b3b7b1053cf.png">

<img width="691" alt="Screen Shot 2022-11-21 at 2 05 33 PM" src="https://user-images.githubusercontent.com/19961693/203148543-99614489-16d8-4135-90a8-9a8437e31652.png">

## Related issues

Related to #16218

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
