### PR TITLE
[Fix] Add starting month selection for an annual metric

### DIFF
--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -301,10 +301,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                     label="Calendar Year (Jan)"
                     value="Calendar Year (Jan)"
                     checked={
-                      metricEnabled &&
-                      (startingMonth === 1 ||
-                        (!startingMonth &&
-                          customOrDefaultFrequency === "ANNUAL"))
+                      metricEnabled && (startingMonth === 1 || !startingMonth)
                     }
                     onChange={() =>
                       handleUpdateMetricReportFrequency({

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -300,7 +300,11 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                     name="metric-config-frequency"
                     label="Calendar Year (Jan)"
                     value="Calendar Year (Jan)"
-                    checked={metricEnabled && startingMonth === 1}
+                    checked={
+                      metricEnabled &&
+                      (startingMonth === 1 ||
+                        customOrDefaultFrequency === "ANNUAL")
+                    }
                     onChange={() =>
                       handleUpdateMetricReportFrequency({
                         customFrequency: "ANNUAL",

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -303,7 +303,8 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                     checked={
                       metricEnabled &&
                       (startingMonth === 1 ||
-                        customOrDefaultFrequency === "ANNUAL")
+                        (!startingMonth &&
+                          customOrDefaultFrequency === "ANNUAL"))
                     }
                     onChange={() =>
                       handleUpdateMetricReportFrequency({


### PR DESCRIPTION
## Description of the change

For some `ANNUAL` metrics, there is no default selection for the starting month (it should default to `Calendar Year (Jan)`). 

<img width="430" alt="Screenshot 2023-01-31 at 11 31 46 AM" src="https://user-images.githubusercontent.com/59492998/215821781-e81987b0-690e-4e83-abcc-1210d477d2fc.png">

I'm wondering if this is the right fix or if I should adjust the backend for these cases (when the backend sends `null` for `starting_month`). My adjustment might just be a bandaid if the backend is meant to send `1` for the `starting_month`. Open to your thoughts!

<img width="226" alt="Screenshot 2023-01-31 at 11 32 49 AM" src="https://user-images.githubusercontent.com/59492998/215822074-dce0e962-8f60-4033-b2f5-42c16e08ddc4.png">


## Related issues

Closes #353

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
