### PR TITLE
Fix link to metric config in data entry form, fix back button on metric config

### DIFF
--- a/publisher/src/components/Reports/DataEntryForm.tsx
+++ b/publisher/src/components/Reports/DataEntryForm.tsx
@@ -374,7 +374,9 @@ const DataEntryForm: React.FC<{
                       {disabledMetricsNames.length > 1 ? "have" : "has"} been
                       disabled. If you believe this is incorrect, go to{" "}
                       <DisabledMetricsInfoLink
-                        onClick={() => navigate("/settings/metric-config")}
+                        onClick={() =>
+                          navigate(`/agency/${agencyId}/settings/metric-config`)
+                        }
                       >
                         Metric Configuration
                       </DisabledMetricsInfoLink>{" "}

--- a/publisher/src/components/Settings/hooks.ts
+++ b/publisher/src/components/Settings/hooks.ts
@@ -27,8 +27,10 @@ export const useSettingsSearchParams = (): [
   const [searchParams, setSearchParams] = useSearchParams();
 
   const settingsSearchParams = getSettingsSearchParams(searchParams);
+  const { system, metric } = settingsSearchParams;
+  const shouldReplace = !system && !metric;
   const setSettingsSearchParams = (params: SettingsSearchParams) => {
-    setSearchParams(params);
+    setSearchParams(params, { replace: shouldReplace });
   };
 
   return [settingsSearchParams, setSettingsSearchParams];


### PR DESCRIPTION
## Description of the change

> Fix link to metric config at the bottom of data entry form
Fix back button behavior on metric config page

## Type of change
Type: Bug

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Closes #300 #301 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
