### PR TITLE
[Fix] Adjust dimension box padding to prevent arrow overlap in long dimension names

### DIFF
--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -394,7 +394,7 @@ export const Dimension = styled.div<{ enabled?: boolean; inView?: boolean }>`
   display: flex;
   align-items: center;
   gap: 12px;
-  padding: 17px 10px;
+  padding: 17px 40px 17px 10px;
   border-bottom: 1px solid ${palette.highlight.grey4};
   position: relative;
   background: ${({ inView }) =>


### PR DESCRIPTION
## Description of the change

Adjusts the padding of the dimension boxes for dimensions with really long names.

Example of current behavior:
<img width="612" alt="Screenshot 2023-01-31 at 12 06 51 PM" src="https://user-images.githubusercontent.com/59492998/215832385-bee74a11-a803-40b5-8017-53af66ca7f3a.png">


Example w/ padding adjustment:
<img width="612" alt="Screenshot 2023-01-31 at 12 04 25 PM" src="https://user-images.githubusercontent.com/59492998/215832352-676c2bbb-35c0-4375-b705-e43aeab4474a.png">

## Related issues

Closes #357

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
