### PR TITLE
Race & Ethnicities: Replace activeMetricKey and activeSystem with URL params

### DIFF
--- a/publisher/src/components/MetricConfiguration/RaceEthnicitiesForm.tsx
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicitiesForm.tsx
@@ -20,6 +20,7 @@ import React from "react";
 
 import { useStore } from "../../stores";
 import { BinaryRadioButton } from "../Forms";
+import { useSettingsSearchParams } from "../Settings";
 import {
   Header,
   Race,
@@ -38,13 +39,21 @@ import {
 } from ".";
 
 export const RaceEthnicitiesForm = observer(() => {
+  const [settingsSearchParams] = useSettingsSearchParams();
   const { metricConfigStore } = useStore();
   const {
-    ethnicitiesByRace,
+    getEthnicitiesByRace,
     updateAllRaceEthnicitiesToDefaultState,
     updateRaceDimensions,
     saveMetricSettings,
   } = metricConfigStore;
+  const { system: systemSearchParam, metric: metricSearchParam } =
+    settingsSearchParams;
+  const ethnicitiesByRace =
+    (systemSearchParam &&
+      metricSearchParam &&
+      getEthnicitiesByRace(systemSearchParam, metricSearchParam)) ||
+    {};
   const ethnicitiesByRaceArray = Object.entries(ethnicitiesByRace);
 
   const canSpecifyEthnicity =
@@ -107,10 +116,13 @@ export const RaceEthnicitiesForm = observer(() => {
               value="yes"
               checked={canSpecifyEthnicity}
               onChange={() => {
+                if (!systemSearchParam || !metricSearchParam) return;
                 const updatedDimensions =
                   updateAllRaceEthnicitiesToDefaultState(
                     "CAN_SPECIFY_ETHNICITY",
-                    raceEthnicityGridStates
+                    raceEthnicityGridStates,
+                    systemSearchParam,
+                    metricSearchParam
                   );
                 saveMetricSettings(updatedDimensions);
               }}
@@ -123,10 +135,13 @@ export const RaceEthnicitiesForm = observer(() => {
               value="no"
               checked={!canSpecifyEthnicity}
               onChange={() => {
+                if (!systemSearchParam || !metricSearchParam) return;
                 const updatedDimensions =
                   updateAllRaceEthnicitiesToDefaultState(
                     "NO_ETHNICITY_HISPANIC_AS_RACE",
-                    raceEthnicityGridStates
+                    raceEthnicityGridStates,
+                    systemSearchParam,
+                    metricSearchParam
                   );
                 saveMetricSettings(updatedDimensions);
               }}
@@ -151,10 +166,13 @@ export const RaceEthnicitiesForm = observer(() => {
                 <RaceSelectionButton
                   selected={!specifiesHispanicAsRace}
                   onClick={() => {
+                    if (!systemSearchParam || !metricSearchParam) return;
                     const updatedDimensions =
                       updateAllRaceEthnicitiesToDefaultState(
                         "NO_ETHNICITY_HISPANIC_NOT_SPECIFIED",
-                        raceEthnicityGridStates
+                        raceEthnicityGridStates,
+                        systemSearchParam,
+                        metricSearchParam
                       );
                     saveMetricSettings(updatedDimensions);
                   }}
@@ -164,10 +182,13 @@ export const RaceEthnicitiesForm = observer(() => {
                 <RaceSelectionButton
                   selected={specifiesHispanicAsRace}
                   onClick={() => {
+                    if (!systemSearchParam || !metricSearchParam) return;
                     const updatedDimensions =
                       updateAllRaceEthnicitiesToDefaultState(
                         "NO_ETHNICITY_HISPANIC_AS_RACE",
-                        raceEthnicityGridStates
+                        raceEthnicityGridStates,
+                        systemSearchParam,
+                        metricSearchParam
                       );
                     saveMetricSettings(updatedDimensions);
                   }}
@@ -191,6 +212,7 @@ export const RaceEthnicitiesForm = observer(() => {
                   <RaceSelectionButton
                     selected={!raceEnabled}
                     onClick={() => {
+                      if (!systemSearchParam || !metricSearchParam) return;
                       let switchedGridStateUpdatedDimensions;
                       /**
                        * When Unknown Race is disabled in NO_ETHNICITY_HISPANIC_AS_RACE state, we automatically switch
@@ -205,7 +227,9 @@ export const RaceEthnicitiesForm = observer(() => {
                         switchedGridStateUpdatedDimensions =
                           updateAllRaceEthnicitiesToDefaultState(
                             "NO_ETHNICITY_HISPANIC_NOT_SPECIFIED",
-                            raceEthnicityGridStates
+                            raceEthnicityGridStates,
+                            systemSearchParam,
+                            metricSearchParam
                           );
                       }
 
@@ -213,7 +237,9 @@ export const RaceEthnicitiesForm = observer(() => {
                         race,
                         false,
                         currentState,
-                        raceEthnicityGridStates
+                        raceEthnicityGridStates,
+                        systemSearchParam,
+                        metricSearchParam
                       );
 
                       if (switchedGridStateUpdatedDimensions) {
@@ -233,11 +259,14 @@ export const RaceEthnicitiesForm = observer(() => {
                   <RaceSelectionButton
                     selected={raceEnabled}
                     onClick={() => {
+                      if (!systemSearchParam || !metricSearchParam) return;
                       const updatedDimensions = updateRaceDimensions(
                         race,
                         true,
                         currentState,
-                        raceEthnicityGridStates
+                        raceEthnicityGridStates,
+                        systemSearchParam,
+                        metricSearchParam
                       );
                       saveMetricSettings(updatedDimensions);
                     }}

--- a/publisher/src/components/MetricConfiguration/RaceEthnicitiesGrid.tsx
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicitiesGrid.tsx
@@ -20,6 +20,7 @@ import React from "react";
 
 import { useStore } from "../../stores";
 import { ReactComponent as RightArrowIcon } from "../assets/right-arrow.svg";
+import { useSettingsSearchParams } from "../Settings";
 import {
   CalloutBox,
   Description,
@@ -40,8 +41,17 @@ export const RaceEthnicitiesGrid: React.FC<{
   disaggregationEnabled: boolean;
   onClick: () => void;
 }> = observer(({ disaggregationEnabled, onClick }) => {
+  const [settingsSearchParams] = useSettingsSearchParams();
   const { metricConfigStore } = useStore();
-  const { ethnicitiesByRace } = metricConfigStore;
+  const { getEthnicitiesByRace } = metricConfigStore;
+
+  const { system: systemSearchParam, metric: metricSearchParam } =
+    settingsSearchParams;
+  const ethnicitiesByRace =
+    (systemSearchParam &&
+      metricSearchParam &&
+      getEthnicitiesByRace(systemSearchParam, metricSearchParam)) ||
+    {};
 
   return (
     <RaceEthnicitiesBreakdownContainer


### PR DESCRIPTION
## Description of the change

Replace all instances of the MetricConfig store's `activeMetricKey` and `activeSystem` with URL params & updates related Race & Ethnicities components. [Huge shout out to all of @ivan-kishko work with implementing the routing]

## Related issues

Closes #185 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
