### PR TITLE
Guidance: Setup Your Agency

### DIFF
--- a/publisher/src/components/Guidance/Guidance.styles.tsx
+++ b/publisher/src/components/Guidance/Guidance.styles.tsx
@@ -61,6 +61,7 @@ export const TopicDescription = styled.div`
 `;
 
 export const ActionButton = styled.button`
+  ${typography.sizeCSS.medium};
   width: fit-content;
   border: none;
   border-radius: 3px;
@@ -72,6 +73,16 @@ export const ActionButton = styled.button`
   &:hover {
     background: ${palette.solid.darkblue};
     cursor: pointer;
+  }
+`;
+
+export const SkipButton = styled.div`
+  ${typography.sizeCSS.normal};
+  color: ${palette.solid.blue};
+
+  &:hover {
+    cursor: pointer;
+    color: ${palette.solid.darkblue};
   }
 `;
 

--- a/publisher/src/components/Guidance/Guidance.tsx
+++ b/publisher/src/components/Guidance/Guidance.tsx
@@ -17,6 +17,7 @@
 
 import { observer } from "mobx-react-lite";
 import React from "react";
+import { useNavigate } from "react-router-dom";
 
 import { useStore } from "../../stores";
 import {
@@ -25,19 +26,28 @@ import {
   GuidanceContainer,
   ProgressStepBubble,
   ProgressStepsContainer,
+  SkipButton,
   TopicDescription,
   TopicTitle,
 } from ".";
 
 export const Guidance = observer(() => {
+  const navigate = useNavigate();
   const { guidanceStore } = useStore();
   const { onboardingTopicsMetadata, currentTopicID, updateTopicStatus } =
     guidanceStore;
 
   const currentTopicDisplayName =
-    currentTopicID && onboardingTopicsMetadata[currentTopicID].topicDisplayName;
+    currentTopicID && onboardingTopicsMetadata[currentTopicID].displayName;
   const currentTopicDescription =
-    currentTopicID && onboardingTopicsMetadata[currentTopicID].topicDescription;
+    currentTopicID && onboardingTopicsMetadata[currentTopicID].description;
+  const skippable =
+    currentTopicID && onboardingTopicsMetadata[currentTopicID].skippable;
+  const buttonDisplayName =
+    currentTopicID &&
+    onboardingTopicsMetadata[currentTopicID].buttonDisplayName;
+  const pathToTask =
+    currentTopicID && onboardingTopicsMetadata[currentTopicID].pathToTask;
   const topLeftPositionedTopic =
     currentTopicID === "WELCOME" || currentTopicID === "METRIC_CONFIG";
 
@@ -77,13 +87,28 @@ export const Guidance = observer(() => {
           {renderProgressSteps()}
           <TopicTitle>{currentTopicDisplayName}</TopicTitle>
           <TopicDescription>{currentTopicDescription}</TopicDescription>
+
+          {/* TODO(#) Replace the || "Next" and only display ActionButton if there is a buttonDisplayName property while mocking */}
           <ActionButton
-            onClick={() =>
-              currentTopicID && updateTopicStatus(currentTopicID, true)
-            }
+            onClick={() => {
+              if (currentTopicID) {
+                if (pathToTask) navigate(pathToTask);
+                updateTopicStatus(currentTopicID, true);
+              }
+            }}
           >
-            Next
+            {buttonDisplayName || "Next"}
           </ActionButton>
+
+          {skippable && (
+            <SkipButton
+              onClick={() =>
+                currentTopicID && updateTopicStatus(currentTopicID, true)
+              }
+            >
+              Skip
+            </SkipButton>
+          )}
         </ContentContainer>
       </GuidanceContainer>
     </>

--- a/publisher/src/components/Guidance/types.ts
+++ b/publisher/src/components/Guidance/types.ts
@@ -71,7 +71,7 @@ export const onboardingTopicsMetadata: OnboardingTopicsMetadata = {
 export const mockTopicsStatus: OnboardingTopicsStatus[] = [
   {
     topicID: "WELCOME",
-    topicCompleted: true,
+    topicCompleted: false,
   },
   {
     topicID: "AGENCY_SETUP",

--- a/publisher/src/components/Guidance/types.ts
+++ b/publisher/src/components/Guidance/types.ts
@@ -24,9 +24,11 @@ export type TopicID =
 
 export type OnboardingTopicsMetadata = {
   [topicID: string]: {
-    topicDisplayName: string;
-    topicDescription: string;
+    displayName: string;
+    description: string;
     pathToTask?: string;
+    buttonDisplayName?: string;
+    skippable?: boolean;
   };
 };
 
@@ -37,36 +39,39 @@ export type OnboardingTopicsStatus = {
 
 export const onboardingTopicsMetadata: OnboardingTopicsMetadata = {
   WELCOME: {
-    topicDisplayName: "Welcome to the Justice Counts Publisher",
-    topicDescription:
+    displayName: "Welcome to the Justice Counts Publisher",
+    description:
       "Publisher is a web-based service that helps criminal justice agencies share important metrics with the public on a regular basis.",
+    buttonDisplayName: "Get Started",
   },
   AGENCY_SETUP: {
-    topicDisplayName: "Setup your agency",
-    topicDescription:
+    displayName: "Setup your agency",
+    description:
       "Review and enter important information about your agency, such as your jurisdiction, colleagues, and more.",
+    pathToTask: "../settings/agency-settings",
+    buttonDisplayName: "Agency Settings",
+    skippable: true,
   },
   METRIC_CONFIG: {
-    topicDisplayName: "Configure metrics",
-    topicDescription:
+    displayName: "Configure metrics",
+    description:
       "Publisher allows agencies participating in Justice Counts must indicate which of the metrics they can and cannot share at a monthly or annual frequency, as well as the agency-specific definitions of those metrics.",
   },
   ADD_DATA: {
-    topicDisplayName: "Add data",
-    topicDescription:
+    displayName: "Add data",
+    description:
       "You can now upload data to your metrics by filling out a monthly report or by uploading a spreadsheet.",
   },
   PUBLISH_DATA: {
-    topicDisplayName: "Publish your uploaded data",
-    topicDescription:
-      "It looks like you have not published your uploaded data.",
+    displayName: "Publish your uploaded data",
+    description: "It looks like you have not published your uploaded data.",
   },
 };
 
 export const mockTopicsStatus: OnboardingTopicsStatus[] = [
   {
     topicID: "WELCOME",
-    topicCompleted: false,
+    topicCompleted: true,
   },
   {
     topicID: "AGENCY_SETUP",


### PR DESCRIPTION
## Description of the change

Implements the Setup Your Agency flow where a user can navigate to the `Agency Settings` portion of the settings page or skip this step.

Working demo:



https://user-images.githubusercontent.com/59492998/210026979-3b3c0360-e008-4116-a787-f9db8db6c95c.mov

*NOTE: since we're just working with mock data that's not persisted, going back to the home screen via (Get Started) or refreshing will clear the temp. persisted progress and start you back at the beginning (you can adjust this by changing the mock values of `mockTopicsStatus`). The actual behavior once the state is persisted on the BE will be that the user goes back to the screen appropriate for the step they are on.

## Related issues

Closes #253 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
