### PR TITLE
[Fix] Add spacing between context items

### DIFF
--- a/publisher/src/components/Forms/BinaryRadioButton.tsx
+++ b/publisher/src/components/Forms/BinaryRadioButton.tsx
@@ -43,7 +43,6 @@ export const BinaryRadioGroupQuestion = styled.div`
   ${typography.sizeCSS.medium}
   display: flex;
   align-items: center;
-  margin-top: 22px;
   color: ${palette.solid.darkgrey};
 `;
 

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -502,7 +502,9 @@ export const MetricContextHeader = styled.div`
   margin: 40px 0 20px 0;
 `;
 
-export const MetricContextItem = styled.div``;
+export const MetricContextItem = styled.div`
+  margin-bottom: 16px;
+`;
 
 export const Label = styled.div<{ noBottomMargin?: boolean }>`
   ${typography.sizeCSS.medium};


### PR DESCRIPTION
## Description of the change

Adjust spacing between context boxes to turn something like this:

<img width="679" alt="Screenshot 2023-01-31 at 11 59 14 AM" src="https://user-images.githubusercontent.com/59492998/215830621-cc690573-e83b-4cac-8a85-6ba4c00a9633.png">


Into this:

<img width="684" alt="Screenshot 2023-01-31 at 11 57 48 AM" src="https://user-images.githubusercontent.com/59492998/215830285-0bd0658e-577a-4036-a53c-821e20f7b68f.png">

I double checked all other context box spacings and everything looks fine after this adjustment - but please let me know if you catch any strange spacing issues!

## Related issues

Closes #354 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
