### PR TITLE
Agency Dashboard playtesting followups

### DIFF
--- a/agency-dashboard/src/DashboardView.styles.tsx
+++ b/agency-dashboard/src/DashboardView.styles.tsx
@@ -68,6 +68,7 @@ export const BackButtonContainer = styled.div`
   margin-top: 16px;
   display: flex;
   align-items: center;
+  align-self: flex-start;
   gap: 8px;
 
   &:hover {

--- a/agency-dashboard/src/DashboardView.tsx
+++ b/agency-dashboard/src/DashboardView.tsx
@@ -134,7 +134,7 @@ const DashboardView = () => {
 
   const { search } = useLocation();
   const query = new URLSearchParams(search);
-  const metricKey = query.get("metric");
+  const metricKey = query.get("metric")?.toLocaleUpperCase();
 
   useEffect(() => {
     const fetchData = async () => {
@@ -271,7 +271,7 @@ const DashboardView = () => {
               agencyDataStore.metricDisplayNameToKey[selectedMetricName];
             if (selectedMetricKey) {
               navigate(
-                `/agency/${agencyId}/dashboard?metric=${selectedMetricKey}`
+                `/agency/${agencyId}/dashboard?metric=${selectedMetricKey.toLocaleLowerCase()}`
               );
             }
           }}

--- a/agency-dashboard/src/index.tsx
+++ b/agency-dashboard/src/index.tsx
@@ -16,12 +16,22 @@
 // =============================================================================
 
 import { GlobalStyle } from "@justice-counts/common/components/GlobalStyles";
-import React from "react";
+import React, { useEffect } from "react";
 import ReactDOM from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { BrowserRouter, useLocation } from "react-router-dom";
 
 import App from "./App";
 import { StoreProvider } from "./stores";
+
+function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}
 
 const root = ReactDOM.createRoot(
   document.getElementById("root") as HTMLElement
@@ -30,6 +40,7 @@ root.render(
   <React.StrictMode>
     <GlobalStyle />
     <BrowserRouter>
+      <ScrollToTop />
       <StoreProvider>
         <App />
       </StoreProvider>

--- a/common/components/DataViz/BarChart.tsx
+++ b/common/components/DataViz/BarChart.tsx
@@ -29,7 +29,7 @@ import styled from "styled-components/macro";
 
 import { Datapoint } from "../../types";
 import { rem } from "../../utils";
-import { COMMON_DESKTOP_WIDTH, palette } from "../GlobalStyles";
+import { palette } from "../GlobalStyles";
 import Tooltip from "./Tooltip";
 import { splitUtcString } from "./utils";
 
@@ -39,13 +39,10 @@ const ChartContainer = styled.div`
   width: 100%;
   height: 100%;
   max-height: calc(100% - 220px);
-
-  @media only screen and (min-width: ${COMMON_DESKTOP_WIDTH}px) {
-    display: flex;
-    flex-grow: 1;
-    justify-content: center;
-    align-items: center;
-  }
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-grow: 1;
 `;
 
 const NoReportedData = styled.div`
