### PR TITLE
send email_verified when retrieving user permissions

### DIFF
--- a/publisher/src/stores/UserStore.ts
+++ b/publisher/src/stores/UserStore.ts
@@ -154,6 +154,10 @@ class UserStore {
     return this.name || this.email;
   }
 
+  get email_verified(): boolean | undefined {
+    return this.authStore.user?.email_verified;
+  }
+
   async updateAndRetrieveUserPermissionsAndAgencies() {
     try {
       const response = (await this.api.request({
@@ -162,6 +166,7 @@ class UserStore {
         body: {
           name: this.name,
           email: this.email,
+          email_verified: this.email_verified,
         },
       })) as Response;
       const { agencies: userAgencies, permissions } = await response.json();


### PR DESCRIPTION
## Description of the change

We need to send email_verified on first login so that we can update the invitation in the Team Management section of Agency Settings ([figma](https://www.figma.com/file/dvX3yg7FMGJSWFaqHWrWgQ/Justice-Counts-Publisher?node-id=6255%3A15227&t=EL8ATUOzlRF42TOS-0)). I added it to the `UserStore.updateAndRetrieveUserPermissionsAndAgencies` method since it is called on login. 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
