### PR TITLE
Get rid of "N/A" in Includes/Excludes

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -15,6 +15,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+import { MetricConfigurationSettingsOptions } from "../publisher/src/components/MetricConfiguration";
+
 export enum Permission {
   RECIDIVIZ_ADMIN = "recidiviz_admin",
   SWITCH_AGENCIES = "switch_agencies",
@@ -114,8 +116,6 @@ export type MetricDisaggregationDimensionsWithErrors =
   MetricDisaggregationDimensions & {
     error?: string;
   };
-
-export type MetricConfigurationSettingsOptions = "Yes" | "No" | "N/A";
 
 export type MetricConfigurationSettings = {
   key: string;

--- a/publisher/src/components/MetricConfiguration/types.ts
+++ b/publisher/src/components/MetricConfiguration/types.ts
@@ -21,7 +21,7 @@ import {
   ReportFrequency,
 } from "@justice-counts/common/types";
 
-export const metricConfigurationSettingsOptions = ["N/A", "No", "Yes"] as const;
+export const metricConfigurationSettingsOptions = ["No", "Yes"] as const;
 export type MetricConfigurationSettingsOptions =
   typeof metricConfigurationSettingsOptions[number];
 


### PR DESCRIPTION
## Description of the change

Removes the "N/A" option in the Metric Definitions (Includes/Excludes). The backend may provide `null` for some of the includes/excludes fields and that will render as no options selected.

We used to have 3 visible options:
<img width="687" alt="Screenshot 2023-01-11 at 5 16 59 PM" src="https://user-images.githubusercontent.com/59492998/211930018-13a66c7e-cb2c-4dde-8ee7-5c01d33bb588.png">



Now, there are only 2 (Yes / No):
<img width="690" alt="Screenshot 2023-01-11 at 5 16 48 PM" src="https://user-images.githubusercontent.com/59492998/211930026-bc7374bb-17f0-48e7-a3c8-ae5e52891d9e.png">


Demo (what it looks like if the backend were to send `null` (in the `included` property) for the first two includes/excludes:
<img width="1728" alt="Screenshot 2023-01-11 at 5 07 41 PM" src="https://user-images.githubusercontent.com/59492998/211930041-18833381-38cc-452d-af53-7db47633fb40.png">

Since I had to hack together a mock response from the backend - it was tough to record a video of the behavior because I would have had to create some temp. state to update those null'd fields (totally doable). Let me know if the above works as a visual - or if you'd rather see something more interactive!

## Related issues

Closes #293

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