@@ -142,7 +139,6 @@ const ResponsiveBarChart: React.FC<{
   percentageView = false,
   resizeHeight = false,
 }) => {
-  const isAnnual = data[0]?.frequency === "ANNUAL";
   const renderBarDefinitions = () => {
     // each Recharts Bar component defines a category type in the stacked bar chart
     const barDefinitions = [];
@@ -214,12 +210,14 @@ const ResponsiveBarChart: React.FC<{
             minTickGap={32}
             tick={tickStyle}
             tickLine={false}
-            tickFormatter={(value) => {
+            tickFormatter={(value, index) => {
               if (data.length === 0) {
                 return "";
               }
               const [, , month, year] = splitUtcString(value);
-              return isAnnual ? year : `${month} ${year}`;
+              return data[index].frequency === "ANNUAL"
+                ? year
+                : `${month} ${year}`;
             }}
             tickMargin={12}
           />
@@ -244,7 +242,6 @@ const ResponsiveBarChart: React.FC<{
             content={
               <Tooltip
                 percentOnly={percentageView}
-                isAnnual={isAnnual}
                 dimensionNames={dimensionNames}
               />
             }

--- a/common/components/DataViz/DatapointsView.styles.tsx
+++ b/common/components/DataViz/DatapointsView.styles.tsx
@@ -305,7 +305,7 @@ export const DatapointsViewControlsRow = styled.div`
   display: flex;
   flex-direction: row;
   align-items: center;
-  gap: 24px;
+  gap: 8px;
   margin-top: 32px;
 
   @media only screen and (max-width: ${TABLET_WIDTH - 1}px) {

--- a/common/components/DataViz/DatapointsView.tsx
+++ b/common/components/DataViz/DatapointsView.tsx
@@ -140,7 +140,9 @@ export const DatapointsView: React.FC<{
       )) ||
     datapointsGroupedByAggregateAndDisaggregations?.aggregate ||
     [];
-  const isAnnual = selectedData[0]?.frequency === "ANNUAL";
+
+  // all datapoints have annual frequency
+  const isAnnualOnly = !selectedData.find((dp) => dp.frequency === "MONTHLY");
   const disaggregations = Object.keys(dimensionNamesByDisaggregation || {});
   const disaggregationOptions = [...disaggregations];
   disaggregationOptions.unshift(noDisaggregationOption);
@@ -154,7 +156,7 @@ export const DatapointsView: React.FC<{
   const selectedTimeRangeValue = DataVizTimeRangesMap[timeRange];
 
   useEffect(() => {
-    if (isAnnual && selectedTimeRangeValue === 6) {
+    if (isAnnualOnly && selectedTimeRangeValue === 6) {
       setTimeRange("All");
     }
     if (!disaggregationOptions.includes(disaggregationName)) {
@@ -215,7 +217,7 @@ export const DatapointsView: React.FC<{
           title="Date Range"
           selectedValue={timeRange}
           options={
-            isAnnual
+            isAnnualOnly
               ? Object.keys(DataVizTimeRangesMap).filter(
                   (key) => key !== "6 Months Ago"
                 )

--- a/common/components/DataViz/DatapointsView.tsx
+++ b/common/components/DataViz/DatapointsView.tsx
@@ -71,7 +71,8 @@ const SelectMetricButton = () => (
 const SelectMetricButtonDropdown: React.FC<{
   onSelect: (metricKey: string) => void;
   options: string[];
-}> = ({ onSelect, options }) => (
+  currentMetricName: string;
+}> = ({ onSelect, options, currentMetricName }) => (
   <ExtendedDropdown>
     <DropdownToggle>
       <SelectMetricButton />
@@ -83,6 +84,7 @@ const SelectMetricButtonDropdown: React.FC<{
           onClick={() => {
             onSelect(value);
           }}
+          highlight={currentMetricName === value}
         >
           {value}
         </ExtendedDropdownMenuItem>
@@ -288,6 +290,7 @@ export const DatapointsView: React.FC<{
           <SelectMetricButtonDropdown
             options={Object.values(metricNamesByCategory).flat()}
             onSelect={onMetricsSelect}
+            currentMetricName={metricName}
           />
         )}
         {renderDataVizControls()}

--- a/common/components/DataViz/Legend.tsx
+++ b/common/components/DataViz/Legend.tsx
@@ -26,7 +26,6 @@ const LegendContainer = styled.div`
   align-items: center;
   flex-wrap: wrap;
   margin-bottom: 20px;
-  height: 50px;
   border-top: 1px solid rgba(23, 28, 43, 0.6);
   padding: 16px 0;
   border-bottom: 1px solid rgba(23, 28, 43, 0.6);

--- a/common/components/DataViz/MobileSelectMetricsModal.tsx
+++ b/common/components/DataViz/MobileSelectMetricsModal.tsx
@@ -51,6 +51,7 @@ export const MobileSelectMetricsModal: React.FC<{
     <MobileModalContainer>
       <MobileModalInnerContainer>
         <MobileModalCloseButton onClick={closeModal}>
+          Close
           <CloseIcon />
         </MobileModalCloseButton>
         <MobileModalHeader>{agencyName}</MobileModalHeader>

--- a/common/components/DataViz/Tooltip.tsx
+++ b/common/components/DataViz/Tooltip.tsx
@@ -55,7 +55,6 @@ const TooltipNameWithBottomMargin = styled(TooltipName)`
 
 interface TooltipProps extends RechartsTooltipProps<number, string> {
   percentOnly: boolean;
-  isAnnual: boolean;
   dimensionNames: string[];
 }
 
@@ -64,11 +63,11 @@ const Tooltip: React.FC<TooltipProps> = ({
   payload,
   label,
   percentOnly,
-  isAnnual,
   dimensionNames,
 }) => {
   if (active && payload && payload.length) {
     const [, , month, year] = label ? splitUtcString(label) : [];
+    const datapoint = payload[0].payload as Datapoint;
 
     const renderText = (val: string | number | null, maxValue: number) => {
       if (typeof val !== "number") {
@@ -94,7 +93,6 @@ const Tooltip: React.FC<TooltipProps> = ({
         return null;
       }
 
-      const datapoint = payload[0].payload as Datapoint;
       if (datapoint.dataVizMissingData !== 0) {
         return (
           <TooltipItemContainer>
@@ -125,7 +123,7 @@ const Tooltip: React.FC<TooltipProps> = ({
     return (
       <TooltipContainer>
         <TooltipNameWithBottomMargin>
-          {isAnnual ? year : `${month} ${year}`}
+          {datapoint.frequency === "ANNUAL" ? year : `${month} ${year}`}
         </TooltipNameWithBottomMargin>
         {renderItems()}
       </TooltipContainer>


### PR DESCRIPTION
## Description of the change

<div>

- "24 months 2 years" becomes "4 years", "13 months" becomes "1 year 1 month"
<img width="807" alt="Screen Shot 2023-01-05 at 9 47 59 AM" src="https://user-images.githubusercontent.com/5040739/210846890-d125b099-1316-4ffe-8ac8-af52286b2f5d.png">
<img width="766" alt="Screen Shot 2023-01-05 at 9 48 15 AM" src="https://user-images.githubusercontent.com/5040739/210846896-8146b498-47c9-45ee-9949-7d38090f70bf.png">
<img width="711" alt="Screen Shot 2023-01-05 at 9 50 28 AM" src="https://user-images.githubusercontent.com/5040739/210847034-4e8ded28-0f32-48ff-9b74-80028855bfee.png">
<img width="708" alt="Screen Shot 2023-01-05 at 9 50 36 AM" src="https://user-images.githubusercontent.com/5040739/210847040-75b09546-4658-4fdf-9b16-4b32132d67d8.png">

- Fix legend in Race & Ethnicity overflow
- Add selected metric state for Select Metrics dropdown
- Fix “No reported data for this metric” placement in tablet and mobile
- Scrolling issue when navigating
- Make the url all lower case
- Fix issue with monthly values formatted as yearly (Agency 152 Readmissions show 4 2022 values)
  - I just made each bar say "month year" or "year" depending on whether that datapoint is annual, or monthly
<img width="1216" alt="Screen Shot 2023-01-05 at 9 48 22 AM" src="https://user-images.githubusercontent.com/5040739/210846753-5d4fcd35-8188-4659-913e-8abc39c4ea63.png">

<img width="1217" alt="Screen Shot 2023-01-05 at 9 48 04 AM" src="https://user-images.githubusercontent.com/5040739/210846736-bf2bcb91-73d2-4b54-a165-95385f37d4f1.png">

- [Agency 152] Funding says 1 year of data in the overview, but the chart says No Data Available
  - The issue is that the frontend is receiving datapoints with Null values. In the aggregate case, it seems like we don't need this, but in the disaggregations case, that might be potentially useful because then we'd know what the dimensions are, even if they have no published values?
  - Or maybe we don't want the backend to serve any datapoints w only null values? Then how does the frontend know which dimensions exist?
  - Link to bug: https://dash---justice-counts-agency-dashboard-web-qqec6jbn6a-uc.a.run.app/agency/152
  - I changed my backend to point to https://dash---justice-counts-agency-dashboard-web-qqec6jbn6a-uc.a.run.app/ to verify the fix works
  - So now the overview should say No Data
- Back to Agency Overview button clickable area is too long
- Select Metrics button gap should be 8px
- Add “Close” to mobile modals

</div>

## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Closes #XXXX

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
