### PR TITLE
Race & Ethnicities (Playtesting Followup): Debounce Saving & Send All Dimensions

### DIFF
--- a/publisher/src/components/Forms/BinaryRadioButton.tsx
+++ b/publisher/src/components/Forms/BinaryRadioButton.tsx
@@ -20,7 +20,7 @@ import {
   typography,
 } from "@justice-counts/common/components/GlobalStyles";
 import React, { InputHTMLAttributes } from "react";
-import styled from "styled-components/macro";
+import styled, { css } from "styled-components/macro";
 
 export const BinaryRadioGroupContainer = styled.div`
   display: flex;
@@ -43,7 +43,7 @@ export const BinaryRadioGroupQuestion = styled.div`
   color: ${palette.solid.darkgrey};
 `;
 
-export const RadioButtonWrapper = styled.div`
+export const RadioButtonWrapper = styled.div<{ lastOptionBlue?: boolean }>`
   display: flex;
   flex: 1 1 0;
   margin: 15px 0 0 0;
@@ -51,6 +51,22 @@ export const RadioButtonWrapper = styled.div`
   &:first-child {
     margin: 15px 10px 0 0;
   }
+
+  ${({ lastOptionBlue }) =>
+    lastOptionBlue &&
+    css`
+      margin: 0;
+
+      &:first-child {
+        margin: 0px 10px 0 0;
+      }
+
+      &:first-child input:checked + label {
+        background-color: ${palette.highlight.grey9};
+        border-color: unset;
+        color: ${palette.solid.white};
+      }
+    `}
 `;
 
 export const RadioButtonElement = styled.input<{
@@ -83,6 +99,7 @@ export const RadioButtonElement = styled.input<{
 
 export const RadioButtonLabel = styled.label<{
   disabled?: boolean;
+  buttonSize?: string;
 }>`
   ${typography.sizeCSS.medium}
   width: 100%;
@@ -100,6 +117,16 @@ export const RadioButtonLabel = styled.label<{
     background-color: ${({ disabled }) =>
       disabled ? "none" : palette.highlight.grey2};
   }
+
+  ${({ buttonSize }) =>
+    buttonSize === "small" &&
+    css`
+      ${typography.sizeCSS.normal}
+      width: unset;
+      height: unset;
+      min-width: 60px;
+      padding: 9px 16px;
+    `}
 `;
 
 export const BinaryRadioGroupClearButton = styled.div<{
@@ -119,6 +146,8 @@ interface RadioButtonProps extends InputHTMLAttributes<HTMLInputElement> {
   label: string;
   context?: string;
   metricKey?: string;
+  buttonSize?: string;
+  lastOptionBlue?: boolean;
 }
 
 /** Single radio button in the style of a regular button */
@@ -127,16 +156,22 @@ export const BinaryRadioButton: React.FC<RadioButtonProps> = ({
   context,
   metricKey,
   disabled,
+  buttonSize,
+  lastOptionBlue,
   ...props
 }): JSX.Element => {
   return (
-    <RadioButtonWrapper>
+    <RadioButtonWrapper lastOptionBlue={lastOptionBlue}>
       <RadioButtonElement
         disabled={disabled}
         {...props}
         data-metric-key={metricKey}
       />
-      <RadioButtonLabel disabled={disabled} htmlFor={props.id}>
+      <RadioButtonLabel
+        disabled={disabled}
+        buttonSize={buttonSize}
+        htmlFor={props.id}
+      >
         {label}
       </RadioButtonLabel>
     </RadioButtonWrapper>

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -686,7 +686,6 @@ class MetricConfigStore {
           ...acc[dimension.race],
           [dimension.ethnicity]: dimension,
         };
-
         return acc;
       },
       {} as {
@@ -718,7 +717,6 @@ class MetricConfigStore {
       state === "NO_ETHNICITY_HISPANIC_AS_RACE" && unknownRaceDisabled
         ? "NO_ETHNICITY_HISPANIC_NOT_SPECIFIED"
         : state;
-    const updatedDimensions = [] as UpdatedDimension[];
 
     /**
      * When Unknown Race dimensions are disabled AND user is switching to NO_ETHNICITY_HISPANIC_AS_RACE state,
@@ -727,18 +725,6 @@ class MetricConfigStore {
     if (unknownRaceDisabled && state === "NO_ETHNICITY_HISPANIC_AS_RACE") {
       ethnicitiesByRace.Unknown.Hispanic.enabled = true;
       ethnicitiesByRace.Unknown["Not Hispanic"].enabled = true;
-      updatedDimensions.push(
-        ...[
-          {
-            ...ethnicitiesByRace.Unknown.Hispanic,
-            enabled: true,
-          },
-          {
-            ...ethnicitiesByRace.Unknown["Not Hispanic"],
-            enabled: true,
-          },
-        ]
-      );
       sanitizedState = state;
     }
 
@@ -770,21 +756,22 @@ class MetricConfigStore {
           ethnicitiesByRace[race][ethnicity].key,
           gridStates[sanitizedState][race][ethnicity]
         );
-
-        updatedDimensions.push({
-          ...ethnicitiesByRace[race][ethnicity],
-          enabled: gridStates[sanitizedState][race][ethnicity],
-        });
       });
     });
 
-    /** Return array of dimensions that were updated */
+    const raceEthnicitiesDimensions =
+      this.dimensions[systemMetricKey][RACE_ETHNICITY_DISAGGREGATION_KEY];
+    const dimensions =
+      raceEthnicitiesDimensions &&
+      (Object.values(raceEthnicitiesDimensions) as UpdatedDimension[]);
+
+    /** Return an object w/ all dimensions in the desired backend data structure for saving purposes */
     return {
       key: metricKey,
       disaggregations: [
         {
           key: RACE_ETHNICITY_DISAGGREGATION_KEY,
-          dimensions: updatedDimensions,
+          dimensions,
         },
       ],
     };
@@ -799,7 +786,6 @@ class MetricConfigStore {
     metricKey: string
   ): UpdatedDisaggregation => {
     const ethnicitiesByRace = this.getEthnicitiesByRace(system, metricKey);
-    const updatedDimensions = [] as UpdatedDimension[];
 
     ethnicities.forEach((ethnicity) => {
       /** No update if intended update matches the current state (e.g. enabling an already enabled dimension) */
@@ -819,17 +805,25 @@ class MetricConfigStore {
         ethnicitiesByRace[race][ethnicity].key,
         enabled
       );
-
-      updatedDimensions.push(ethnicitiesByRace[race][ethnicity]);
     });
 
-    /** Return array of dimensions that were updated */
+    const systemMetricKey = MetricConfigStore.getSystemMetricKey(
+      system,
+      metricKey
+    );
+    const raceEthnicitiesDimensions =
+      this.dimensions[systemMetricKey][RACE_ETHNICITY_DISAGGREGATION_KEY];
+    const dimensions =
+      raceEthnicitiesDimensions &&
+      (Object.values(raceEthnicitiesDimensions) as UpdatedDimension[]);
+
+    /** Return an object w/ all dimensions in the desired backend data structure for saving purposes */
     return {
       key: metricKey,
       disaggregations: [
         {
           key: RACE_ETHNICITY_DISAGGREGATION_KEY,
-          dimensions: updatedDimensions,
+          dimensions,
         },
       ],
     };


### PR DESCRIPTION
## Description of the change

Debounce saving and send all 24 dimensions instead of the deltas. Also, optimize saving by using `input`s for the buttons and utilizing `onChange`.

Demo: https://playtesting---justice-counts-web-qqec6jbn6a-uc.a.run.app/

## Related issues

Contributes to #180 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
