### PR TITLE
Race & Ethnicities: Sorting Races & Quick Fix

### DIFF
--- a/publisher/src/components/MetricConfiguration/RaceEthnicitiesForm.tsx
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicitiesForm.tsx
@@ -34,6 +34,7 @@ import {
   raceEthnicityGridStates,
   RaceSelection,
   RadioButtonGroupWrapper,
+  sortRaces,
   SpecifyEthnicityWrapper,
   Subheader,
 } from ".";
@@ -214,83 +215,87 @@ export const RaceEthnicitiesForm = observer(() => {
           )}
 
           {/* Races (Enable/Disable) */}
-          {Object.entries(ethnicitiesByRace).map(([race, ethnicities]) => {
-            const raceEnabled = Boolean(
-              Object.values(ethnicities).find((ethnicity) => ethnicity.enabled)
-            );
+          {Object.entries(ethnicitiesByRace)
+            .sort(sortRaces)
+            .map(([race, ethnicities]) => {
+              const raceEnabled = Boolean(
+                Object.values(ethnicities).find(
+                  (ethnicity) => ethnicity.enabled
+                )
+              );
 
-            return (
-              <Race key={race}>
-                <RaceDisplayName>{race}</RaceDisplayName>
-                <RaceSelection>
-                  <RadioButtonGroupWrapper>
-                    <BinaryRadioButton
-                      type="radio"
-                      id={`${race}-no`}
-                      name={`${race}`}
-                      label="No"
-                      value="no"
-                      checked={!raceEnabled}
-                      lastOptionBlue
-                      buttonSize="small"
-                      onChange={() => {
-                        if (!systemSearchParam || !metricSearchParam) return;
-                        /**
-                         * When Unknown Race is disabled in NO_ETHNICITY_HISPANIC_AS_RACE state, we automatically switch
-                         * to the NO_ETHNICITY_HISPANIC_NOT_SPECIFIED state because the Unknown Race (Hispanic/Latino Ethnicity)
-                         * dimension is the only dimension an agency can specify their numbers for Hispanic/Latino as a Race (while
-                         * in the NO_ETHNICITY_HISPANIC_AS_RACE state).
-                         */
-                        if (
-                          race === "Unknown" &&
-                          currentState === "NO_ETHNICITY_HISPANIC_AS_RACE"
-                        ) {
-                          updateAllRaceEthnicitiesToDefaultState(
-                            "NO_ETHNICITY_HISPANIC_NOT_SPECIFIED",
+              return (
+                <Race key={race}>
+                  <RaceDisplayName>{race}</RaceDisplayName>
+                  <RaceSelection>
+                    <RadioButtonGroupWrapper>
+                      <BinaryRadioButton
+                        type="radio"
+                        id={`${race}-no`}
+                        name={`${race}`}
+                        label="No"
+                        value="no"
+                        checked={!raceEnabled}
+                        lastOptionBlue
+                        buttonSize="small"
+                        onChange={() => {
+                          if (!systemSearchParam || !metricSearchParam) return;
+                          /**
+                           * When Unknown Race is disabled in NO_ETHNICITY_HISPANIC_AS_RACE state, we automatically switch
+                           * to the NO_ETHNICITY_HISPANIC_NOT_SPECIFIED state because the Unknown Race (Hispanic/Latino Ethnicity)
+                           * dimension is the only dimension an agency can specify their numbers for Hispanic/Latino as a Race (while
+                           * in the NO_ETHNICITY_HISPANIC_AS_RACE state).
+                           */
+                          if (
+                            race === "Unknown" &&
+                            currentState === "NO_ETHNICITY_HISPANIC_AS_RACE"
+                          ) {
+                            updateAllRaceEthnicitiesToDefaultState(
+                              "NO_ETHNICITY_HISPANIC_NOT_SPECIFIED",
+                              raceEthnicityGridStates,
+                              systemSearchParam,
+                              metricSearchParam
+                            );
+                          }
+
+                          const updatedDimensions = updateRaceDimensions(
+                            race,
+                            false,
+                            currentState,
                             raceEthnicityGridStates,
                             systemSearchParam,
                             metricSearchParam
                           );
-                        }
-
-                        const updatedDimensions = updateRaceDimensions(
-                          race,
-                          false,
-                          currentState,
-                          raceEthnicityGridStates,
-                          systemSearchParam,
-                          metricSearchParam
-                        );
-                        debouncedSave(updatedDimensions);
-                      }}
-                    />
-                    <BinaryRadioButton
-                      type="radio"
-                      id={`${race}-yes`}
-                      name={`${race}`}
-                      label="Yes"
-                      value="yes"
-                      checked={raceEnabled}
-                      lastOptionBlue
-                      buttonSize="small"
-                      onChange={() => {
-                        if (!systemSearchParam || !metricSearchParam) return;
-                        const updatedDimensions = updateRaceDimensions(
-                          race,
-                          true,
-                          currentState,
-                          raceEthnicityGridStates,
-                          systemSearchParam,
-                          metricSearchParam
-                        );
-                        debouncedSave(updatedDimensions);
-                      }}
-                    />
-                  </RadioButtonGroupWrapper>
-                </RaceSelection>
-              </Race>
-            );
-          })}
+                          debouncedSave(updatedDimensions);
+                        }}
+                      />
+                      <BinaryRadioButton
+                        type="radio"
+                        id={`${race}-yes`}
+                        name={`${race}`}
+                        label="Yes"
+                        value="yes"
+                        checked={raceEnabled}
+                        lastOptionBlue
+                        buttonSize="small"
+                        onChange={() => {
+                          if (!systemSearchParam || !metricSearchParam) return;
+                          const updatedDimensions = updateRaceDimensions(
+                            race,
+                            true,
+                            currentState,
+                            raceEthnicityGridStates,
+                            systemSearchParam,
+                            metricSearchParam
+                          );
+                          debouncedSave(updatedDimensions);
+                        }}
+                      />
+                    </RadioButtonGroupWrapper>
+                  </RaceSelection>
+                </Race>
+              );
+            })}
         </RaceContainer>
       </RaceEthnicitiesDisplay>
     </RaceEthnicitiesContainer>

--- a/publisher/src/components/MetricConfiguration/RaceEthnicitiesGrid.tsx
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicitiesGrid.tsx
@@ -35,6 +35,7 @@ import {
   RaceEthnicitiesBreakdownContainer,
   RaceEthnicitiesRow,
   RaceEthnicitiesTable,
+  sortRaces,
 } from ".";
 
 export const RaceEthnicitiesGrid: React.FC<{
@@ -78,19 +79,21 @@ export const RaceEthnicitiesGrid: React.FC<{
       </GridHeaderContainer>
 
       <RaceEthnicitiesTable>
-        {Object.entries(ethnicitiesByRace).map(([race, ethnicities]) => (
-          <RaceEthnicitiesRow key={race}>
-            <RaceCell>{race}</RaceCell>
-            <EthnicitiesRow>
-              {Object.values(ethnicities).map((ethnicity) => (
-                <EthnicityCell
-                  key={ethnicity.key}
-                  enabled={ethnicity.enabled}
-                />
-              ))}
-            </EthnicitiesRow>
-          </RaceEthnicitiesRow>
-        ))}
+        {Object.entries(ethnicitiesByRace)
+          .sort(sortRaces)
+          .map(([race, ethnicities]) => (
+            <RaceEthnicitiesRow key={race}>
+              <RaceCell>{race}</RaceCell>
+              <EthnicitiesRow>
+                {Object.values(ethnicities).map((ethnicity) => (
+                  <EthnicityCell
+                    key={ethnicity.key}
+                    enabled={ethnicity.enabled}
+                  />
+                ))}
+              </EthnicitiesRow>
+            </RaceEthnicitiesRow>
+          ))}
       </RaceEthnicitiesTable>
     </RaceEthnicitiesBreakdownContainer>
   );

--- a/publisher/src/components/MetricConfiguration/utils.ts
+++ b/publisher/src/components/MetricConfiguration/utils.ts
@@ -35,10 +35,10 @@ export const sortRaces = (
     }
   ]
 ) => {
-  if (b === "More than one race" && a === "Other") {
+  if (b === "More than one race" && (a === "Other" || a === "Unknown")) {
     return 0;
   }
-  if (b === "More than one race" && a !== "Unknown" && a !== "Other") {
+  if (b === "More than one race" && a !== "Other" && a !== "Unknown") {
     return -1;
   }
   return 1;

--- a/publisher/src/components/MetricConfiguration/utils.ts
+++ b/publisher/src/components/MetricConfiguration/utils.ts
@@ -15,16 +15,31 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-export * from "./Configuration";
-export * from "./constants";
-export * from "./ContextConfiguration";
-export * from "./MetricBox";
-export * from "./MetricConfiguration";
-export * from "./MetricConfiguration.styles";
-export * from "./MetricDefinitions";
-export * from "./RaceEthnicities.styles";
-export * from "./RaceEthnicitiesForm";
-export * from "./RaceEthnicitiesGrid";
-export * from "./RaceEthnicitiesGridStates";
-export * from "./types";
-export * from "./utils";
+import { UpdatedDimension } from ".";
+
+/**
+ * Sort Races from an `ethnicitiesByRace` object entries array in the following order:
+ * 'American Indian / Alaskan Native', 'Asian', 'Black', 'Native Hawaiian / Pacific Islander', 'White', 'More than one race', 'Other', 'Unknown'
+ */
+export const sortRaces = (
+  [a, _]: [
+    string,
+    {
+      [ethnicity: string]: UpdatedDimension;
+    }
+  ],
+  [b, __]: [
+    string,
+    {
+      [ethnicity: string]: UpdatedDimension;
+    }
+  ]
+) => {
+  if (b === "More than one race" && a === "Other") {
+    return 0;
+  }
+  if (b === "More than one race" && a !== "Unknown" && a !== "Other") {
+    return -1;
+  }
+  return 1;
+};

--- a/publisher/src/components/Settings/Settings.styles.tsx
+++ b/publisher/src/components/Settings/Settings.styles.tsx
@@ -85,6 +85,9 @@ export const MetricsListItem = styled.div<{ activeSection?: boolean }>`
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+  border-bottom: 2px solid
+    ${({ activeSection }) =>
+      activeSection ? palette.solid.blue : `transparent`};
 
   &:hover {
     cursor: pointer;


### PR DESCRIPTION
## Description of the change

Quick last minute items:

- Almost forgot about sorting the races (sorted based on the updated spec):
<img width="1275" alt="Screenshot 2022-11-30 at 4 10 48 PM" src="https://user-images.githubusercontent.com/59492998/204920272-39c67b5f-9c0a-4dc9-9417-b53a4d640a65.png">


- The active metric in the Settings menu metrics list lost its bottom blue border - it must've gotten lost somewhere in the overlapping PRs & rebases:
<img width="288" alt="Screenshot 2022-11-30 at 4 11 53 PM" src="https://user-images.githubusercontent.com/59492998/204920065-b032dc29-32f8-41a2-9b3a-38c734acee09.png">

## Related issues

Closes #180

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
