### PR TITLE
Guidance: Routing

### DIFF
--- a/publisher/src/App.tsx
+++ b/publisher/src/App.tsx
@@ -48,7 +48,8 @@ const App: React.FC = (): ReactElement => {
   // if false then we just show user page that there are no associated agencies
   // if user has agencies but route is out of pattern /agency/:agencyId then redirect to /agency/:initialAgencyId/reports
   const initialAgency = userStore.getInitialAgencyId();
-  const hasCompletedOnboarding = false;
+  // TODO(#249): Move boolean to mobX data store
+  const hasCompletedOnboarding = true;
 
   const renderRoutesBasedOnOnboardingStatus = (): JSX.Element => {
     if (!hasCompletedOnboarding) {

--- a/publisher/src/App.tsx
+++ b/publisher/src/App.tsx
@@ -48,30 +48,59 @@ const App: React.FC = (): ReactElement => {
   // if false then we just show user page that there are no associated agencies
   // if user has agencies but route is out of pattern /agency/:agencyId then redirect to /agency/:initialAgencyId/reports
   const initialAgency = userStore.getInitialAgencyId();
+  const hasCompletedOnboarding = false;
 
-  return (
-    <PageWrapper>
-      {initialAgency ? (
+  const renderRoutesBasedOnOnboardingStatus = (): JSX.Element => {
+    if (!hasCompletedOnboarding) {
+      return (
         <Routes>
           <Route
             path="/"
             element={
-              <Navigate to={`/agency/${initialAgency}/${REPORTS_LOWERCASE}`} />
+              <Navigate to={`/agency/${initialAgency}/getting-started`} />
             }
           />
           <Route path="/agency/:agencyId/*" element={<Router />} />
           <Route
             path="*"
             element={
-              <Navigate to={`/agency/${initialAgency}/${REPORTS_LOWERCASE}`} />
+              <Navigate to={`/agency/${initialAgency}/getting-started`} />
             }
           />
         </Routes>
-      ) : (
-        <NoAgencies />
-      )}
-    </PageWrapper>
-  );
+      );
+    }
+
+    return (
+      <>
+        {initialAgency ? (
+          <Routes>
+            <Route
+              path="/"
+              element={
+                <Navigate
+                  to={`/agency/${initialAgency}/${REPORTS_LOWERCASE}`}
+                />
+              }
+            />
+            <Route path="/agency/:agencyId/*" element={<Router />} />
+            <Route
+              path="*"
+              element={
+                <Navigate
+                  to={`/agency/${initialAgency}/${REPORTS_LOWERCASE}`}
+                />
+              }
+            />
+          </Routes>
+        ) : (
+          <NoAgencies />
+        )}
+      </>
+    );
+  };
+
+  return <PageWrapper>{renderRoutesBasedOnOnboardingStatus()}</PageWrapper>;
 };
 
 export default observer(App);

--- a/publisher/src/components/Guidance/Guidance.tsx
+++ b/publisher/src/components/Guidance/Guidance.tsx
@@ -1,0 +1,22 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2022 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import React from "react";
+
+export const Guidance = () => {
+  return <div>Guidance</div>;
+};

--- a/publisher/src/components/Guidance/index.ts
+++ b/publisher/src/components/Guidance/index.ts
@@ -1,0 +1,18 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2022 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+export * from "./Guidance";

--- a/publisher/src/router/Router.tsx
+++ b/publisher/src/router/Router.tsx
@@ -20,6 +20,7 @@ import { Navigate, Route, Routes, useParams } from "react-router-dom";
 
 import { DataUpload } from "../components/DataUpload";
 import { REPORTS_LOWERCASE } from "../components/Global/constants";
+import { Guidance } from "../components/Guidance";
 import Header from "../components/Header";
 import { MetricsView } from "../components/MetricConfiguration/MetricsView";
 import CreateReport from "../components/Reports/CreateReport";
@@ -47,7 +48,7 @@ export const Router = () => {
       return (
         <Routes>
           <Route path="/" element={<Navigate to="getting-started" />} />
-          <Route path="/getting-started" element={<DataUpload />} />
+          <Route path="/getting-started" element={<Guidance />} />
           <Route path="*" element={<Navigate to="getting-started" />} />
         </Routes>
       );
@@ -55,6 +56,7 @@ export const Router = () => {
 
     return (
       <>
+        <Header />
         {isAgencyIdInUserAgencies ? (
           <Routes>
             <Route
@@ -90,10 +92,5 @@ export const Router = () => {
     );
   };
 
-  return (
-    <>
-      <Header />
-      {renderRoutesBasedOnOnboardingStatus()}
-    </>
-  );
+  return <>{renderRoutesBasedOnOnboardingStatus()}</>;
 };

--- a/publisher/src/router/Router.tsx
+++ b/publisher/src/router/Router.tsx
@@ -41,7 +41,8 @@ export const Router = () => {
   // e.g. reports page with initial available user agency
   // or maybe display some text since header is available and user can pick available agency
   const isAgencyIdInUserAgencies = userStore.getAgency(agencyId);
-  const hasCompletedOnboarding = false;
+  // TODO(#249): Move boolean to mobX data store
+  const hasCompletedOnboarding = true;
 
   const renderRoutesBasedOnOnboardingStatus = (): JSX.Element => {
     if (!hasCompletedOnboarding) {

--- a/publisher/src/router/Router.tsx
+++ b/publisher/src/router/Router.tsx
@@ -40,36 +40,60 @@ export const Router = () => {
   // e.g. reports page with initial available user agency
   // or maybe display some text since header is available and user can pick available agency
   const isAgencyIdInUserAgencies = userStore.getAgency(agencyId);
+  const hasCompletedOnboarding = false;
+
+  const renderRoutesBasedOnOnboardingStatus = (): JSX.Element => {
+    if (!hasCompletedOnboarding) {
+      return (
+        <Routes>
+          <Route path="/" element={<Navigate to="getting-started" />} />
+          <Route path="/getting-started" element={<DataUpload />} />
+          <Route path="*" element={<Navigate to="getting-started" />} />
+        </Routes>
+      );
+    }
+
+    return (
+      <>
+        {isAgencyIdInUserAgencies ? (
+          <Routes>
+            <Route
+              path="/"
+              element={<Navigate to={`${REPORTS_LOWERCASE}`} />}
+            />
+            <Route path={`/${REPORTS_LOWERCASE}`} element={<Reports />} />
+            <Route path="/data" element={<MetricsView />} />
+            <Route
+              path={`/${REPORTS_LOWERCASE}/create`}
+              element={<CreateReport />}
+            />
+            <Route
+              path={`/${REPORTS_LOWERCASE}/:id`}
+              element={<ReportDataEntry />}
+            />
+            <Route
+              path={`/${REPORTS_LOWERCASE}/:id/review`}
+              element={<ReviewReportDataEntry />}
+            />
+            <Route path="/settings/*" element={<Settings />} />
+            <Route path="/upload" element={<DataUpload />} />
+            <Route path="/upload/review-metrics" element={<ReviewMetrics />} />
+            <Route
+              path="*"
+              element={<Navigate to={`${REPORTS_LOWERCASE}`} />}
+            />
+          </Routes>
+        ) : (
+          <NotFound />
+        )}
+      </>
+    );
+  };
 
   return (
     <>
       <Header />
-
-      {isAgencyIdInUserAgencies ? (
-        <Routes>
-          <Route path="/" element={<Navigate to={`${REPORTS_LOWERCASE}`} />} />
-          <Route path={`/${REPORTS_LOWERCASE}`} element={<Reports />} />
-          <Route path="/data" element={<MetricsView />} />
-          <Route
-            path={`/${REPORTS_LOWERCASE}/create`}
-            element={<CreateReport />}
-          />
-          <Route
-            path={`/${REPORTS_LOWERCASE}/:id`}
-            element={<ReportDataEntry />}
-          />
-          <Route
-            path={`/${REPORTS_LOWERCASE}/:id/review`}
-            element={<ReviewReportDataEntry />}
-          />
-          <Route path="/settings/*" element={<Settings />} />
-          <Route path="/upload" element={<DataUpload />} />
-          <Route path="/upload/review-metrics" element={<ReviewMetrics />} />
-          <Route path="*" element={<Navigate to={`${REPORTS_LOWERCASE}`} />} />
-        </Routes>
-      ) : (
-        <NotFound />
-      )}
+      {renderRoutesBasedOnOnboardingStatus()}
     </>
   );
 };


### PR DESCRIPTION
## Description of the change

Sets up `/getting-started` route to redirect users who have not completed onboarding to the new barebones Guidance component.

There is a mock `hasCompletedOnboarding` boolean flag in the `App.tsx` and `Router.tsx` that controls whether to redirect the user to `/getting-started` route. The `hasCompletedOnboarding` will eventually live in a mobX data store `App.tsx` and `Router.tsx` can refer to that single source of truth.

Expected behavior: when `hasCompletedOnboarding` is set to `false` in both `App.tsx` and `Router.tsx` - you are redirected to `/agency/{:agencyId}/getting-started`. When set to `true`, you can enter and explore the app as usual.


https://user-images.githubusercontent.com/59492998/209717169-6c23e628-d208-4b03-a37d-868435ad38c9.mov



## Related issues

Closes #248 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
