### PR TITLE
[Justice Counts] Replace hardcoded email addresses with emails from the DB

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -37,6 +37,7 @@ export type AgencySystems =
 export type AgencyTeam = {
   auth0_user_id: string;
   name: string;
+  email: string;
 };
 
 export const SupervisionSystems: AgencySystems[] = [

--- a/publisher/src/components/Settings/AgencySettings.tsx
+++ b/publisher/src/components/Settings/AgencySettings.tsx
@@ -180,11 +180,10 @@ export const AgencySettings: React.FC = observer(() => {
               </a>
               .
             </AgencySettingsBlockDescription>
-            {agencyTeam?.map(({ name }) => (
+            {agencyTeam?.map(({ name, email }) => (
               <AgencySettingsInfoRow key={name}>
                 {name}
-                {/* email is mocked */}
-                <span>{`${name}@doc1.wa.gov`}</span>
+                <span>{email}</span>
               </AgencySettingsInfoRow>
             ))}
           </AgencySettingsBlock>


### PR DESCRIPTION
## Description of the change

This PR grabs the email address from the agency response instead of hard coding the email addresses in the Team Management section of Agency Settings. 

Results after deploying to my playtesting branch and using the `nichelle-hall/surface-emails` branch in the BE. 

<img width="715" alt="Screen Shot 2023-01-06 at 11 12 11 AM" src="https://user-images.githubusercontent.com/19961693/211040953-3fe0e7b0-1b6b-4e6b-87f3-cf19a7b58c8a.png">


## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
