### PR TITLE
Guidance: Publish Data

### DIFF
--- a/publisher/src/components/Guidance/Guidance.styles.tsx
+++ b/publisher/src/components/Guidance/Guidance.styles.tsx
@@ -144,3 +144,48 @@ export const UploadDataButton = styled(Button)<{ activated?: boolean }>`
         }
     `}
 `;
+
+export const ReportsOverviewContainer = styled.div`
+  width: 100%;
+  max-height: 30vh;
+  height: 30vh;
+  padding: 10px 0;
+  overflow-y: scroll;
+`;
+
+export const ReportsOverviewItemWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px 0;
+  border-bottom: 1px solid ${palette.solid.darkgrey};
+`;
+
+export const ReportTitle = styled.div`
+  ${typography.sizeCSS.large}
+  display: flex;
+  align-items: center;
+
+  &:hover {
+    cursor: pointer;
+  }
+`;
+export const ReviewPublishLink = styled.div`
+  ${typography.sizeCSS.normal}
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  color: ${palette.solid.blue};
+
+  svg {
+    width: 14px;
+    path {
+      fill: ${palette.solid.blue};
+    }
+  }
+
+  &:hover {
+    cursor: pointer;
+    color: ${palette.solid.darkblue};
+  }
+`;

--- a/publisher/src/components/Guidance/GuidanceHeader.tsx
+++ b/publisher/src/components/Guidance/GuidanceHeader.tsx
@@ -35,13 +35,16 @@ export const GuidanceHeader = observer(() => {
     home: "getting-started",
     settings: "settings",
     records: REPORTS_LOWERCASE,
+    data: "data",
   };
 
   const isHome = params["*"] === guidancePaths.home;
   const isSettings = params["*"]?.includes(guidancePaths.settings);
   const isRecords = params["*"]?.includes(guidancePaths.records);
+  const isDataVizPage = params["*"]?.includes(guidancePaths.data);
+  const isPublishDataStep = currentTopicID === "PUBLISH_DATA";
   const isAddDataOrPublishDataStep =
-    currentTopicID === "ADD_DATA" || currentTopicID === "PUBLISH_DATA";
+    currentTopicID === "ADD_DATA" || isPublishDataStep;
 
   return (
     <HeaderBar bottomBorder>
@@ -64,6 +67,15 @@ export const GuidanceHeader = observer(() => {
               onClick={() => navigate(guidancePaths.records)}
             >
               Records
+            </MenuItem>
+          )}
+
+          {isPublishDataStep && (
+            <MenuItem
+              active={isDataVizPage}
+              onClick={() => navigate(guidancePaths.data)}
+            >
+              Data
             </MenuItem>
           )}
 

--- a/publisher/src/components/Reports/PublishConfirmation.tsx
+++ b/publisher/src/components/Reports/PublishConfirmation.tsx
@@ -249,7 +249,7 @@ const MetricsDisplay: React.FC<{
 const PublishConfirmation: React.FC<{ reportID: number }> = ({ reportID }) => {
   const [isPublishable, setIsPublishable] = useState(false);
   const [metricsPreview, setMetricsPreview] = useState<MetricWithErrors[]>();
-  const { formStore, reportStore, userStore } = useStore();
+  const { formStore, reportStore, userStore, guidanceStore } = useStore();
   const { agencyId } = useParams();
   const navigate = useNavigate();
   const checkMetricForErrors = useCheckMetricForErrors(reportID);
@@ -268,6 +268,12 @@ const PublishConfirmation: React.FC<{ reportID: number }> = ({ reportID }) => {
       )) as Response;
 
       if (response.status === 200) {
+        // For users who have not completed the onboarding flow and are publishing for the first time.
+        if (
+          guidanceStore.currentTopicID === "PUBLISH_DATA" &&
+          !guidanceStore.hasCompletedOnboarding
+        )
+          guidanceStore.updateTopicStatus("PUBLISH_DATA", true);
         navigate(`/agency/${agencyId}/${REPORTS_LOWERCASE}`);
         showToast(
           `Congratulations! You published the ${printReportTitle(
@@ -298,6 +304,7 @@ const PublishConfirmation: React.FC<{ reportID: number }> = ({ reportID }) => {
     const { metrics, isPublishable: publishable } =
       formStore.validateAndGetAllMetricFormValues(reportID);
     const enabledMetrics = metrics.filter((metric) => metric.enabled);
+
     setMetricsPreview(enabledMetrics);
     setIsPublishable(publishable);
   }, [formStore, reportID]);

--- a/publisher/src/components/Reports/ReviewReportDataEntry.tsx
+++ b/publisher/src/components/Reports/ReviewReportDataEntry.tsx
@@ -30,7 +30,7 @@ import { ReportDataEntryWrapper } from "./ReportDataEntry.styles";
 const ReviewReportDataEntry = () => {
   const params = useParams();
   const reportID = Number(params.id);
-  const { reportStore } = useStore();
+  const { reportStore, formStore } = useStore();
 
   const [loadingError, setLoadingError] = useState<string | undefined>(
     undefined
@@ -40,13 +40,12 @@ const ReviewReportDataEntry = () => {
     const initialize = async () => {
       const result = await reportStore.getReport(reportID);
       if (result instanceof Error) {
-        setLoadingError(result.message);
+        return setLoadingError(result.message);
       }
+      formStore.validatePreviouslySavedInputs(reportID);
     };
 
-    if (Object.keys(reportStore.reportOverviews).length === 0) {
-      initialize();
-    }
+    initialize();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 

--- a/publisher/src/router/Router.tsx
+++ b/publisher/src/router/Router.tsx
@@ -45,8 +45,9 @@ export const Router = () => {
 
   const renderRoutesBasedOnOnboardingStatus = (): JSX.Element => {
     if (!hasCompletedOnboarding) {
+      const isPublishDataStep = currentTopicID === "PUBLISH_DATA";
       const isAddDataOrPublishDataStep =
-        currentTopicID === "ADD_DATA" || currentTopicID === "PUBLISH_DATA";
+        currentTopicID === "ADD_DATA" || isPublishDataStep;
 
       return (
         <>
@@ -81,6 +82,9 @@ export const Router = () => {
                       element={<ReviewReportDataEntry />}
                     />
                   </>
+                )}
+                {isPublishDataStep && (
+                  <Route path="/data" element={<MetricsView />} />
                 )}
               </>
             )}


### PR DESCRIPTION
## Description of the change

Implements the Publish Data step in the guidance flow. Here a user will see a list of their draft/unpublished records and be encouraged to publish data. The `Data` link to view the visualizations of the uploaded metrics is unlocked which means the rest of the app functionality is available to the user. If they haven't published data yet, every time they return to the app, they will be greeted by the "Publish Data" step of guidance.

Demo:

https://user-images.githubusercontent.com/59492998/210675307-38561b4d-7d1d-4d4c-a9dd-fec5df38529c.mov

NOTE: the "Next" button won't exist here in the final version (it's just to get you through to the next screen - which is completing the guidance journey)

## Related issues

Closes #259 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
