### PR TITLE
Small adjustments to the First Run Experience

### DIFF
--- a/publisher/src/components/Onboarding/Onboarding.tsx
+++ b/publisher/src/components/Onboarding/Onboarding.tsx
@@ -202,16 +202,15 @@ const OnboardingModal = styled.div<{
   box-shadow: 0px 4px 10px rgba(53, 83, 98, 0.4);
   animation: ${float} 3s infinite ease-in-out;
 
-  @media only screen and (max-width: ${TWO_PANEL_MAX_WIDTH}px) {
-    ${({ position, modalHeight }) => {
-      if (position === "publishdata") {
+  @media only screen and (max-width: ${ONE_PANEL_MAX_WIDTH}px) {
+    ${({ position }) => {
+      if (position === "reportsummary") {
         return `
-          top: calc(100% - ${modalHeight}px - 28px);
-          right: calc(100% - 532px - ${SIDE_PANEL_WIDTH}px);
-          left: ${SIDE_PANEL_WIDTH}px;
+          top: ${HEADER_BAR_HEIGHT}px;
+          right: 10px;
+          left: unset;
         `;
       }
-      return ``;
     }}
   }
 `;

--- a/publisher/src/components/Onboarding/Onboarding.tsx
+++ b/publisher/src/components/Onboarding/Onboarding.tsx
@@ -325,7 +325,7 @@ const OnboardingFadedContainer = styled.div<OnboardingFadedContainerProps>`
     }
     if (position === "center") {
       return `
-        width: ${DATA_ENTRY_WIDTH}px; 
+        width: ${DATA_ENTRY_WIDTH + 20}px; 
       `;
     }
   }};
@@ -355,6 +355,11 @@ const OnboardingFadedContainer = styled.div<OnboardingFadedContainerProps>`
       if (position === "right" || position === "left") {
         return `
           display: none;
+        `;
+      }
+      if (position === "center") {
+        return `
+          margin-left: 0;
         `;
       }
     }};

--- a/publisher/src/components/Onboarding/Onboarding.tsx
+++ b/publisher/src/components/Onboarding/Onboarding.tsx
@@ -206,9 +206,10 @@ const OnboardingModal = styled.div<{
     ${({ position }) => {
       if (position === "reportsummary") {
         return `
-          top: ${HEADER_BAR_HEIGHT}px;
-          right: 10px;
-          left: unset;
+          top: unset;
+          left: calc(100% - 532px - 24px);
+          bottom: 24px;
+          right: 24px;
         `;
       }
     }}
@@ -446,10 +447,10 @@ const OnboardingSessionView = ({
       html: (
         <>
           <p>
-            You can view and edit your agency’s Justice Counts metrics in the{" "}
-            <strong>Settings</strong> page, accessible from the menu bar at the
-            top of the screen. You can also change your display name and email
-            from this page.
+            You can view and edit the Justice Counts metrics your agency is able
+            to record in the <strong>Settings</strong> page, accessible from the
+            menu bar at the top of the screen. You can also change your display
+            name and email from this page.
           </p>
         </>
       ),

--- a/publisher/src/components/Onboarding/Onboarding.tsx
+++ b/publisher/src/components/Onboarding/Onboarding.tsx
@@ -206,6 +206,13 @@ const OnboardingModal = styled.div<{
     ${({ position }) => {
       if (position === "reportsummary") {
         return `
+          &::after {
+            content: "Available on wider screens.";
+            position: absolute;
+            bottom: 23px;
+            font-size: 12px;
+          }
+          
           top: unset;
           left: calc(100% - 532px - 24px);
           bottom: 24px;


### PR DESCRIPTION
## Description of the change

Makes the following adjustments to the First Run Experience:

* Update copy for the Settings modal

  Before:
  <img width="328" alt="Screenshot 2023-02-01 at 12 56 20 PM" src="https://user-images.githubusercontent.com/59492998/216124578-82d71512-926a-4ec8-8e23-8cf9e4c246f8.png">

  After:
    <img width="328" alt="Screenshot 2023-02-01 at 12 57 39 PM" src="https://user-images.githubusercontent.com/59492998/216124591-43d5e996-95d7-406e-b486-d8397b9ac91f.png">

* Fix opacity overlay gap in data entry view
* Adjust positioning of Record Summary modal in responsive view (moved to bottom right corner)
  * Adds text that lets a user know that the Record Summary is available in wider screens


https://user-images.githubusercontent.com/59492998/216125291-d302342b-9f45-4b6e-b30f-974ae636f834.mov



## Related issues

Closes #362 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
