### PR TITLE
Add metric and dimension descriptions in the Metric Config settings

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -207,6 +207,7 @@ export interface MetricDisaggregationDimensions {
   enabled?: boolean;
   settings?: MetricConfigurationSettings[];
   display_name?: string;
+  description?: string;
   race?: string;
   ethnicity?: string;
   datapoints?: RawDatapoint[];

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -683,6 +683,10 @@ export const DefinitionsDescription = styled.div`
   }
 `;
 
+export const MetricBreakdownDescription = styled(DefinitionsDescription)`
+  margin-bottom: 20px;
+`;
+
 export const RevertToDefaultButton = styled.div`
   ${typography.sizeCSS.normal}
   width: 314px;

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -39,6 +39,7 @@ import {
   DefinitionsSubTitle,
   DefinitionsTitle,
   DimensionContexts,
+  MetricBreakdownDescription,
   MetricSettings,
   RevertToDefaultButton,
 } from ".";
@@ -78,6 +79,13 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
         dimensions[systemMetricKey]?.[activeDisaggregationKey]?.[
           activeDimensionKey
         ]?.label;
+
+    const activeMetricOrDimensionDescription =
+      activeDimensionKey && activeDisaggregationKey
+        ? dimensions[systemMetricKey]?.[activeDisaggregationKey]?.[
+            activeDimensionKey
+          ]?.description
+        : metrics[systemMetricKey]?.description;
 
     const metricDefinitionSettingsKeys =
       metricDefinitionSettings[systemMetricKey] &&
@@ -233,6 +241,10 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
 
           {Boolean(activeSettingsKeys?.length) && (
             <>
+              <MetricBreakdownDescription>
+                {activeMetricOrDimensionDescription}
+              </MetricBreakdownDescription>
+
               <DefinitionsSubTitle>Definitions</DefinitionsSubTitle>
               <DefinitionsDescription>
                 Indicate which of the following categories your agency considers
@@ -313,10 +325,15 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
           {noSettingsAvailable &&
             !hasMinOneDimensionContext &&
             !hasMinOneMetricLevelContext && (
-              <DefinitionsSubTitle>
-                Technical Definitions are not available for this{" "}
-                {activeDimensionKey ? "breakdown." : "metric yet."}
-              </DefinitionsSubTitle>
+              <>
+                <MetricBreakdownDescription>
+                  {activeMetricOrDimensionDescription}
+                </MetricBreakdownDescription>
+                <DefinitionsSubTitle>
+                  Technical Definitions are not available for this{" "}
+                  {activeDimensionKey ? "breakdown." : "metric yet."}
+                </DefinitionsSubTitle>
+              </>
             )}
 
           {/* Display when dimension has additional contexts */}

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -238,13 +238,12 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
           <DefinitionsTitle>
             {activeMetricOrDimensionDisplayName}
           </DefinitionsTitle>
+          <MetricBreakdownDescription>
+            {activeMetricOrDimensionDescription}
+          </MetricBreakdownDescription>
 
           {Boolean(activeSettingsKeys?.length) && (
             <>
-              <MetricBreakdownDescription>
-                {activeMetricOrDimensionDescription}
-              </MetricBreakdownDescription>
-
               <DefinitionsSubTitle>Definitions</DefinitionsSubTitle>
               <DefinitionsDescription>
                 Indicate which of the following categories your agency considers
@@ -326,9 +325,6 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
             !hasMinOneDimensionContext &&
             !hasMinOneMetricLevelContext && (
               <>
-                <MetricBreakdownDescription>
-                  {activeMetricOrDimensionDescription}
-                </MetricBreakdownDescription>
                 <DefinitionsSubTitle>
                   Technical Definitions are not available for this{" "}
                   {activeDimensionKey ? "breakdown." : "metric yet."}

--- a/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricDefinitions.tsx
@@ -324,12 +324,10 @@ export const MetricDefinitions: React.FC<MetricDefinitionsProps> = observer(
           {noSettingsAvailable &&
             !hasMinOneDimensionContext &&
             !hasMinOneMetricLevelContext && (
-              <>
-                <DefinitionsSubTitle>
-                  Technical Definitions are not available for this{" "}
-                  {activeDimensionKey ? "breakdown." : "metric yet."}
-                </DefinitionsSubTitle>
-              </>
+              <DefinitionsSubTitle>
+                Technical Definitions are not available for this{" "}
+                {activeDimensionKey ? "breakdown." : "metric yet."}
+              </DefinitionsSubTitle>
             )}
 
           {/* Display when dimension has additional contexts */}

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -90,6 +90,7 @@ class MetricConfigStore {
           enabled?: boolean;
           contexts?: { key: string; value: string }[];
           label?: string;
+          description?: string;
           key?: string;
           race?: Races;
           ethnicity?: Ethnicities;
@@ -270,12 +271,14 @@ class MetricConfigStore {
                   ? {
                       label: dimension.label,
                       key: dimension.key,
+                      description: dimension.description,
                       race: dimension.race,
                       ethnicity: dimension.ethnicity,
                     }
                   : {
                       label: dimension.label,
                       key: dimension.key,
+                      description: dimension.description,
                     };
 
               /** Initialize Dimension Status (Enabled/Disabled) */
@@ -617,6 +620,9 @@ class MetricConfigStore {
         metadata.label;
       this.dimensions[systemMetricKey][disaggregationKey][dimensionKey].key =
         metadata.key;
+      this.dimensions[systemMetricKey][disaggregationKey][
+        dimensionKey
+      ].description = metadata.description;
 
       if (disaggregationKey === RACE_ETHNICITY_DISAGGREGATION_KEY) {
         this.dimensions[systemMetricKey][disaggregationKey][dimensionKey].race =


### PR DESCRIPTION
## Description of the change

Adds metric-level and dimension-level descriptions in the Metric Configuration settings.

Demo:

https://user-images.githubusercontent.com/59492998/216123174-bc280b6a-942e-440f-81e5-ca7a99cb9780.mov

## Related issues

Closes #363 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
