### PR TITLE
[Fix] Settings: Metric Configuration Link

### DIFF
--- a/publisher/src/components/Settings/SettingsMenu.tsx
+++ b/publisher/src/components/Settings/SettingsMenu.tsx
@@ -54,6 +54,9 @@ export const SettingsMenu: React.FC = observer(() => {
           <MenuItem
             selected={location.pathname === path}
             onClick={() => {
+              if (displayName === "Metric Configuration") {
+                return navigate(`${path}?system=${systemSearchParam}`);
+              }
               navigate(path);
             }}
           >

--- a/publisher/src/components/Settings/SettingsMenu.tsx
+++ b/publisher/src/components/Settings/SettingsMenu.tsx
@@ -54,7 +54,7 @@ export const SettingsMenu: React.FC = observer(() => {
           <MenuItem
             selected={location.pathname === path}
             onClick={() => {
-              if (displayName === "Metric Configuration") {
+              if (path === "/settings/metric-config") {
                 return navigate(`${path}?system=${systemSearchParam}`);
               }
               navigate(path);


### PR DESCRIPTION
## Description of the change

Terry pointed out an issue with the Metric Configuration link in the Settings side menu where it shows up nothing when clicked (after you've selected a metric). After debugging, it looks like it navigates back to `/settings/metric-config` without the additional params. The solution is to update the Settings menu navigation to include the system params for the Metric Configuration link.

## Related issues

Closes #XXXX

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
