### PR TITLE
Fix initializing metric config values

### DIFF
--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -130,7 +130,6 @@ export const MetricConfiguration: React.FC = observer(() => {
 
   useEffect(() => {
     const initialize = async () => {
-      setIsLoading(true);
       await initializeMetricConfiguration();
     };
 

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -366,7 +366,9 @@ class MetricConfigStore {
     );
 
     /** Initialize nested objects for quick lookup and update and reduce re-renders */
-    this.metricDefinitionSettings[systemMetricKey] = {};
+    if (!this.metricDefinitionSettings[systemMetricKey]) {
+      this.metricDefinitionSettings[systemMetricKey] = {};
+    }
     this.metricDefinitionSettings[systemMetricKey][settingKey] =
       metricDefinitionSettings;
   };
@@ -383,7 +385,9 @@ class MetricConfigStore {
     );
 
     /** Initialize nested objects for quick lookup and update and reduce re-renders */
-    this.disaggregations[systemMetricKey] = {};
+    if (!this.disaggregations[systemMetricKey]) {
+      this.disaggregations[systemMetricKey] = {};
+    }
     this.disaggregations[systemMetricKey][disaggregationKey] =
       disaggregationData;
   };
@@ -404,9 +408,15 @@ class MetricConfigStore {
     );
 
     /** Initialize nested objects for quick lookup and update and reduce re-renders */
-    this.dimensions[systemMetricKey] = {};
-    this.dimensions[systemMetricKey][disaggregationKey] = {};
-    this.dimensions[systemMetricKey][disaggregationKey][dimensionKey] = {};
+    if (!this.dimensions[systemMetricKey]) {
+      this.dimensions[systemMetricKey] = {};
+    }
+    if (!this.dimensions[systemMetricKey][disaggregationKey]) {
+      this.dimensions[systemMetricKey][disaggregationKey] = {};
+    }
+    if (!this.dimensions[systemMetricKey][disaggregationKey][dimensionKey]) {
+      this.dimensions[systemMetricKey][disaggregationKey][dimensionKey] = {};
+    }
 
     this.dimensions[systemMetricKey][disaggregationKey][dimensionKey].label =
       dimensionData.label;
@@ -437,6 +447,21 @@ class MetricConfigStore {
       metricKey
     );
 
+    if (!this.dimensionContexts[systemMetricKey]) {
+      this.dimensionContexts[systemMetricKey] = {};
+    }
+
+    if (!this.dimensionContexts[systemMetricKey][disaggregationKey]) {
+      this.dimensionContexts[systemMetricKey][disaggregationKey] = {};
+    }
+
+    if (
+      !this.dimensionContexts[systemMetricKey][disaggregationKey][dimensionKey]
+    ) {
+      this.dimensionContexts[systemMetricKey][disaggregationKey][dimensionKey] =
+        {};
+    }
+
     this.dimensionContexts[systemMetricKey][disaggregationKey][dimensionKey][
       contextKey
     ] = { label };
@@ -460,7 +485,9 @@ class MetricConfigStore {
     );
 
     /** Initialize nested objects for quick lookup and update and reduce re-renders */
-    this.contexts[systemMetricKey] = {};
+    if (!this.contexts[systemMetricKey]) {
+      this.contexts[systemMetricKey] = {};
+    }
     this.contexts[systemMetricKey][contextKey] = contextData;
   };
 
@@ -701,6 +728,24 @@ class MetricConfigStore {
       system,
       metricKey
     );
+
+    if (!this.dimensionDefinitionSettings[systemMetricKey]) {
+      this.dimensionDefinitionSettings[systemMetricKey] = {};
+    }
+
+    if (!this.dimensionDefinitionSettings[systemMetricKey][disaggregationKey]) {
+      this.dimensionDefinitionSettings[systemMetricKey][disaggregationKey] = {};
+    }
+
+    if (
+      !this.dimensionDefinitionSettings[systemMetricKey][disaggregationKey][
+        dimensionKey
+      ]
+    ) {
+      this.dimensionDefinitionSettings[systemMetricKey][disaggregationKey][
+        dimensionKey
+      ] = {};
+    }
 
     this.dimensionDefinitionSettings[systemMetricKey][disaggregationKey][
       dimensionKey


### PR DESCRIPTION
## Description of the change

Fix a couple issues with initializing metric config store values from this refactor: https://github.com/Recidiviz/justice-counts/pull/315

- Make sure to create nested objects so we can access them later
- Make sure to only create new nested objects if they hadn't been created yet

This fixes the two issues of not being able to load the metric config page and accidentally only setting one dimension in each metric.

## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Closes #XXXX

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
