### PR TITLE
Playtesting Followup: General Styling Fixes

### DIFF
--- a/common/components/Toast/Toast.ts
+++ b/common/components/Toast/Toast.ts
@@ -78,7 +78,7 @@ export const showToast = (
   }
   toastElement.style.cssText = `
       width: auto;
-      height: ${HEADER_BAR_HEIGHT}px;
+      height: ${HEADER_BAR_HEIGHT - 1}px;
       display: flex;
       align-items: center;
       background: ${toastBackgroundColor};

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -245,7 +245,8 @@ export const Metric = styled.div<{ inView: boolean }>`
     inView ? palette.highlight.lightblue1 : `none`};
 
   &:hover {
-    background: ${palette.highlight.grey1};
+    background: ${({ inView }) =>
+      inView ? palette.highlight.lightblue1 : palette.highlight.grey1};
     cursor: pointer;
   }
 
@@ -379,7 +380,8 @@ export const Dimension = styled.div<{ enabled?: boolean; inView?: boolean }>`
     inView ? palette.highlight.lightblue1 : `none`};
 
   &:hover {
-    background: ${palette.highlight.grey1};
+    background: ${({ inView }) =>
+      inView ? palette.highlight.lightblue1 : palette.highlight.grey1};
     cursor: pointer;
   }
 

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -619,7 +619,7 @@ export const DefinitionsDisplayContainer = styled.div`
   display: flex;
   flex-direction: column;
   flex: 1 1 55%;
-  padding: 48px 12px 50px 70px;
+  padding: 18px 12px 50px 70px;
   overflow-y: scroll;
 
   @media only screen and (max-width: ${METRICS_VIEW_CONTAINER_BREAKPOINT}px) {

--- a/publisher/src/components/MetricConfiguration/RaceEthnicities.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicities.styles.tsx
@@ -66,7 +66,7 @@ export const CalloutBox = styled.div`
   border-radius: 2px;
   border: 1px solid ${palette.solid.blue};
   box-shadow: 0px 2px 4px rgba(0, 115, 229, 0.25);
-  transition: box-shadow 0.3s ease;
+  transition: 0.2s ease;
 
   svg {
     position: absolute;
@@ -75,7 +75,7 @@ export const CalloutBox = styled.div`
 
   &:hover {
     cursor: pointer;
-    box-shadow: 0px 0px 0px rgba(0, 115, 229, 0.25);
+    background-color: ${palette.highlight.blue};
   }
 `;
 

--- a/publisher/src/components/Onboarding/Onboarding.tsx
+++ b/publisher/src/components/Onboarding/Onboarding.tsx
@@ -189,8 +189,8 @@ const OnboardingModal = styled.div<{
     if (position === "publishdata") {
       return `
         bottom: calc(100% - ${modalHeight}px - 113px);
-        left: calc(100% - 552px);
-        top: 64px;
+        left: calc(100% - 532px - ${SIDE_PANEL_WIDTH}px);
+        top: 113px;
         right: ${SIDE_PANEL_WIDTH}px;
       `;
     }

--- a/publisher/src/components/Onboarding/Onboarding.tsx
+++ b/publisher/src/components/Onboarding/Onboarding.tsx
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import {
+  HEADER_BAR_HEIGHT,
   palette,
   typography,
 } from "@justice-counts/common/components/GlobalStyles";
@@ -188,8 +189,8 @@ const OnboardingModal = styled.div<{
     if (position === "publishdata") {
       return `
         bottom: calc(100% - ${modalHeight}px - 113px);
-        left: calc(100% - 532px - ${SIDE_PANEL_WIDTH}px);
-        top: 113px;
+        left: calc(100% - 552px);
+        top: 64px;
         right: ${SIDE_PANEL_WIDTH}px;
       `;
     }
@@ -308,7 +309,7 @@ const OnboardingFadedContainer = styled.div<OnboardingFadedContainerProps>`
   background: ${palette.solid.white};
   opacity: 0.7;
   position: absolute;
-  top: 0;
+  top: ${HEADER_BAR_HEIGHT}px;
   ${({ position }) => {
     if (position === "left") {
       return `


### PR DESCRIPTION
## Description of the change

General styling-related clean up:
- Reduce toast height 
  - <img width="206" alt="Screenshot 2022-12-02 at 12 55 18 PM" src="https://user-images.githubusercontent.com/59492998/205382066-730e3034-e68d-4652-b43d-13863ee53197.png"> to <img width="167" alt="Screenshot 2022-12-02 at 12 55 34 PM" src="https://user-images.githubusercontent.com/59492998/205382063-ab687fed-1348-428d-a3b0-2d07fd294e7d.png">

- Reduce top padding on right panel in Metric Config
  - <img width="728" alt="Screenshot 2022-12-02 at 2 44 43 PM" src="https://user-images.githubusercontent.com/59492998/205383494-dc317e3b-2b40-4da5-a57c-980a6b02199f.png">

- Adjust hover state of call out box to have a light blue background
  - <img width="644" alt="Screenshot 2022-12-02 at 2 45 01 PM" src="https://user-images.githubusercontent.com/59492998/205383448-64f8bf15-a5e3-44ff-bc43-9e129de70993.png">

- Adjust onboarding faded container to be below the bordered header in data entry page
  - <img width="528" alt="Screenshot 2022-12-02 at 2 46 16 PM" src="https://user-images.githubusercontent.com/59492998/205383936-c151dc09-f649-498d-b2f2-688b8a43df3a.png"> to <img width="528" alt="Screenshot 2022-12-02 at 2 45 58 PM" src="https://user-images.githubusercontent.com/59492998/205383939-d8ab04af-80da-4fea-8079-11d071d76cb5.png">

- Hover state for active dimension should be blue and not grey

## Related issues

Closes #193 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
