### PR TITLE
Partially refactor metric config store to provide separate initiators from updators

### DIFF
--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -57,7 +57,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
       metricDefinitionSettings,
       dimensions,
       dimensionDefinitionSettings,
-      updateMetricDefinitionSetting,
+      updateMetricDefinitionSettingIncluded,
       updateDimensionDefinitionSetting,
       saveMetricSettings,
     } = metricConfigStore;
@@ -107,7 +107,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
             currentSettingDefaultValue =
               metricDefinitionSettings[systemMetricKey][settingKey].default;
 
-            updateMetricDefinitionSetting(
+            updateMetricDefinitionSettingIncluded(
               systemSearchParam,
               metricSearchParam,
               settingKey,
@@ -234,7 +234,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
                                 if (systemSearchParam && metricSearchParam) {
                                   if (isMetricDefinitionSettings) {
                                     const updatedSetting =
-                                      updateMetricDefinitionSetting(
+                                      updateMetricDefinitionSettingIncluded(
                                         systemSearchParam,
                                         metricSearchParam,
                                         settingKey,


### PR DESCRIPTION
## Description of the change

So I proposed this refactor because I would read the function name as `updateMetricEnabledStatus`, which I would expect to update the `enabled` part of a metric configuration, but the function itself is also used to put entire metric config objects in the store.

In the case of putting the entire metric config object in the store, as used in `initializeMetricConfigStoreValues`, I separate that logic out into an `initializeMetric` function. Then separate `updateMetricEnabledStatus`, `updateMetricReportFrequency` functions update just the relevant keys in the store.

I thought of taking a page from Ivan's work (https://github.com/Recidiviz/justice-counts/pull/315/files) that reused the initializer as also an updater, but I decided against it so that the initializer could be typed to instantiate whole objects and not partial keys.

## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Closes #XXXX

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
