### PR TITLE
Race & Ethnicities (Playtesting Followup): Group Races by Ethnicities in Data Entry Publish Confirmation

### DIFF
--- a/publisher/src/components/Reports/PublishConfirmation.styles.tsx
+++ b/publisher/src/components/Reports/PublishConfirmation.styles.tsx
@@ -20,7 +20,7 @@ import {
   palette,
   typography,
 } from "@justice-counts/common/components/GlobalStyles";
-import styled from "styled-components/macro";
+import styled, { css } from "styled-components/macro";
 
 import { Button } from "../DataUpload";
 import {
@@ -190,10 +190,16 @@ export const MetricDetailWrapper = styled.div<{ isExpanded: boolean }>`
   display: ${({ isExpanded }) => (isExpanded ? "block" : "none")};
 `;
 
-export const MetricSubTitleContainer = styled.div`
+export const MetricSubTitleContainer = styled.div<{ secondary?: boolean }>`
   ${typography.sizeCSS.small}
   margin-bottom: 16px;
   margin-top: 16px;
+  ${({ secondary }) =>
+    secondary &&
+    css`
+      color: ${palette.highlight.grey7};
+      margin-bottom: 8px;
+    `}
 `;
 
 export const Breakdown = styled.div<{ missing?: boolean }>`


### PR DESCRIPTION
## Description of the change

Cleans up the Data Entry Publish Confirmation rendering of the Race & Ethnicities dimensions by grouping the dimensions by ethnicity w/ respective headers. 

The disaggregation headers are already an incredibly small font size and I couldn't reasonably go smaller for the ethnicity headers - so I opted to keep them the same size but with a grey font color. Not sure if it's clear or confusing - would love some design help or your ideas if unclear.


Demo:

https://user-images.githubusercontent.com/59492998/203653011-35d52c6a-9a5b-42ae-9098-ba4784318e8c.mov


## Related issues

Contributes to #180

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
