### PR TITLE
Guidance: Add Data

### DIFF
--- a/publisher/src/components/Guidance/Guidance.styles.tsx
+++ b/publisher/src/components/Guidance/Guidance.styles.tsx
@@ -60,19 +60,30 @@ export const TopicDescription = styled.div`
   ${typography.sizeCSS.medium};
 `;
 
-export const ActionButton = styled.button`
+export const ActionButtonWrapper = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+
+export const ActionButton = styled.button<{ kind?: "primary" | "bordered" }>`
   ${typography.sizeCSS.medium};
   width: fit-content;
-  border: none;
+  border: 1px solid
+    ${({ kind }) =>
+      kind === "bordered" ? palette.highlight.grey4 : palette.solid.blue};
   border-radius: 3px;
   padding: 16px 32px;
-  background: ${palette.solid.blue};
-  color: ${palette.solid.white};
+  background: ${({ kind }) =>
+    kind === "bordered" ? `none` : palette.solid.blue};
+  color: ${({ kind }) =>
+    kind === "bordered" ? palette.solid.darkgrey : palette.solid.white};
   transition: 0.3s ease;
 
   &:hover {
-    background: ${palette.solid.darkblue};
     cursor: pointer;
+    background: ${({ kind }) =>
+      kind === "bordered" ? palette.solid.blue : palette.solid.darkblue};
+    ${({ kind }) => kind === "bordered" && `color: ${palette.solid.white};`}
   }
 `;
 

--- a/publisher/src/components/Guidance/Guidance.tsx
+++ b/publisher/src/components/Guidance/Guidance.tsx
@@ -22,6 +22,7 @@ import { useNavigate } from "react-router-dom";
 import { useStore } from "../../stores";
 import {
   ActionButton,
+  ActionButtonWrapper,
   ContentContainer,
   GuidanceContainer,
   ProgressStepBubble,
@@ -88,17 +89,36 @@ export const Guidance = observer(() => {
           <TopicTitle>{currentTopicDisplayName}</TopicTitle>
           <TopicDescription>{currentTopicDescription}</TopicDescription>
 
-          {/* TODO(#) Replace the || "Next" and only display ActionButton if there is a buttonDisplayName property while mocking */}
-          <ActionButton
-            onClick={() => {
-              if (currentTopicID) {
-                if (pathToTask) navigate(pathToTask);
-                updateTopicStatus(currentTopicID, true);
-              }
-            }}
-          >
-            {buttonDisplayName || "Next"}
-          </ActionButton>
+          {currentTopicID === "ADD_DATA" ? (
+            <ActionButtonWrapper>
+              <ActionButton
+                kind="primary"
+                onClick={() => navigate("../upload")}
+              >
+                Upload spreadsheet
+              </ActionButton>
+              <ActionButton
+                kind="bordered"
+                onClick={() => navigate("../records")}
+              >
+                Fill out report
+              </ActionButton>
+            </ActionButtonWrapper>
+          ) : (
+            <>
+              {/* TODO(#) Replace the || "Next" and only display ActionButton if there is a buttonDisplayName property while mocking */}
+              <ActionButton
+                onClick={() => {
+                  if (currentTopicID) {
+                    if (pathToTask) navigate(pathToTask);
+                    updateTopicStatus(currentTopicID, true);
+                  }
+                }}
+              >
+                {buttonDisplayName || "Next"}
+              </ActionButton>
+            </>
+          )}
 
           {skippable && (
             <SkipButton

--- a/publisher/src/components/Guidance/Guidance.tsx
+++ b/publisher/src/components/Guidance/Guidance.tsx
@@ -20,6 +20,7 @@ import React, { useEffect } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { useStore } from "../../stores";
+import { REPORTS_LOWERCASE } from "../Global/constants";
 import {
   ActionButton,
   ActionButtonWrapper,
@@ -119,7 +120,7 @@ export const Guidance = observer(() => {
               </ActionButton>
               <ActionButton
                 kind="bordered"
-                onClick={() => navigate("../records")}
+                onClick={() => navigate(`../${REPORTS_LOWERCASE}`)}
               >
                 Fill out report
               </ActionButton>

--- a/publisher/src/components/Guidance/Guidance.tsx
+++ b/publisher/src/components/Guidance/Guidance.tsx
@@ -16,8 +16,8 @@
 // =============================================================================
 
 import { observer } from "mobx-react-lite";
-import React from "react";
-import { useNavigate } from "react-router-dom";
+import React, { useEffect } from "react";
+import { useNavigate, useParams } from "react-router-dom";
 
 import { useStore } from "../../stores";
 import {
@@ -34,9 +34,11 @@ import {
 
 export const Guidance = observer(() => {
   const navigate = useNavigate();
-  const { guidanceStore } = useStore();
+  const { agencyId } = useParams();
+  const { guidanceStore, reportStore } = useStore();
   const { onboardingTopicsMetadata, currentTopicID, updateTopicStatus } =
     guidanceStore;
+  const { reportOverviews, getReportOverviews, resetState } = reportStore;
 
   const currentTopicDisplayName =
     currentTopicID && onboardingTopicsMetadata[currentTopicID].displayName;
@@ -51,6 +53,22 @@ export const Guidance = observer(() => {
     currentTopicID && onboardingTopicsMetadata[currentTopicID].pathToTask;
   const topLeftPositionedTopic =
     currentTopicID === "WELCOME" || currentTopicID === "METRIC_CONFIG";
+
+  useEffect(() => {
+    const initialize = async () => {
+      resetState();
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      await getReportOverviews(agencyId!);
+      const hasMinimumOneReport =
+        currentTopicID === "ADD_DATA" &&
+        Object.keys(reportOverviews).length > 0;
+
+      if (hasMinimumOneReport) updateTopicStatus(currentTopicID, true);
+    };
+
+    if (currentTopicID === "ADD_DATA") initialize();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [agencyId, currentTopicID]);
 
   const renderProgressSteps = () => {
     if (currentTopicID === "WELCOME") return;

--- a/publisher/src/components/Guidance/Guidance.tsx
+++ b/publisher/src/components/Guidance/Guidance.tsx
@@ -63,7 +63,7 @@ export const Guidance = observer(() => {
         Object.keys(reportStore.reportOverviews).length > 0;
 
       if (hasMinimumOneReport) {
-        /* TODO(#) Enable this to check during the ADD_DATA whether or not a user has atleast one draft (if so, then the topic is complete) */
+        /* TODO(#267) Enable this to check during the ADD_DATA whether or not a user has atleast one draft (if so, then the topic is complete) */
         // updateTopicStatus(currentTopicID, true);
       }
     };
@@ -126,7 +126,7 @@ export const Guidance = observer(() => {
             </ActionButtonWrapper>
           ) : (
             <>
-              {/* TODO(#) Replace the || "Next" and only display ActionButton if there is a buttonDisplayName property while mocking */}
+              {/* TODO(#268) Replace the || "Next" and only display ActionButton if there is a buttonDisplayName property while mocking */}
               <ActionButton
                 onClick={() => {
                   if (currentTopicID) {

--- a/publisher/src/components/Guidance/Guidance.tsx
+++ b/publisher/src/components/Guidance/Guidance.tsx
@@ -58,17 +58,17 @@ export const Guidance = observer(() => {
       reportStore.resetState();
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       await reportStore.getReportOverviews(agencyId!);
-      const hasMinimumOneReport =
-        currentTopicID === "ADD_DATA" &&
-        Object.keys(reportStore.reportOverviews).length > 0;
-
-      if (hasMinimumOneReport) {
-        /* TODO(#267) Enable this to check during the ADD_DATA whether or not a user has atleast one draft (if so, then the topic is complete) */
-        // updateTopicStatus(currentTopicID, true);
-      }
     };
 
-    if (currentTopicID === "ADD_DATA") initialize();
+    if (currentTopicID === "ADD_DATA") {
+      const hasMinimumOneReport =
+        Object.keys(reportStore.reportOverviews).length > 0;
+      if (hasMinimumOneReport) {
+        /* TODO(#267) Enable this to check during the ADD_DATA step whether or not a user has atleast one draft (if so, then mark the topic as complete) */
+        // updateTopicStatus(currentTopicID, true);
+      }
+      initialize();
+    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agencyId, currentTopicID]);
 

--- a/publisher/src/components/Guidance/Guidance.tsx
+++ b/publisher/src/components/Guidance/Guidance.tsx
@@ -63,7 +63,10 @@ export const Guidance = observer(() => {
         currentTopicID === "ADD_DATA" &&
         Object.keys(reportOverviews).length > 0;
 
-      if (hasMinimumOneReport) updateTopicStatus(currentTopicID, true);
+      if (hasMinimumOneReport) {
+        /* TODO(#) Enable this to check during the ADD_DATA whether or not a user has atleast one draft (if so, then the topic is complete) */
+        // updateTopicStatus(currentTopicID, true);
+      }
     };
 
     if (currentTopicID === "ADD_DATA") initialize();

--- a/publisher/src/components/Guidance/Guidance.tsx
+++ b/publisher/src/components/Guidance/Guidance.tsx
@@ -38,7 +38,6 @@ export const Guidance = observer(() => {
   const { guidanceStore, reportStore } = useStore();
   const { onboardingTopicsMetadata, currentTopicID, updateTopicStatus } =
     guidanceStore;
-  const { reportOverviews, getReportOverviews, resetState } = reportStore;
 
   const currentTopicDisplayName =
     currentTopicID && onboardingTopicsMetadata[currentTopicID].displayName;
@@ -56,12 +55,12 @@ export const Guidance = observer(() => {
 
   useEffect(() => {
     const initialize = async () => {
-      resetState();
+      reportStore.resetState();
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      await getReportOverviews(agencyId!);
+      await reportStore.getReportOverviews(agencyId!);
       const hasMinimumOneReport =
         currentTopicID === "ADD_DATA" &&
-        Object.keys(reportOverviews).length > 0;
+        Object.keys(reportStore.reportOverviews).length > 0;
 
       if (hasMinimumOneReport) {
         /* TODO(#) Enable this to check during the ADD_DATA whether or not a user has atleast one draft (if so, then the topic is complete) */

--- a/publisher/src/components/Guidance/GuidanceHeader.tsx
+++ b/publisher/src/components/Guidance/GuidanceHeader.tsx
@@ -21,6 +21,7 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import { useStore } from "../../stores";
 import logo from "../assets/jc-logo-vector.png";
+import { REPORTS_LOWERCASE } from "../Global/constants";
 import { HeaderBar, Logo, LogoContainer } from "../Header";
 import { MenuContainer, MenuItem } from "../Menu";
 import { UploadDataButton } from ".";
@@ -33,7 +34,7 @@ export const GuidanceHeader = observer(() => {
   const guidancePaths = {
     home: "getting-started",
     settings: "settings",
-    records: "records",
+    records: REPORTS_LOWERCASE,
   };
 
   const isHome = params["*"] === guidancePaths.home;

--- a/publisher/src/components/Guidance/GuidanceHeader.tsx
+++ b/publisher/src/components/Guidance/GuidanceHeader.tsx
@@ -33,10 +33,12 @@ export const GuidanceHeader = observer(() => {
   const guidancePaths = {
     home: "getting-started",
     settings: "settings",
+    records: "records",
   };
 
   const isHome = params["*"] === guidancePaths.home;
   const isSettings = params["*"]?.includes(guidancePaths.settings);
+  const isRecords = params["*"]?.includes(guidancePaths.records);
   const isAddDataOrPublishDataStep =
     currentTopicID === "ADD_DATA" || currentTopicID === "PUBLISH_DATA";
 
@@ -55,12 +57,22 @@ export const GuidanceHeader = observer(() => {
             Get Started
           </MenuItem>
 
+          {isAddDataOrPublishDataStep && (
+            <MenuItem
+              active={isRecords}
+              onClick={() => navigate(guidancePaths.records)}
+            >
+              Records
+            </MenuItem>
+          )}
+
           <MenuItem
             active={isSettings}
             onClick={() => navigate(guidancePaths.settings)}
           >
             Settings
           </MenuItem>
+
           <MenuItem buttonPadding>
             <UploadDataButton
               type={isAddDataOrPublishDataStep ? "blue" : "border"}

--- a/publisher/src/router/Router.tsx
+++ b/publisher/src/router/Router.tsx
@@ -58,7 +58,10 @@ export const Router = () => {
               <>
                 <Route path="/settings/*" element={<Settings />} />
                 {isAddDataOrPublishDataStep && (
-                  <Route path="/upload/*" element={<DataUpload />} />
+                  <>
+                    <Route path="/upload/*" element={<DataUpload />} />
+                    <Route path="/records/*" element={<Reports />} />
+                  </>
                 )}
               </>
             )}

--- a/publisher/src/router/Router.tsx
+++ b/publisher/src/router/Router.tsx
@@ -60,7 +60,26 @@ export const Router = () => {
                 {isAddDataOrPublishDataStep && (
                   <>
                     <Route path="/upload/*" element={<DataUpload />} />
-                    <Route path="/records/*" element={<Reports />} />
+                    <Route
+                      path="/upload/review-metrics"
+                      element={<ReviewMetrics />}
+                    />
+                    <Route
+                      path={`/${REPORTS_LOWERCASE}/*`}
+                      element={<Reports />}
+                    />
+                    <Route
+                      path={`/${REPORTS_LOWERCASE}/create`}
+                      element={<CreateReport />}
+                    />
+                    <Route
+                      path={`/${REPORTS_LOWERCASE}/:id`}
+                      element={<ReportDataEntry />}
+                    />
+                    <Route
+                      path={`/${REPORTS_LOWERCASE}/:id/review`}
+                      element={<ReviewReportDataEntry />}
+                    />
                   </>
                 )}
               </>


### PR DESCRIPTION
## Description of the change

Implements the Add Data step in the guidance flow which allows a user to choose between uploading a spreadsheet or manually filling out a record. This step unlocks the `Records` page as well as the `Upload Data` button (in the header). 

NOTE: I've commented out the line that updates the topic status based on whether or not the user has at least one report. Since we all have atleast one report - I figured I'll disable it for now so you can experience this step (otherwise, it'll skip this step because you've already added data and go to the Publish Data step).

Demo:

https://user-images.githubusercontent.com/59492998/210604999-0bdea03f-1ef5-487f-b51d-b1c047fc2ef8.mov


## Related issues

Closes #258 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
