### PR TITLE
send user email in requests to /api/users

### DIFF
--- a/publisher/src/stores/UserStore.ts
+++ b/publisher/src/stores/UserStore.ts
@@ -160,6 +160,7 @@ class UserStore {
         method: "PUT",
         body: {
           name: this.name,
+          email: this.email,
         },
       })) as Response;
       const { agencies: userAgencies, permissions } = await response.json();


### PR DESCRIPTION
## Description of the change

Send the user email on requests to `PUT` `api/users` so that the BE can store the email in the `UserAccount` table. 

I checked this locally end-to-end while using the `nichelle-hall/update-backfill-script` branch in the BE, and saw that the database was updated when I logged in. 

<img width="779" alt="Screen Shot 2022-12-14 at 3 21 37 PM" src="https://user-images.githubusercontent.com/19961693/207706788-0662370e-4794-4839-8b4a-2bc495bd3d1c.png">



## Related issues

Closes #17274

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
