### PR TITLE
[Fix] Adjustments to "Technical Definitions are not available for this metric yet." logic

### DIFF
--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -108,7 +108,6 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
 
     const hasMinOneContext =
       dimensionContextsMap && Object.values(dimensionContextsMap).length > 0;
-    console.log(hasMinOneContext);
 
     const noSettingsAvailable =
       !activeSettingsKeys ||

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -307,7 +307,8 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
           {/* Display when user is viewing a dimension & there are no settings available */}
           {noSettingsAvailable && !hasMinOneContext && (
             <DefinitionsSubTitle>
-              Technical Definitions are not available for this metric yet.
+              Technical Definitions are not available for this{" "}
+              {activeDimensionKey ? "breakdown." : "metric yet."}
             </DefinitionsSubTitle>
           )}
 

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -106,6 +106,10 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
         activeDimensionKey
       ];
 
+    const hasMinOneContext =
+      dimensionContextsMap && Object.values(dimensionContextsMap).length > 0;
+    console.log(hasMinOneContext);
+
     const noSettingsAvailable =
       !activeSettingsKeys ||
       Boolean(
@@ -301,7 +305,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
           )}
 
           {/* Display when user is viewing a dimension & there are no settings available */}
-          {noSettingsAvailable && (
+          {noSettingsAvailable && !hasMinOneContext && (
             <DefinitionsSubTitle>
               Technical Definitions are not available for this metric yet.
             </DefinitionsSubTitle>

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -56,6 +56,7 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
     const {
       metrics,
       metricDefinitionSettings,
+      contexts,
       dimensions,
       dimensionDefinitionSettings,
       dimensionContexts,
@@ -106,8 +107,13 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
         activeDimensionKey
       ];
 
-    const hasMinOneContext =
+    const hasMinOneDimensionContext =
       dimensionContextsMap && Object.values(dimensionContextsMap).length > 0;
+
+    const hasMinOneMetricLevelContext =
+      !activeDimensionKey &&
+      contexts[systemMetricKey] &&
+      Object.values(contexts[systemMetricKey]).length > 0;
 
     const noSettingsAvailable =
       !activeSettingsKeys ||
@@ -304,12 +310,14 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
           )}
 
           {/* Display when user is viewing a dimension & there are no settings available */}
-          {noSettingsAvailable && !hasMinOneContext && (
-            <DefinitionsSubTitle>
-              Technical Definitions are not available for this{" "}
-              {activeDimensionKey ? "breakdown." : "metric yet."}
-            </DefinitionsSubTitle>
-          )}
+          {noSettingsAvailable &&
+            !hasMinOneDimensionContext &&
+            !hasMinOneMetricLevelContext && (
+              <DefinitionsSubTitle>
+                Technical Definitions are not available for this{" "}
+                {activeDimensionKey ? "breakdown." : "metric yet."}
+              </DefinitionsSubTitle>
+            )}
 
           {/* Display when dimension has additional contexts */}
           {dimensionContextsMap && (


### PR DESCRIPTION
## Description of the change

Adjusts the logic that displays the "Technical definitions are not available for this metric yet." for the top level metric and dimensions.

Description of the different cases as outlined in issue #336:

Case 1: Top-level metric does not have any includes/excludes defined.
We should show "Technical Definitions are not available for this metric yet." (I believe this is the current behavior already!)

Case 2: Dimension does not have any includes/excludes define, BUT it does have at least one context (i.e. all Other dimensions will fall in this category).
We should not show the "Technical Definitions are not available for this metric yet.", and should just show the text box.

Case 3: Dimension does not have any includes/excludes define, and doesn't have a context either (all Unknown dimensions will fall in this category).
We should say ""There are no technical definitions for this breakdown." instead of "Technical Definitions are not available for this metric yet." This will require a small change.

https://user-images.githubusercontent.com/59492998/214896450-88608331-a01c-4e6d-bb54-0d320c98f32a.mov

## Related issues

Closes #336 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
