### PR TITLE
fix: set starting month to July when user selects fiscal year

### DIFF
--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -105,8 +105,8 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
     const customFrequency = metrics[systemMetricKey]?.customFrequency;
     const startingMonth = metrics[systemMetricKey]?.startingMonth;
     const customOrDefaultFrequency = customFrequency || defaultFrequency;
-    const startingMonthNotJanuaryJune =
-      startingMonth !== null && startingMonth !== 1 && startingMonth !== 6;
+    const startingMonthNotJanuaryJuly =
+      startingMonth !== null && startingMonth !== 1 && startingMonth !== 7;
 
     useEffect(
       () => {
@@ -223,15 +223,15 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                   type="radio"
                   id="metric-config-fiscal-year"
                   name="metric-config-frequency"
-                  label="Fiscal Year (Jun)"
-                  value="Fiscal Year (Jun)"
-                  checked={metricEnabled && startingMonth === 6}
+                  label="Fiscal Year (Jul)"
+                  value="Fiscal Year (Jul)"
+                  checked={metricEnabled && startingMonth === 7}
                   onChange={() => {
                     if (systemSearchParam && metricSearchParam) {
                       const updatedSetting = updateMetricReportFrequency(
                         systemSearchParam,
                         metricSearchParam,
-                        { customFrequency: "ANNUAL", startingMonth: 6 }
+                        { customFrequency: "ANNUAL", startingMonth: 7 }
                       );
                       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                       saveMetricSettings(updatedSetting, agencyId!);
@@ -241,21 +241,21 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                 <Dropdown>
                   <DropdownButton
                     kind="borderless"
-                    checked={startingMonthNotJanuaryJune}
+                    checked={startingMonthNotJanuaryJuly}
                   >
-                    {startingMonthNotJanuaryJune ? (
+                    {startingMonthNotJanuaryJuly ? (
                       <CalendarIconLight />
                     ) : (
                       <CalendarIconDark />
                     )}
-                    {(startingMonthNotJanuaryJune &&
+                    {(startingMonthNotJanuaryJuly &&
                       startingMonth &&
                       monthsByName[startingMonth - 1]) ||
                       `Other...`}
                   </DropdownButton>
                   <ExtendedDropdownMenu alignment="right">
                     {monthsByName
-                      .filter((month) => !["January", "June"].includes(month))
+                      .filter((month) => !["January", "July"].includes(month))
                       .map((month) => {
                         const monthNumber = monthsByName.indexOf(month) + 1;
                         return (


### PR DESCRIPTION
## Description of the change

This fix sets the reporting frequency starting month to July, not June, when a user selects a fiscal year reporting frequency. 

https://user-images.githubusercontent.com/19961693/206739231-00d08615-1cb5-4ed4-8d09-5a04ecbeb182.mov


## Related issues

Related to #204 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
