### PR TITLE
Supervision Metrics - Disaggregated vs Combined

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -44,6 +44,7 @@ export const SupervisionSystems: AgencySystems[] = [
   "PAROLE",
   "PROBATION",
   "POST_RELEASE",
+  "PRETRIAL_SUPERVISION",
   "OTHER_SUPERVISION",
 ];
 

--- a/common/types.ts
+++ b/common/types.ts
@@ -39,6 +39,14 @@ export type AgencyTeam = {
   name: string;
 };
 
+export const SupervisionSystems: AgencySystems[] = [
+  "SUPERVISION",
+  "PAROLE",
+  "PROBATION",
+  "POST_RELEASE",
+  "OTHER_SUPERVISION",
+];
+
 export interface UserAgency {
   name: string;
   id: number;
@@ -118,6 +126,7 @@ export interface Metric {
   settings?: MetricConfigurationSettings[];
   starting_month?: number;
   frequency?: ReportFrequency;
+  disaggregated_by_supervision_subsystems?: boolean;
 }
 
 export interface MetricDefinition {

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -16,10 +16,7 @@
 // =============================================================================
 
 import { showToast } from "@justice-counts/common/components/Toast";
-import {
-  AgencySystems,
-  SupervisionSystems,
-} from "@justice-counts/common/types";
+import { SupervisionSystems } from "@justice-counts/common/types";
 import { printCommaSeparatedList } from "@justice-counts/common/utils";
 import { Dropdown } from "@recidiviz/design-system";
 import { observer } from "mobx-react-lite";

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -144,6 +144,34 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
       [systemMetricKey]
     );
 
+    const handleSupervisionDisaggregationSelection = (status: boolean) => {
+      if (systemSearchParam && metricSearchParam) {
+        const updatedSetting = updateDisaggregatedBySupervisionSubsystems(
+          systemSearchParam,
+          metricSearchParam,
+          status
+        );
+        const toastMessage = status
+          ? `${removeSnakeCase(
+              metricSearchParam
+            )} is being moved to the ${printCommaSeparatedList(
+              normalizedSupervisionSubsystems
+            )} systems. Redirecting to the Metric Configuration home page.`
+          : `${removeSnakeCase(
+              metricSearchParam
+            )} is being moved to the Supervision system. Redirecting to the Metric Configuration home page.`;
+
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        saveMetricSettings(updatedSetting, agencyId!);
+
+        setTimeout(() => showToast(toastMessage), 1000);
+        setTimeout(() => {
+          navigate("../metric-config");
+          window.location.reload();
+        }, 4000);
+      }
+    };
+
     return (
       <MetricConfigurationContainer>
         {/* Metric (Enable/Disable) & Frequency */}
@@ -342,34 +370,9 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                   name="supervision-subsystem"
                   label="All Populations / Combined"
                   value="All Populations / Combined"
-                  onChange={() => {
-                    if (systemSearchParam && metricSearchParam) {
-                      const updatedSetting =
-                        updateDisaggregatedBySupervisionSubsystems(
-                          systemSearchParam,
-                          metricSearchParam,
-                          false
-                        );
-                      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                      saveMetricSettings(updatedSetting, agencyId!);
-
-                      setTimeout(
-                        () =>
-                          showToast(
-                            `${removeSnakeCase(
-                              metricSearchParam
-                            )} is being moved to the ${printCommaSeparatedList(
-                              normalizedSupervisionSubsystems
-                            )} systems. Redirecting to the Metric Configuration home page.`
-                          ),
-                        1000
-                      );
-                      setTimeout(() => {
-                        navigate("../metric-config?system=SUPERVISION");
-                        window.location.reload();
-                      }, 4000);
-                    }
-                  }}
+                  onChange={() =>
+                    handleSupervisionDisaggregationSelection(false)
+                  }
                   defaultChecked={!disaggregatedBySupervisionSubsystems}
                 />
                 <BinaryRadioButton
@@ -378,34 +381,9 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                   name="supervision-subsystem"
                   label="Disaggregated"
                   value="Disaggregated"
-                  onChange={() => {
-                    if (systemSearchParam && metricSearchParam) {
-                      const updatedSetting =
-                        updateDisaggregatedBySupervisionSubsystems(
-                          systemSearchParam,
-                          metricSearchParam,
-                          true
-                        );
-                      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-                      saveMetricSettings(updatedSetting, agencyId!);
-
-                      setTimeout(
-                        () =>
-                          showToast(
-                            `${removeSnakeCase(
-                              metricSearchParam
-                            )} is being moved to the ${printCommaSeparatedList(
-                              normalizedSupervisionSubsystems
-                            )} systems. Redirecting to the Metric Configuration home page.`
-                          ),
-                        1000
-                      );
-                      setTimeout(() => {
-                        navigate("../metric-config?system=SUPERVISION");
-                        window.location.reload();
-                      }, 4000);
-                    }
-                  }}
+                  onChange={() =>
+                    handleSupervisionDisaggregationSelection(true)
+                  }
                   defaultChecked={disaggregatedBySupervisionSubsystems}
                 />
               </RadioButtonGroupWrapper>

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -20,6 +20,7 @@ import {
   AgencySystems,
   SupervisionSystems,
 } from "@justice-counts/common/types";
+import { printCommaSeparatedList } from "@justice-counts/common/utils";
 import { Dropdown } from "@recidiviz/design-system";
 import { observer } from "mobx-react-lite";
 import React, { useEffect } from "react";
@@ -59,7 +60,6 @@ import {
   ReportFrequencyUpdate,
   Subheader,
 } from ".";
-import { printCommaSeparatedList } from "@justice-counts/common/utils";
 
 type MetricConfigurationProps = {
   activeDimensionKey: string | undefined;
@@ -122,6 +122,11 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
     const customOrDefaultFrequency = customFrequency || defaultFrequency;
     const startingMonthNotJanuaryJuly =
       startingMonth !== null && startingMonth !== 1 && startingMonth !== 7;
+
+    const normalizedSupervisionSubsystems =
+      supervisionSubsystems?.map((system) => {
+        return system.charAt(0).toUpperCase() + system.slice(1);
+      }) || [];
 
     useEffect(
       () => {
@@ -343,14 +348,9 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                           showToast(
                             `${removeSnakeCase(
                               metricSearchParam
-                            )} is being moved to the ${
-                              supervisionSubsystems &&
-                              printCommaSeparatedList(
-                                supervisionSubsystems.map((system) =>
-                                  system.toUpperCase()
-                                )
-                              )
-                            } systems. Redirecting to the Metric Configuration home page.`
+                            )} is being moved to the ${printCommaSeparatedList(
+                              normalizedSupervisionSubsystems
+                            )} systems. Redirecting to the Metric Configuration home page.`
                           ),
                         1000
                       );
@@ -384,14 +384,9 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                           showToast(
                             `${removeSnakeCase(
                               metricSearchParam
-                            )} is being moved to the ${
-                              supervisionSubsystems &&
-                              printCommaSeparatedList(
-                                supervisionSubsystems.map((system) =>
-                                  system.toUpperCase()
-                                )
-                              )
-                            } systems. Redirecting to the Metric Configuration home page.`
+                            )} is being moved to the ${printCommaSeparatedList(
+                              normalizedSupervisionSubsystems
+                            )} systems. Redirecting to the Metric Configuration home page.`
                           ),
                         1000
                       );

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -15,7 +15,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { SupervisionSystems } from "@justice-counts/common/types";
+import { showToast } from "@justice-counts/common/components/Toast";
+import {
+  AgencySystems,
+  SupervisionSystems,
+} from "@justice-counts/common/types";
 import { Dropdown } from "@recidiviz/design-system";
 import { observer } from "mobx-react-lite";
 import React, { useEffect } from "react";
@@ -55,6 +59,7 @@ import {
   ReportFrequencyUpdate,
   Subheader,
 } from ".";
+import { printCommaSeparatedList } from "@justice-counts/common/utils";
 
 type MetricConfigurationProps = {
   activeDimensionKey: string | undefined;
@@ -65,6 +70,7 @@ type MetricConfigurationProps = {
   setActiveDisaggregationKey: React.Dispatch<
     React.SetStateAction<string | undefined>
   >;
+  supervisionSubsystems?: string[];
 };
 
 export const Configuration: React.FC<MetricConfigurationProps> = observer(
@@ -73,6 +79,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
     setActiveDimensionKey,
     activeDisaggregationKey,
     setActiveDisaggregationKey,
+    supervisionSubsystems,
   }): JSX.Element => {
     const { agencyId } = useParams();
     const [settingsSearchParams] = useSettingsSearchParams();
@@ -330,8 +337,27 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                         );
                       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                       saveMetricSettings(updatedSetting, agencyId!);
-                      navigate("../metric-config");
-                      window.location.reload();
+
+                      setTimeout(
+                        () =>
+                          showToast(
+                            `${removeSnakeCase(
+                              metricSearchParam
+                            )} is being moved to the ${
+                              supervisionSubsystems &&
+                              printCommaSeparatedList(
+                                supervisionSubsystems.map((system) =>
+                                  system.toUpperCase()
+                                )
+                              )
+                            } systems. Redirecting to the Metric Configuration home page.`
+                          ),
+                        1000
+                      );
+                      setTimeout(() => {
+                        navigate("../metric-config?system=SUPERVISION");
+                        window.location.reload();
+                      }, 4000);
                     }
                   }}
                   defaultChecked={!disaggregatedBySupervisionSubsystems}
