### PR TITLE
[Bug] Prevent rendering of metric level context component when the context array is empty

### DIFF
--- a/publisher/src/components/MetricConfiguration/MetricContextConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricContextConfiguration.tsx
@@ -78,10 +78,11 @@ export const ContextConfiguration: React.FC = observer(() => {
     }
   };
 
+  if (activeContextKeys.length === 0) return null;
+
   return (
     <MetricContextContainer enabled={metrics[systemMetricKey]?.enabled}>
       <MetricContextHeader>Context</MetricContextHeader>
-
       {activeContextKeys.map((contextKey) => {
         const currentContext = contexts[systemMetricKey][contextKey];
 

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -97,12 +97,22 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
       ? metricDefinitionSettingsKeys
       : dimensionDefinitionSettingsKeys;
 
+    const hasActiveDisaggregationAndDimensionKey =
+      activeDisaggregationKey && activeDimensionKey;
+
     const dimensionContextsMap =
-      activeDisaggregationKey &&
-      activeDimensionKey &&
-      dimensionContexts[systemMetricKey][activeDisaggregationKey]?.[
+      hasActiveDisaggregationAndDimensionKey &&
+      dimensionContexts[systemMetricKey]?.[activeDisaggregationKey]?.[
         activeDimensionKey
       ];
+
+    const noSettingsAvailable =
+      !activeSettingsKeys ||
+      Boolean(
+        !activeSettingsKeys?.length &&
+          activeDimensionKey &&
+          !dimensionContextsMap
+      );
 
     const [showDefaultSettings, setShowDefaultSettings] = useState(false);
 
@@ -291,14 +301,11 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
           )}
 
           {/* Display when user is viewing a dimension & there are no settings available */}
-          {(!activeSettingsKeys?.length &&
-            activeDimensionKey &&
-            !dimensionContextsMap) ||
-            (!activeSettingsKeys && (
-              <DefinitionsSubTitle>
-                Technical Definitions are not available for this metric yet.
-              </DefinitionsSubTitle>
-            ))}
+          {noSettingsAvailable && (
+            <DefinitionsSubTitle>
+              Technical Definitions are not available for this metric yet.
+            </DefinitionsSubTitle>
+          )}
 
           {/* Display when dimension has additional contexts */}
           {dimensionContextsMap && (

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -291,13 +291,14 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
           )}
 
           {/* Display when user is viewing a dimension & there are no settings available */}
-          {!activeSettingsKeys?.length &&
+          {(!activeSettingsKeys?.length &&
             activeDimensionKey &&
-            !dimensionContextsMap && (
+            !dimensionContextsMap) ||
+            (!activeSettingsKeys && (
               <DefinitionsSubTitle>
                 Technical Definitions are not available for this metric yet.
               </DefinitionsSubTitle>
-            )}
+            ))}
 
           {/* Display when dimension has additional contexts */}
           {dimensionContextsMap && (


### PR DESCRIPTION
## Description of the change

It looks like there are some metrics that do not have a metric level context. This fix prevents us from rendering any of the context component (right now it just shows the header) when the metric level context array is empty. I thought that all metric level contexts have at least one free text box - but I'm not 100% sure. Either way, this helped expose the unnecessary rendering.

<img width="1725" alt="Screenshot 2023-01-20 at 8 04 43 PM" src="https://user-images.githubusercontent.com/59492998/213831055-05c23a1e-3bd3-4e94-8e8c-921ce16573ac.png">

## Related issues

Closes #326 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
