### PR TITLE
Race & Ethnicities (Playtesting Followup): Grey Out Grid When Disaggregation Is Disabled

### DIFF
--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -230,7 +230,13 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
               {/* Dimension Fields (Enable/Disable) */}
               {/* Race & Ethnicities Grid (when active disaggregation is Race / Ethnicity) */}
               {activeDisaggregationKey === RACE_ETHNICITY_DISAGGREGATION_KEY ? (
-                <RaceEthnicitiesGrid />
+                <RaceEthnicitiesGrid
+                  disaggregationEnabled={Boolean(
+                    disaggregations[systemMetricKey][
+                      RACE_ETHNICITY_DISAGGREGATION_KEY
+                    ]?.enabled
+                  )}
+                />
               ) : (
                 activeDimensionKeys?.map((dimensionKey) => {
                   const currentDisaggregation =

--- a/publisher/src/components/MetricConfiguration/RaceEthnicities.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicities.styles.tsx
@@ -19,7 +19,7 @@ import {
   palette,
   typography,
 } from "@justice-counts/common/components/GlobalStyles";
-import styled from "styled-components/macro";
+import styled, { css } from "styled-components/macro";
 
 import {
   DefinitionDisplayName,
@@ -34,8 +34,26 @@ import {
   MetricOnOffWrapper,
 } from ".";
 
-export const RaceEthnicitiesBreakdownContainer = styled.div`
+export const RaceEthnicitiesBreakdownContainer = styled.div<{
+  disaggregationEnabled?: boolean;
+}>`
   padding-top: 14px;
+  position: relative;
+
+  ${({ disaggregationEnabled }) =>
+    !disaggregationEnabled &&
+    css`
+      &::after {
+        content: "";
+        position: absolute;
+        top: 0;
+        left: 0;
+        height: 100%;
+        width: 100%;
+        background: ${palette.solid.white};
+        opacity: 0.5;
+      }
+    `}
 `;
 
 export const CalloutBox = styled.div`

--- a/publisher/src/components/MetricConfiguration/RaceEthnicitiesGrid.tsx
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicitiesGrid.tsx
@@ -36,47 +36,50 @@ import {
   RaceEthnicitiesTable,
 } from ".";
 
-export const RaceEthnicitiesGrid: React.FC = observer(() => {
-  const { metricConfigStore } = useStore();
-  const { ethnicitiesByRace } = metricConfigStore;
+export const RaceEthnicitiesGrid: React.FC<{ disaggregationEnabled: boolean }> =
+  observer(({ disaggregationEnabled }) => {
+    const { metricConfigStore } = useStore();
+    const { ethnicitiesByRace } = metricConfigStore;
 
-  return (
-    <RaceEthnicitiesBreakdownContainer>
-      <CalloutBox>
-        <Description>
-          Answer the questions on the <span>Race and Ethnicity</span> form; the
-          grid below will reflect your responses.
-        </Description>
-        <RightArrowIcon />
-      </CalloutBox>
+    return (
+      <RaceEthnicitiesBreakdownContainer
+        disaggregationEnabled={disaggregationEnabled}
+      >
+        <CalloutBox>
+          <Description>
+            Answer the questions on the <span>Race and Ethnicity</span> form;
+            the grid below will reflect your responses.
+          </Description>
+          <RightArrowIcon />
+        </CalloutBox>
 
-      <GridHeaderContainer>
-        <GridRaceHeader>Race</GridRaceHeader>
-        <GridEthnicitiesHeader>
-          <EthnicityLabel>
-            Ethnicity <RightArrowIcon />
-          </EthnicityLabel>
-          <Ethnicity>Hispanic</Ethnicity>
-          <Ethnicity>Not Hispanic</Ethnicity>
-          <Ethnicity>Unknown</Ethnicity>
-        </GridEthnicitiesHeader>
-      </GridHeaderContainer>
+        <GridHeaderContainer>
+          <GridRaceHeader>Race</GridRaceHeader>
+          <GridEthnicitiesHeader>
+            <EthnicityLabel>
+              Ethnicity <RightArrowIcon />
+            </EthnicityLabel>
+            <Ethnicity>Hispanic</Ethnicity>
+            <Ethnicity>Not Hispanic</Ethnicity>
+            <Ethnicity>Unknown</Ethnicity>
+          </GridEthnicitiesHeader>
+        </GridHeaderContainer>
 
-      <RaceEthnicitiesTable>
-        {Object.entries(ethnicitiesByRace).map(([race, ethnicities]) => (
-          <RaceEthnicitiesRow key={race}>
-            <RaceCell>{race}</RaceCell>
-            <EthnicitiesRow>
-              {Object.values(ethnicities).map((ethnicity) => (
-                <EthnicityCell
-                  key={ethnicity.key}
-                  enabled={ethnicity.enabled}
-                />
-              ))}
-            </EthnicitiesRow>
-          </RaceEthnicitiesRow>
-        ))}
-      </RaceEthnicitiesTable>
-    </RaceEthnicitiesBreakdownContainer>
-  );
-});
+        <RaceEthnicitiesTable>
+          {Object.entries(ethnicitiesByRace).map(([race, ethnicities]) => (
+            <RaceEthnicitiesRow key={race}>
+              <RaceCell>{race}</RaceCell>
+              <EthnicitiesRow>
+                {Object.values(ethnicities).map((ethnicity) => (
+                  <EthnicityCell
+                    key={ethnicity.key}
+                    enabled={ethnicity.enabled}
+                  />
+                ))}
+              </EthnicitiesRow>
+            </RaceEthnicitiesRow>
+          ))}
+        </RaceEthnicitiesTable>
+      </RaceEthnicitiesBreakdownContainer>
+    );
+  });


### PR DESCRIPTION
## Description of the change

When disaggregation is disabled, the grid area is grey'd-out.

Demo:

https://user-images.githubusercontent.com/59492998/203653152-10446df7-54bb-4123-a60e-d8cd5254feb1.mov

## Related issues

Contributes to #180

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