@@ -352,8 +378,27 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                         );
                       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                       saveMetricSettings(updatedSetting, agencyId!);
-                      navigate("../metric-config");
-                      window.location.reload();
+
+                      setTimeout(
+                        () =>
+                          showToast(
+                            `${removeSnakeCase(
+                              metricSearchParam
+                            )} is being moved to the ${
+                              supervisionSubsystems &&
+                              printCommaSeparatedList(
+                                supervisionSubsystems.map((system) =>
+                                  system.toUpperCase()
+                                )
+                              )
+                            } systems. Redirecting to the Metric Configuration home page.`
+                          ),
+                        1000
+                      );
+                      setTimeout(() => {
+                        navigate("../metric-config?system=SUPERVISION");
+                        window.location.reload();
+                      }, 4000);
                     }
                   }}
                   defaultChecked={disaggregatedBySupervisionSubsystems}

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -296,14 +296,13 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
             </>
           )}
 
-          {/* Supervision Systems ONLY */}
+          {/* Supervision Subsystem Disaggregation Selection (Supervision Systems ONLY) */}
           {systemSearchParam && SupervisionSystems.includes(systemSearchParam) && (
             <PromptWrapper>
               <Header>
                 For which supervision populations can you report this metric?
               </Header>
               <Subheader>
-                {/* TODO(#231) Add link to Agency Settings */}
                 <p>
                   Disaggregations include the populations you selected in{" "}
                   <BlueLinkSpan onClick={() => navigate("../agency-settings")}>

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -329,6 +329,10 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                   ({printCommaSeparatedList(normalizedSupervisionSubsystems)}
                   ).
                 </p>
+                <p>
+                  NOTE: Changing this option will refresh the page to reflect
+                  the changes.
+                </p>
               </Subheader>
 
               <RadioButtonGroupWrapper>

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -164,11 +164,14 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         saveMetricSettings(updatedSetting, agencyId!);
 
-        setTimeout(() => showToast(toastMessage), 1000);
+        setTimeout(
+          () => showToast(toastMessage, undefined, undefined, 5000),
+          1000
+        );
         setTimeout(() => {
           navigate("../metric-config");
           window.location.reload();
-        }, 4000);
+        }, 5000);
       }
     };
 

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -122,6 +122,15 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
 
     const normalizedSupervisionSubsystems =
       supervisionSubsystems?.map((system) => {
+        const systemName = removeSnakeCase(system).split(" ");
+
+        /** For capitalizing multi-word system names (e.g OTHER SUPERVISION) */
+        if (systemName.length > 1) {
+          const capitalizedSystemName = systemName.map(
+            (name) => name.charAt(0).toUpperCase() + name.slice(1)
+          );
+          return capitalizedSystemName.join(" ");
+        }
         return system.charAt(0).toUpperCase() + system.slice(1);
       }) || [];
 
