### PR TITLE
[1/n] get role and invitation status from agency json response

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -34,11 +34,13 @@ export type AgencySystems =
   | "PRETRIAL_SUPERVISION"
   | "OTHER_SUPERVISION";
 
-export type AgencyTeam = {
+export interface AgencyTeam {
   auth0_user_id: string;
   name: string;
   email: string;
-};
+  role: string;
+  invitation_status: string;
+}
 
 export const SupervisionSystems: AgencySystems[] = [
   "SUPERVISION",

--- a/publisher/src/components/Settings/AgencySettingsTeamManagement.tsx
+++ b/publisher/src/components/Settings/AgencySettingsTeamManagement.tsx
@@ -84,18 +84,14 @@ export const AgencySettingsTeamManagement: React.FC<{
   // edit mode simulation, transforming team to include status id and email
   const [team, setTeam] = useState(() =>
     agencyTeam
-      ? agencyTeam.map((member, index) => {
-          let isInvited = false;
-          let isAdmin = false;
-          if (index % 2 === 0) isInvited = true;
-          if (index % 3 === 0) isAdmin = true;
-
+      ? agencyTeam.map((member) => {
           return {
             ...member,
-            id: member.name,
-            email: `${member.name.toLowerCase().replace(" ", "_")}@doc1.wa.gov`,
-            isInvited,
-            isAdmin,
+            id: member.email,
+            name: member.name,
+            email: member.email,
+            isInvited: member.invitation_status === "PENDING",
+            isAdmin: member.role === "ADMIN",
           };
         })
       : []
@@ -114,10 +110,12 @@ export const AgencySettingsTeamManagement: React.FC<{
       } = {
         name,
         email,
-        id: name,
+        id: email,
         auth0_user_id: "",
         isInvited: true,
         isAdmin: false,
+        role: "CONTRIBUTOR",
+        invitation_status: "PENDING",
       };
       setTeam([newMember, ...team]);
       setNameValue("");
@@ -133,13 +131,13 @@ export const AgencySettingsTeamManagement: React.FC<{
   };
   const handleMakeAdmin = (memberIds: string[]) => {
     const updatedTeam = team.map((member) =>
-      memberIds.includes(member.id) ? { ...member, isAdmin: true } : member
+      memberIds.includes(member.email) ? { ...member, isAdmin: true } : member
     );
     setTeam(updatedTeam);
     setCheckedMembersIds([]);
   };
   const handleRemoveMembers = (memberIds: string[]) => {
-    setTeam(team.filter((member) => !memberIds.includes(member.id)));
+    setTeam(team.filter((member) => !memberIds.includes(member.email)));
     setCheckedMembersIds([]);
     setIsModalOpen(false);
   };
@@ -179,7 +177,6 @@ export const AgencySettingsTeamManagement: React.FC<{
                     <TeamMemberBadge isInvited>Invited</TeamMemberBadge>
                   )}
                 </TeamMemberName>
-                {/* email is mocked */}
                 <span>{email}</span>
               </AgencySettingsInfoRow>
             ))}
@@ -228,7 +225,6 @@ export const AgencySettingsTeamManagement: React.FC<{
                   onClick={allowEdit ? () => handleCheckMembers(id) : undefined}
                 >
                   <TeamMemberInfoContainer>
-                    {/* fake isInvited simulation */}
                     <TeamMemberName isInvited={isInvited}>
                       {name}
                       {isAdmin && (
@@ -238,7 +234,6 @@ export const AgencySettingsTeamManagement: React.FC<{
                         <TeamMemberBadge isInvited>Invited</TeamMemberBadge>
                       )}
                     </TeamMemberName>
-                    {/* email is mocked */}
                     <TeamMemberEmail>{email}</TeamMemberEmail>
                   </TeamMemberInfoContainer>
                   {allowEdit && (


### PR DESCRIPTION
## Description of the change

Surfaces role and invitation status for a user from agency response, removes mocks. 
<img width="773" alt="Screen Shot 2023-01-23 at 7 47 55 PM" src="https://user-images.githubusercontent.com/19961693/214198818-586e4e13-90aa-45d1-a286-099d2433bc4a.png">


## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
