### PR TITLE
Race & Ethnicities (Playtesting Followup): Remove Back To Metrics

### DIFF
--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -28,7 +28,6 @@ import { Loading } from "../Loading";
 import { TabbedBar, TabbedItem, TabbedOptions } from "../Reports";
 import { getActiveSystemMetricKey, useSettingsSearchParams } from "../Settings";
 import {
-  BackToMetrics,
   Configuration,
   Metric,
   MetricBox,
@@ -208,15 +207,6 @@ export const MetricConfiguration: React.FC = observer(() => {
             <MetricConfigurationWrapper>
               {/* Metric Configuration */}
               <MetricConfigurationDisplay>
-                <BackToMetrics
-                  onClick={() => {
-                    setSettingsSearchParams({ system: systemSearchParam });
-                    setActiveDimensionKey(undefined);
-                  }}
-                >
-                  ← Back to Metrics
-                </BackToMetrics>
-
                 <Metric
                   onClick={() => setActiveDimensionKey(undefined)}
                   inView={!activeDimensionKey}


### PR DESCRIPTION
## Description of the change

Removes the Back To Metrics link.

Reference:
<img width="441" alt="Screenshot 2022-11-23 at 4 02 41 PM" src="https://user-images.githubusercontent.com/59492998/203653487-ff8673bf-65ba-4b63-a482-9827f78f61a6.png">


## Related issues

Contributes to #180 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
