### PR TITLE
Fix loader position (make more consistent) between different settings pages

### DIFF
--- a/publisher/src/components/DataUpload/DataUpload.styles.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.styles.tsx
@@ -314,13 +314,6 @@ export const Icon = styled.img<{ grayscale?: boolean }>`
   ${({ grayscale }) => grayscale && `filter: grayscale(1);`}
 `;
 
-export const UploadedFilesLoading = styled.div`
-  width: 100%;
-  display: flex;
-  justify-content: center;
-  margin-top: 50px;
-`;
-
 export const UploadedFilesError = styled.div`
   display: flex;
   justify-content: center;

--- a/publisher/src/components/DataUpload/UploadedFiles.tsx
+++ b/publisher/src/components/DataUpload/UploadedFiles.tsx
@@ -29,7 +29,7 @@ import { useStore } from "../../stores";
 import { removeSnakeCase } from "../../utils";
 import downloadIcon from "../assets/download-icon.png";
 import { Title, TitleWrapper } from "../Forms";
-import { Loader } from "../Loading";
+import { ContainedLoader } from "../Loading";
 import { TeamMemberNameWithBadge } from "../primitives";
 import {
   ActionButton,
@@ -45,7 +45,6 @@ import {
   UploadedFile,
   UploadedFilesContainer,
   UploadedFilesError,
-  UploadedFilesLoading,
   UploadedFilesTable,
   UploadedFileStatus,
   UploadedFilesWrapper,
@@ -313,11 +312,7 @@ export const UploadedFiles: React.FC = observer(() => {
   );
 
   if (isLoading) {
-    return (
-      <UploadedFilesLoading>
-        <Loader />
-      </UploadedFilesLoading>
-    );
+    return <ContainedLoader />;
   }
 
   if (fetchError) {

--- a/publisher/src/components/Loading/Loading.tsx
+++ b/publisher/src/components/Loading/Loading.tsx
@@ -23,7 +23,7 @@ import sprite from "../assets/loader-sprite-horizontal.svg";
 const loaderWidth = 144;
 const spriteFrames = 104;
 
-const LoadingWrapper = styled.div`
+const FullPageLoadingWrapper = styled.div`
   height: 100vh;
   width: 100vw;
   display: flex;
@@ -40,6 +40,13 @@ const loadingSpriteAnimation = keyframes`
   }
 `;
 
+export const ContainedLoadingWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  margin-top: 50px;
+`;
+
 export const Loader = styled.div`
   height: ${loaderWidth}px;
   width: ${loaderWidth}px;
@@ -51,10 +58,18 @@ export const Loader = styled.div`
     alternate;
 `;
 
+export const ContainedLoader = () => {
+  return (
+    <ContainedLoadingWrapper>
+      <Loader />
+    </ContainedLoadingWrapper>
+  );
+};
+
 export const Loading = () => {
   return (
-    <LoadingWrapper>
+    <FullPageLoadingWrapper>
       <Loader data-testid="loading" />
-    </LoadingWrapper>
+    </FullPageLoadingWrapper>
   );
 };

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -29,7 +29,7 @@ import { useParams } from "react-router-dom";
 import { useStore } from "../../stores";
 import { removeSnakeCase } from "../../utils";
 import { ReactComponent as RightArrowIcon } from "../assets/right-arrow.svg";
-import { Loading } from "../Loading";
+import { ContainedLoader } from "../Loading";
 import { TabbedBar, TabbedItem, TabbedOptions } from "../Reports";
 import { getActiveSystemMetricKey, useSettingsSearchParams } from "../Settings";
 import {
@@ -140,7 +140,7 @@ export const MetricConfiguration: React.FC = observer(() => {
   }, [agencyId]);
 
   if (isLoading) {
-    return <Loading />;
+    return <ContainedLoader />;
   }
 
   if (loadingErrorMessage) {

--- a/publisher/src/components/Settings/AgencySettings.tsx
+++ b/publisher/src/components/Settings/AgencySettings.tsx
@@ -20,7 +20,7 @@ import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import { useStore } from "../../stores";
-import { Loading } from "../Loading";
+import { ContainedLoader } from "../Loading";
 import {
   AgencySettingsContent,
   AgencySettingsTitle,
@@ -72,7 +72,7 @@ export const AgencySettings: React.FC = observer(() => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agencyId]);
 
-  if (loadingSettings) return <Loading />;
+  if (loadingSettings) return <ContainedLoader />;
 
   return (
     <AgencySettingsWrapper>


### PR DESCRIPTION
## Description of the change

Fix loader position within the Agency Settings, Uploaded Files and Metric Configuration components in the Settings so that it is more uniform and consistent. Introduced a more specific loader `ContainedLoader` that will take up the width of the container it is in as opposed to the full width and height of the entire screen.

Before:

https://user-images.githubusercontent.com/59492998/216488172-4a256fd9-5d40-4c32-8586-a72ef0f5267b.mov


After:

https://user-images.githubusercontent.com/59492998/216488210-59d6dca1-3607-4470-b6a2-4029503d1631.mov



## Related issues

Closes #355 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