@@ -316,10 +325,10 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                   Disaggregations include the populations you selected in{" "}
                   <BlueLinkSpan onClick={() => navigate("../agency-settings")}>
                     Agency Settings
-                  </BlueLinkSpan>
-                  .
+                  </BlueLinkSpan>{" "}
+                  ({printCommaSeparatedList(normalizedSupervisionSubsystems)}
+                  ).
                 </p>
-                <p>Probation, Parole, and Dual Supervision.</p>
               </Subheader>
 
               <RadioButtonGroupWrapper>

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -120,7 +120,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
     const startingMonthNotJanuaryJuly =
       startingMonth !== null && startingMonth !== 1 && startingMonth !== 7;
 
-    const normalizedSupervisionSubsystems =
+    const capitalizedSupervisionSubsystems =
       supervisionSubsystems?.map((system) => {
         const systemName = removeSnakeCase(system).split(" ");
 
@@ -155,7 +155,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
           ? `${removeSnakeCase(
               metricSearchParam
             )} is being moved to the ${printCommaSeparatedList(
-              normalizedSupervisionSubsystems
+              capitalizedSupervisionSubsystems
             )} systems. Redirecting to the Metric Configuration home page.`
           : `${removeSnakeCase(
               metricSearchParam
@@ -354,7 +354,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                   <BlueLinkSpan onClick={() => navigate("../agency-settings")}>
                     Agency Settings
                   </BlueLinkSpan>{" "}
-                  ({printCommaSeparatedList(normalizedSupervisionSubsystems)}
+                  ({printCommaSeparatedList(capitalizedSupervisionSubsystems)}
                   ).
                 </p>
                 <p>

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -19,7 +19,7 @@ import { SupervisionSystems } from "@justice-counts/common/types";
 import { Dropdown } from "@recidiviz/design-system";
 import { observer } from "mobx-react-lite";
 import React, { useEffect } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
 import { useStore } from "../../stores";
 import { monthsByName, removeSnakeCase } from "../../utils";
@@ -34,6 +34,7 @@ import { TabbedBar, TabbedItem, TabbedOptions } from "../Reports";
 import { getActiveSystemMetricKey, useSettingsSearchParams } from "../Settings";
 import {
   BlueCheckIcon,
+  BlueLinkSpan,
   BreakdownHeader,
   Checkbox,
   CheckboxWrapper,
@@ -75,6 +76,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
   }): JSX.Element => {
     const { agencyId } = useParams();
     const [settingsSearchParams] = useSettingsSearchParams();
+    const navigate = useNavigate();
     const { metricConfigStore } = useStore();
     const {
       metrics,
@@ -303,8 +305,11 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
               <Subheader>
                 {/* TODO(#231) Add link to Agency Settings */}
                 <p>
-                  Disaggregations include the populations you selected in Agency
-                  Settings.
+                  Disaggregations include the populations you selected in{" "}
+                  <BlueLinkSpan onClick={() => navigate("../agency-settings")}>
+                    Agency Settings
+                  </BlueLinkSpan>
+                  .
                 </p>
                 <p>Probation, Parole, and Dual Supervision.</p>
               </Subheader>

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -330,6 +330,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                         );
                       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                       saveMetricSettings(updatedSetting, agencyId!);
+                      window.location.reload();
                     }
                   }}
                   defaultChecked={!disaggregatedBySupervisionSubsystems}
@@ -350,6 +351,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                         );
                       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                       saveMetricSettings(updatedSetting, agencyId!);
+                      window.location.reload();
                     }
                   }}
                   defaultChecked={disaggregatedBySupervisionSubsystems}

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+import { SupervisionSystems } from "@justice-counts/common/types";
 import { Dropdown } from "@recidiviz/design-system";
 import { observer } from "mobx-react-lite";
 import React, { useEffect } from "react";
@@ -46,6 +47,7 @@ import {
   MetricConfigurationContainer,
   MetricDisaggregations,
   MetricOnOffWrapper,
+  PromptWrapper,
   RACE_ETHNICITY_DISAGGREGATION_KEY,
   RaceEthnicitiesGrid,
   RadioButtonGroupWrapper,
@@ -82,6 +84,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
       updateDisaggregationEnabledStatus,
       updateDimensionEnabledStatus,
       updateMetricReportFrequency,
+      updateDisaggregatedBySupervisionSubsystems,
       saveMetricSettings,
     } = metricConfigStore;
 
@@ -100,10 +103,13 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
         ? Object.keys(dimensions[systemMetricKey][activeDisaggregationKey])
         : [];
 
+    const {
+      defaultFrequency,
+      customFrequency,
+      startingMonth,
+      disaggregatedBySupervisionSubsystems,
+    } = metrics[systemMetricKey];
     const metricEnabled = Boolean(metrics[systemMetricKey]?.enabled);
-    const defaultFrequency = metrics[systemMetricKey]?.defaultFrequency;
-    const customFrequency = metrics[systemMetricKey]?.customFrequency;
-    const startingMonth = metrics[systemMetricKey]?.startingMonth;
     const customOrDefaultFrequency = customFrequency || defaultFrequency;
     const startingMonthNotJanuaryJuly =
       startingMonth !== null && startingMonth !== 1 && startingMonth !== 7;
@@ -286,6 +292,66 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                 </Dropdown>
               </RadioButtonGroupWrapper>
             </>
+          )}
+
+          {/* Supervision Systems ONLY */}
+          {systemSearchParam && SupervisionSystems.includes(systemSearchParam) && (
+            <PromptWrapper>
+              <Header>
+                For which supervision populations can you report this metric?
+              </Header>
+              <Subheader>
+                {/* TODO(#231) Add link to Agency Settings */}
+                <p>
+                  Disaggregations include the populations you selected in Agency
+                  Settings.
+                </p>
+                <p>Probation, Parole, and Dual Supervision.</p>
+              </Subheader>
+
+              <RadioButtonGroupWrapper>
+                <BinaryRadioButton
+                  type="radio"
+                  id="supervision-subsystem-combined"
+                  name="supervision-subsystem"
+                  label="All Populations / Combined"
+                  value="All Populations / Combined"
+                  onChange={() => {
+                    if (systemSearchParam && metricSearchParam) {
+                      const updatedSetting =
+                        updateDisaggregatedBySupervisionSubsystems(
+                          systemSearchParam,
+                          metricSearchParam,
+                          false
+                        );
+                      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                      saveMetricSettings(updatedSetting, agencyId!);
+                    }
+                  }}
+                  defaultChecked={!disaggregatedBySupervisionSubsystems}
+                />
+                <BinaryRadioButton
+                  type="radio"
+                  id="supervision-subsystem-disaggregated"
+                  name="supervision-subsystem"
+                  label="Disaggregated"
+                  value="Disaggregated"
+                  onChange={() => {
+                    if (systemSearchParam && metricSearchParam) {
+                      const updatedSetting =
+                        updateDisaggregatedBySupervisionSubsystems(
+                          systemSearchParam,
+                          metricSearchParam,
+                          true
+                        );
+                      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+                      saveMetricSettings(updatedSetting, agencyId!);
+                    }
+                  }}
+                  defaultChecked={disaggregatedBySupervisionSubsystems}
+                />
+              </RadioButtonGroupWrapper>
+            </PromptWrapper>
           )}
         </MetricOnOffWrapper>
 

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -330,6 +330,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                         );
                       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                       saveMetricSettings(updatedSetting, agencyId!);
+                      navigate("../metric-config");
                       window.location.reload();
                     }
                   }}
@@ -351,6 +352,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                         );
                       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
                       saveMetricSettings(updatedSetting, agencyId!);
+                      navigate("../metric-config");
                       window.location.reload();
                     }
                   }}

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -815,3 +815,11 @@ export const PromptWrapper = styled.div`
 export const CapitalizedSpan = styled.span`
   text-transform: capitalize;
 `;
+
+export const BlueLinkSpan = styled.span`
+  color: ${palette.solid.blue};
+
+  &:hover {
+    cursor: pointer;
+  }
+`;

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -807,3 +807,11 @@ export const DropdownButton = styled(DropdownToggle)<{ checked?: boolean }>`
     color: ${palette.solid.darkgrey};
   }
 `;
+
+export const PromptWrapper = styled.div`
+  margin-top: 35px;
+`;
+
+export const CapitalizedSpan = styled.span`
+  text-transform: capitalize;
+`;

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -266,6 +266,7 @@ export const MetricConfiguration: React.FC = observer(() => {
                     setActiveDimensionKey={setActiveDimensionKey}
                     activeDisaggregationKey={activeDisaggregationKey}
                     setActiveDisaggregationKey={setActiveDisaggregationKey}
+                    supervisionSubsystems={supervisionSubsystems}
                   />
                 </MetricDetailsDisplay>
               </MetricConfigurationDisplay>

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -22,7 +22,6 @@ import {
   ReportFrequency,
   SupervisionSystems,
 } from "@justice-counts/common/types";
-import { printCommaSeparatedList } from "@justice-counts/common/utils";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
@@ -34,7 +33,6 @@ import { Loading } from "../Loading";
 import { TabbedBar, TabbedItem, TabbedOptions } from "../Reports";
 import { getActiveSystemMetricKey, useSettingsSearchParams } from "../Settings";
 import {
-  CapitalizedSpan,
   Configuration,
   Metric,
   MetricBox,

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -169,16 +169,20 @@ export const MetricConfiguration: React.FC = observer(() => {
             <StickyHeader>
               <TabbedBar noPadding>
                 <TabbedOptions>
-                  {currentAgency?.systems.map((filterOption) => (
-                    <TabbedItem
-                      key={filterOption}
-                      selected={systemSearchParam === filterOption}
-                      onClick={() => handleSystemClick(filterOption)}
-                      capitalize
-                    >
-                      {removeSnakeCase(filterOption.toLowerCase())}
-                    </TabbedItem>
-                  ))}
+                  {currentAgency?.systems
+                    .filter(
+                      (system) => getMetricsBySystem(system)?.length !== 0
+                    )
+                    .map((filterOption) => (
+                      <TabbedItem
+                        key={filterOption}
+                        selected={systemSearchParam === filterOption}
+                        onClick={() => handleSystemClick(filterOption)}
+                        capitalize
+                      >
+                        {removeSnakeCase(filterOption.toLowerCase())}
+                      </TabbedItem>
+                    ))}
                 </TabbedOptions>
               </TabbedBar>
             </StickyHeader>
@@ -204,35 +208,6 @@ export const MetricConfiguration: React.FC = observer(() => {
                     />
                   )
                 )}
-
-                {/* Message for when there are no metrics in the SUPERVISION system (e.g. subsystems are disaggregated into their respective tab(s))  */}
-                {systemSearchParam === "SUPERVISION" &&
-                  getMetricsBySystem(systemSearchParam)?.length === 0 &&
-                  supervisionSubsystems && (
-                    <div>
-                      The metrics for Supervision are now disaggregated and
-                      moved to the{" "}
-                      <CapitalizedSpan>
-                        {printCommaSeparatedList(supervisionSubsystems)}{" "}
-                      </CapitalizedSpan>{" "}
-                      tabs.
-                    </div>
-                  )}
-
-                {/* Message for when there are no metrics in a Supervision subsystem (e.g. subsystems are combined under the Supervision tab) */}
-                {systemSearchParam &&
-                  supervisionSubsystems?.includes(
-                    systemSearchParam?.toLowerCase()
-                  ) &&
-                  getMetricsBySystem(systemSearchParam)?.length === 0 && (
-                    <div>
-                      The metrics for{" "}
-                      <CapitalizedSpan>
-                        {removeSnakeCase(systemSearchParam.toLowerCase())}
-                      </CapitalizedSpan>{" "}
-                      are combined and can be found in the Supervision tab.
-                    </div>
-                  )}
               </MetricBoxContainerWrapper>
             </MetricBoxBottomPaddingContainer>
           )}

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -17,7 +17,12 @@
 
 import { Badge } from "@justice-counts/common/components/Badge";
 import { showToast } from "@justice-counts/common/components/Toast";
-import { AgencySystems, ReportFrequency } from "@justice-counts/common/types";
+import {
+  AgencySystems,
+  ReportFrequency,
+  SupervisionSystems,
+} from "@justice-counts/common/types";
+import { printCommaSeparatedList } from "@justice-counts/common/utils";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
@@ -29,6 +34,7 @@ import { Loading } from "../Loading";
 import { TabbedBar, TabbedItem, TabbedOptions } from "../Reports";
 import { getActiveSystemMetricKey, useSettingsSearchParams } from "../Settings";
 import {
+  CapitalizedSpan,
   Configuration,
   Metric,
   MetricBox,
@@ -146,6 +152,12 @@ export const MetricConfiguration: React.FC = observer(() => {
   }
 
   const currentAgency = userStore.getAgency(agencyId);
+  const supervisionSubsystems = currentAgency?.systems
+    .filter(
+      (system) =>
+        SupervisionSystems.includes(system) && system !== "SUPERVISION"
+    )
+    .map((system) => system.toLowerCase());
 
   return (
     <>
@@ -192,6 +204,35 @@ export const MetricConfiguration: React.FC = observer(() => {
                     />
                   )
                 )}
+
+                {/* Message for when there are no metrics in the SUPERVISION system (e.g. subsystems are disaggregated into their respective tab(s))  */}
+                {systemSearchParam === "SUPERVISION" &&
+                  getMetricsBySystem(systemSearchParam)?.length === 0 &&
+                  supervisionSubsystems && (
+                    <div>
+                      The metrics for Supervision are now disaggregated and
+                      moved to the{" "}
+                      <CapitalizedSpan>
+                        {printCommaSeparatedList(supervisionSubsystems)}{" "}
+                      </CapitalizedSpan>{" "}
+                      tabs.
+                    </div>
+                  )}
+
+                {/* Message for when there are no metrics in a Supervision subsystem (e.g. subsystems are combined under the Supervision tab) */}
+                {systemSearchParam &&
+                  supervisionSubsystems?.includes(
+                    systemSearchParam?.toLowerCase()
+                  ) &&
+                  getMetricsBySystem(systemSearchParam)?.length === 0 && (
+                    <div>
+                      The metrics for{" "}
+                      <CapitalizedSpan>
+                        {removeSnakeCase(systemSearchParam.toLowerCase())}
+                      </CapitalizedSpan>{" "}
+                      are combined and can be found in the Supervision tab.
+                    </div>
+                  )}
               </MetricBoxContainerWrapper>
             </MetricBoxBottomPaddingContainer>
           )}

--- a/publisher/src/components/MetricConfiguration/types.ts
+++ b/publisher/src/components/MetricConfiguration/types.ts
@@ -93,7 +93,8 @@ export type MetricInfo = {
   description?: Metric["description"];
   defaultFrequency?: ReportFrequency;
   customFrequency?: Metric["custom_frequency"];
-  startingMonth?: Metric["starting_month"];
+  startingMonth?: Metric["starting_month"] | null;
+  disaggregatedBySupervisionSubsystems?: boolean;
 };
 
 export type ReportFrequencyUpdate = {

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -49,14 +49,7 @@ class MetricConfigStore {
   api: API;
 
   metrics: {
-    [systemMetricKey: string]: {
-      enabled?: boolean;
-      label?: string;
-      description?: Metric["description"];
-      defaultFrequency?: ReportFrequency;
-      customFrequency?: Metric["custom_frequency"];
-      startingMonth?: Metric["starting_month"] | null;
-    };
+    [systemMetricKey: string]: MetricInfo;
   };
 
   metricDefinitionSettings: {
@@ -229,6 +222,8 @@ class MetricConfigStore {
               defaultFrequency: metric.frequency,
               customFrequency: metric.custom_frequency,
               startingMonth: metric.starting_month,
+              disaggregatedBySupervisionSubsystems:
+                metric.disaggregated_by_supervision_subsystems,
             }
           );
 
@@ -335,6 +330,8 @@ class MetricConfigStore {
         metadata.defaultFrequency;
       this.metrics[systemMetricKey].customFrequency = metadata.customFrequency;
       this.metrics[systemMetricKey].startingMonth = metadata.startingMonth;
+      this.metrics[systemMetricKey].disaggregatedBySupervisionSubsystems =
+        metadata.disaggregatedBySupervisionSubsystems;
     }
 
     /** Update value */
@@ -375,6 +372,27 @@ class MetricConfigStore {
       frequency: update.defaultFrequency,
       custom_frequency: update.customFrequency,
       starting_month: update.startingMonth,
+    };
+  };
+
+  /** Allows a supervision agency to specify whether or not a metric is reported as disaggregated by supervision subsystems */
+  updateDisaggregatedBySupervisionSubsystems = (
+    system: AgencySystems,
+    metricKey: string,
+    status: boolean
+  ) => {
+    const systemMetricKey = MetricConfigStore.getSystemMetricKey(
+      system,
+      metricKey
+    );
+
+    /** Update values */
+    this.metrics[systemMetricKey].disaggregatedBySupervisionSubsystems = status;
+
+    /** Return an object in the desired backend data structure for saving purposes */
+    return {
+      key: metricKey,
+      disaggregated_by_supervision_subsystems: status,
     };
   };
 


### PR DESCRIPTION
## Description of the change

This is the frontend piece to [#17161](https://github.com/Recidiviz/recidiviz-data/pull/17161/files) which allows an agency to specify whether or not a metric is reported as disaggregated by supervision subsystems.

Quick Demo:

https://user-images.githubusercontent.com/59492998/207926892-2198ecce-fd0c-49d1-8e81-39fb080e4a69.mov

Deployed here: https://mahmoudtest---justice-counts-web-qqec6jbn6a-uc.a.run.app

## Related issues

Closes #229 #231 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
