### PR TITLE
Update Supervision name to be "Supervision (Combined)" for supervision agencies with subsystems

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -34,6 +34,7 @@ export type AgencySystems =
   | "POST_RELEASE"
   | "PRETRIAL_SUPERVISION"
   | "OTHER_SUPERVISION";
+// | "Supervision (Combined)";
 
 export type AgencyTeam = {
   auth0_user_id: string;

--- a/common/types.ts
+++ b/common/types.ts
@@ -34,7 +34,6 @@ export type AgencySystems =
   | "POST_RELEASE"
   | "PRETRIAL_SUPERVISION"
   | "OTHER_SUPERVISION";
-// | "Supervision (Combined)";
 
 export type AgencyTeam = {
   auth0_user_id: string;

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -16,10 +16,12 @@
 // =============================================================================
 
 import checkIcon from "@justice-counts/common/assets/status-check-icon.png";
+import { AgencySystems } from "@justice-counts/common/types";
 import React, { Fragment } from "react";
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 
-import { removeSnakeCase } from "../../utils";
+import { useStore } from "../../stores";
+import { formatSystemName } from "../../utils";
 import { ReactComponent as ErrorIcon } from "../assets/error-icon.svg";
 import { ReactComponent as WarningIcon } from "../assets/warning-icon.svg";
 import {
@@ -51,7 +53,7 @@ import {
 
 type UploadErrorsWarningsProps = {
   errorsWarningsMetrics: ErrorsWarningsMetrics;
-  selectedSystem: string | undefined;
+  selectedSystem: AgencySystems | undefined;
   resetToNewUpload: () => void;
 };
 export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
@@ -59,9 +61,13 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
   selectedSystem,
   resetToNewUpload,
 }) => {
+  const navigate = useNavigate();
+  const { agencyId } = useParams() as { agencyId: string };
+  const { userStore } = useStore();
+  const currentAgency = userStore.getAgency(agencyId);
+
   const { metrics, errorsWarningsAndSuccessfulMetrics, nonMetricErrors } =
     errorsWarningsMetrics;
-  const navigate = useNavigate();
   const systemFileName =
     selectedSystem && systemToTemplateSpreadsheetFileName[selectedSystem];
   const successfulMetricsCount =
@@ -249,7 +255,10 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
     return (
       <>
         <span>
-          {selectedSystem && removeSnakeCase(selectedSystem).toLowerCase()}
+          {selectedSystem &&
+            formatSystemName(selectedSystem, {
+              allUserSystems: currentAgency?.systems,
+            })}
         </span>{" "}
         system (
         <a href={`./assets/${systemFileName}`} download={systemFileName}>

--- a/publisher/src/components/DataUpload/UploadedFiles.tsx
+++ b/publisher/src/components/DataUpload/UploadedFiles.tsx
@@ -257,10 +257,10 @@ export const UploadedFiles: React.FC = observer(() => {
       badgeText: fileStatus?.toLowerCase() || "Uploading",
       dateUploaded: formatDate(file.uploaded_at),
       dateIngested: file.ingested_at ? formatDate(file.ingested_at) : "--",
-      system: formatSystemName(
-        file.system,
-        currentAgency?.systems
-      ) as AgencySystems,
+      system: formatSystemName(file.system, {
+        allUserSystems: currentAgency?.systems,
+        hideCombined: true,
+      }) as AgencySystems,
       uploadedBy: file.uploaded_by,
     };
   };

--- a/publisher/src/components/DataUpload/UploadedFiles.tsx
+++ b/publisher/src/components/DataUpload/UploadedFiles.tsx
@@ -21,12 +21,13 @@ import {
   BadgeColors,
 } from "@justice-counts/common/components/Badge";
 import { showToast } from "@justice-counts/common/components/Toast";
+import { AgencySystems } from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import { useStore } from "../../stores";
-import { removeSnakeCase } from "../../utils";
+import { formatSystemName } from "../../utils";
 import downloadIcon from "../assets/download-icon.png";
 import { Title, TitleWrapper } from "../Forms";
 import { Loader } from "../Loading";
@@ -61,7 +62,7 @@ export const UploadedFileRow: React.FC<{
     badgeText: string;
     dateUploaded: string;
     dateIngested: string;
-    system?: string;
+    system?: AgencySystems;
     uploadedBy: string;
   };
   deleteUploadedFile: (spreadsheetID: number) => void;
@@ -209,7 +210,8 @@ export const UploadedFileRow: React.FC<{
 
 export const UploadedFiles: React.FC = observer(() => {
   const { agencyId } = useParams() as { agencyId: string };
-  const { reportStore } = useStore();
+  const { reportStore, userStore } = useStore();
+  const currentAgency = userStore.getAgency(agencyId);
   const dataUploadColumnTitles = [
     "Filename",
     "Uploaded",
@@ -255,7 +257,10 @@ export const UploadedFiles: React.FC = observer(() => {
       badgeText: fileStatus?.toLowerCase() || "Uploading",
       dateUploaded: formatDate(file.uploaded_at),
       dateIngested: file.ingested_at ? formatDate(file.ingested_at) : "--",
-      system: removeSnakeCase(file.system).toLowerCase(),
+      system: formatSystemName(
+        file.system,
+        currentAgency?.systems
+      ) as AgencySystems,
       uploadedBy: file.uploaded_by,
     };
   };

--- a/publisher/src/components/Forms/Form.styles.tsx
+++ b/publisher/src/components/Forms/Form.styles.tsx
@@ -98,7 +98,7 @@ export const OnePanelBackLinkContainer = styled(PreTitle)`
   }
 `;
 
-export const MetricsSectionTitle = styled.div`
+export const MetricSummarySectionTitle = styled.div`
   ${typography.sizeCSS.normal}
   text-transform: capitalize;
   margin-top: 6px;

--- a/publisher/src/components/Forms/Form.styles.tsx
+++ b/publisher/src/components/Forms/Form.styles.tsx
@@ -100,6 +100,7 @@ export const OnePanelBackLinkContainer = styled(PreTitle)`
 
 export const MetricsSectionTitle = styled.div`
   ${typography.sizeCSS.normal}
+  text-transform: capitalize;
   margin-top: 6px;
   margin-right: 17px;
 `;
@@ -143,6 +144,7 @@ export const MetricSectionTitleWrapper = styled.div`
 
 export const MetricSectionTitle = styled.div<{ notReporting?: boolean }>`
   ${typography.sizeCSS.large}
+  text-transform: capitalize;
   margin-right: 17px;
   margin-top: 32px;
   color: ${({ notReporting }) =>
@@ -157,6 +159,7 @@ export const MetricSystemTitle = styled(MetricSectionTitle)<{
     firstTitle ? `none` : `1px solid ${palette.highlight.grey8}`};
   padding-top: ${({ firstTitle }) => (firstTitle ? `none` : `30px`)};
   width: 100%;
+  text-transform: capitalize;
 
   &:first-child {
     border-top: none;

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -149,6 +149,13 @@ export const MetricConfiguration: React.FC = observer(() => {
   const enabledSupervisionSubsystems = currentAgency?.systems
     .filter((system) => SupervisionSubsystems.includes(system))
     .map((system) => system.toLowerCase());
+  const hasSupervisionWithSubsystems =
+    currentAgency &&
+    currentAgency.systems?.includes("SUPERVISION") &&
+    currentAgency.systems.length > 1 &&
+    currentAgency.systems.filter((system) =>
+      SupervisionSubsystems.includes(system)
+    ).length > 0;
 
   return (
     <>
@@ -164,16 +171,23 @@ export const MetricConfiguration: React.FC = observer(() => {
                     .filter(
                       (system) => getMetricsBySystem(system)?.length !== 0
                     )
-                    .map((filterOption) => (
-                      <TabbedItem
-                        key={filterOption}
-                        selected={systemSearchParam === filterOption}
-                        onClick={() => handleSystemClick(filterOption)}
-                        capitalize
-                      >
-                        {removeSnakeCase(filterOption.toLowerCase())}
-                      </TabbedItem>
-                    ))}
+                    .map((filterOption) => {
+                      return (
+                        <TabbedItem
+                          key={filterOption}
+                          selected={systemSearchParam === filterOption}
+                          onClick={() => handleSystemClick(filterOption)}
+                          capitalize
+                        >
+                          {filterOption === "SUPERVISION" &&
+                          hasSupervisionWithSubsystems
+                            ? `${removeSnakeCase(
+                                filterOption.toLowerCase()
+                              )} (Combined)`
+                            : removeSnakeCase(filterOption.toLowerCase())}
+                        </TabbedItem>
+                      );
+                    })}
                 </TabbedOptions>
               </TabbedBar>
             </StickyHeader>

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -172,7 +172,9 @@ export const MetricConfiguration: React.FC = observer(() => {
                           onClick={() => handleSystemClick(system)}
                           capitalize
                         >
-                          {formatSystemName(system, currentAgency?.systems)}
+                          {formatSystemName(system, {
+                            allUserSystems: currentAgency?.systems,
+                          })}
                         </TabbedItem>
                       );
                     })}

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.tsx
@@ -27,7 +27,7 @@ import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import { useStore } from "../../stores";
-import { removeSnakeCase } from "../../utils";
+import { formatSystemName } from "../../utils";
 import { ReactComponent as RightArrowIcon } from "../assets/right-arrow.svg";
 import { Loading } from "../Loading";
 import { TabbedBar, TabbedItem, TabbedOptions } from "../Reports";
@@ -149,13 +149,6 @@ export const MetricConfiguration: React.FC = observer(() => {
   const enabledSupervisionSubsystems = currentAgency?.systems
     .filter((system) => SupervisionSubsystems.includes(system))
     .map((system) => system.toLowerCase());
-  const hasSupervisionWithSubsystems =
-    currentAgency &&
-    currentAgency.systems?.includes("SUPERVISION") &&
-    currentAgency.systems.length > 1 &&
-    currentAgency.systems.filter((system) =>
-      SupervisionSubsystems.includes(system)
-    ).length > 0;
 
   return (
     <>
@@ -171,20 +164,15 @@ export const MetricConfiguration: React.FC = observer(() => {
                     .filter(
                       (system) => getMetricsBySystem(system)?.length !== 0
                     )
-                    .map((filterOption) => {
+                    .map((system) => {
                       return (
                         <TabbedItem
-                          key={filterOption}
-                          selected={systemSearchParam === filterOption}
-                          onClick={() => handleSystemClick(filterOption)}
+                          key={system}
+                          selected={systemSearchParam === system}
+                          onClick={() => handleSystemClick(system)}
                           capitalize
                         >
-                          {filterOption === "SUPERVISION" &&
-                          hasSupervisionWithSubsystems
-                            ? `${removeSnakeCase(
-                                filterOption.toLowerCase()
-                              )} (Combined)`
-                            : removeSnakeCase(filterOption.toLowerCase())}
+                          {formatSystemName(system, currentAgency?.systems)}
                         </TabbedItem>
                       );
                     })}

--- a/publisher/src/components/MetricConfiguration/MetricsView.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricsView.tsx
@@ -16,15 +16,13 @@
 // =============================================================================
 
 import { showToast } from "@justice-counts/common/components/Toast";
-import {
-  AgencySystems,
-  SupervisionSubsystems,
-} from "@justice-counts/common/types";
+import { AgencySystems } from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
 import { createSearchParams, useNavigate, useParams } from "react-router-dom";
 
 import { useStore } from "../../stores";
+import { formatSystemName } from "../../utils";
 import { ReactComponent as GoToMetricConfig } from "../assets/goto-metric-configuration-icon.svg";
 import { ReactComponent as SwitchToChartIcon } from "../assets/switch-to-chart-icon.svg";
 import { ReactComponent as SwitchToDataTableIcon } from "../assets/switch-to-data-table-icon.svg";
@@ -56,6 +54,7 @@ export const MetricsView: React.FC = observer(() => {
   const { reportStore, userStore, datapointsStore } = useStore();
   const { agencyId } = useParams() as { agencyId: string };
   const { metricsBySystem } = reportStore;
+  const currentAgency = userStore.getAgency(agencyId);
 
   const [settingsSearchParams, setSettingsSearchParams] =
     useSettingsSearchParams();
@@ -75,7 +74,6 @@ export const MetricsView: React.FC = observer(() => {
       return setLoadingError(result.message);
     }
 
-    const currentAgency = userStore.getAgency(agencyId);
     const defaultSystemSearchParam = Object.keys(result)[0]
       .toLowerCase()
       .replace(" ", "_") as AgencySystems;
@@ -158,14 +156,6 @@ export const MetricsView: React.FC = observer(() => {
   const metricName = currentMetric?.display_name || "";
   const metricFrequency =
     currentMetric?.custom_frequency || currentMetric?.frequency;
-  const currentAgency = userStore.getAgency(agencyId);
-  const hasSupervisionWithSubsystems =
-    currentAgency &&
-    currentAgency.systems?.includes("SUPERVISION") &&
-    currentAgency.systems.length > 1 &&
-    currentAgency.systems.filter((system) =>
-      SupervisionSubsystems.includes(system)
-    ).length > 0;
 
   return (
     <>
@@ -187,10 +177,10 @@ export const MetricsView: React.FC = observer(() => {
                       }}
                     >
                       <SystemName>
-                        {metrics[0].system.display_name === "Supervision" &&
-                        hasSupervisionWithSubsystems
-                          ? `${metrics[0].system.display_name} (Combined)`
-                          : metrics[0].system.display_name}
+                        {formatSystemName(
+                          metrics[0].system.key,
+                          currentAgency?.systems
+                        )}
                       </SystemName>
                       <SystemNamePlusSign
                         isSystemActive={system === systemSearchParam}

--- a/publisher/src/components/MetricConfiguration/MetricsView.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricsView.tsx
@@ -177,10 +177,9 @@ export const MetricsView: React.FC = observer(() => {
                       }}
                     >
                       <SystemName>
-                        {formatSystemName(
-                          metrics[0].system.key,
-                          currentAgency?.systems
-                        )}
+                        {formatSystemName(metrics[0].system.key, {
+                          allUserSystems: currentAgency?.systems,
+                        })}
                       </SystemName>
                       <SystemNamePlusSign
                         isSystemActive={system === systemSearchParam}

--- a/publisher/src/components/MetricConfiguration/MetricsView.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricsView.tsx
@@ -16,7 +16,10 @@
 // =============================================================================
 
 import { showToast } from "@justice-counts/common/components/Toast";
-import { AgencySystems } from "@justice-counts/common/types";
+import {
+  AgencySystems,
+  SupervisionSubsystems,
+} from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
 import { createSearchParams, useNavigate, useParams } from "react-router-dom";
@@ -155,6 +158,14 @@ export const MetricsView: React.FC = observer(() => {
   const metricName = currentMetric?.display_name || "";
   const metricFrequency =
     currentMetric?.custom_frequency || currentMetric?.frequency;
+  const currentAgency = userStore.getAgency(agencyId);
+  const hasSupervisionWithSubsystems =
+    currentAgency &&
+    currentAgency.systems?.includes("SUPERVISION") &&
+    currentAgency.systems.length > 1 &&
+    currentAgency.systems.filter((system) =>
+      SupervisionSubsystems.includes(system)
+    ).length > 0;
 
   return (
     <>
@@ -175,7 +186,12 @@ export const MetricsView: React.FC = observer(() => {
                         });
                       }}
                     >
-                      <SystemName>{metrics[0].system.display_name}</SystemName>
+                      <SystemName>
+                        {metrics[0].system.display_name === "Supervision" &&
+                        hasSupervisionWithSubsystems
+                          ? `${metrics[0].system.display_name} (Combined)`
+                          : metrics[0].system.display_name}
+                      </SystemName>
                       <SystemNamePlusSign
                         isSystemActive={system === systemSearchParam}
                       />

--- a/publisher/src/components/Reports/DataEntryForm.tsx
+++ b/publisher/src/components/Reports/DataEntryForm.tsx
@@ -341,10 +341,9 @@ const DataEntryForm: React.FC<{
                 <Fragment key={system}>
                   {showMetricSectionTitles && (
                     <MetricSystemTitle firstTitle={systemIndex === 0}>
-                      {formatSystemName(
-                        system as AgencySystems,
-                        currentAgency?.systems
-                      )}
+                      {formatSystemName(system as AgencySystems, {
+                        allUserSystems: currentAgency?.systems,
+                      })}
                     </MetricSystemTitle>
                   )}
 

--- a/publisher/src/components/Reports/DataEntryForm.tsx
+++ b/publisher/src/components/Reports/DataEntryForm.tsx
@@ -20,7 +20,7 @@ import {
   palette,
 } from "@justice-counts/common/components/GlobalStyles";
 import { showToast } from "@justice-counts/common/components/Toast";
-import { Report } from "@justice-counts/common/types";
+import { AgencySystems, Report } from "@justice-counts/common/types";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react-lite";
 import React, { Fragment, useEffect, useRef, useState } from "react";
@@ -33,7 +33,11 @@ import {
   trackReportNotStartedToDraft,
 } from "../../analytics";
 import { useStore } from "../../stores";
-import { memoizeDebounce, printReportTitle } from "../../utils";
+import {
+  formatSystemName,
+  memoizeDebounce,
+  printReportTitle,
+} from "../../utils";
 import logoImg from "../assets/jc-logo-vector.png";
 import { Button, DataUploadHeader } from "../DataUpload";
 import {
@@ -117,8 +121,9 @@ const DataEntryForm: React.FC<{
   const [scrolled, setScrolled] = useState(false);
   const metricsRef = useRef<HTMLDivElement[]>([]);
   const { formStore, reportStore, userStore } = useStore();
-  const { agencyId } = useParams();
+  const { agencyId } = useParams() as { agencyId: string };
   const navigate = useNavigate();
+  const currentAgency = userStore.getAgency(agencyId);
 
   const isPublished =
     reportStore.reportOverviews[reportID].status === "PUBLISHED";
@@ -336,7 +341,10 @@ const DataEntryForm: React.FC<{
                 <Fragment key={system}>
                   {showMetricSectionTitles && (
                     <MetricSystemTitle firstTitle={systemIndex === 0}>
-                      {system}
+                      {formatSystemName(
+                        system as AgencySystems,
+                        currentAgency?.systems
+                      )}
                     </MetricSystemTitle>
                   )}
 

--- a/publisher/src/components/Reports/PublishConfirmationSummaryPanel.tsx
+++ b/publisher/src/components/Reports/PublishConfirmationSummaryPanel.tsx
@@ -82,10 +82,9 @@ const PublishConfirmationSummaryPanel: React.FC<{
             <React.Fragment key={system}>
               {showMetricSectionTitles && (
                 <MetricSummarySectionTitle>
-                  {formatSystemName(
-                    system as AgencySystems,
-                    currentAgency?.systems
-                  )}
+                  {formatSystemName(system as AgencySystems, {
+                    allUserSystems: currentAgency?.systems,
+                  })}
                 </MetricSummarySectionTitle>
               )}
               {enabledMetrics.map((metric) => {

--- a/publisher/src/components/Reports/PublishConfirmationSummaryPanel.tsx
+++ b/publisher/src/components/Reports/PublishConfirmationSummaryPanel.tsx
@@ -15,11 +15,13 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { Metric } from "@justice-counts/common/types";
+import { AgencySystems, Metric } from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
 import React from "react";
+import { useParams } from "react-router-dom";
 
 import { useStore } from "../../stores";
+import { formatSystemName } from "../../utils";
 import checkIcon from "../assets/check-icon.svg";
 import errorIcon from "../assets/status-error-icon.png";
 import { MetricsSectionTitle } from "../Forms";
@@ -62,8 +64,10 @@ const ReportStatusIconComponent: React.FC<{
 const PublishConfirmationSummaryPanel: React.FC<{
   reportID: number;
 }> = ({ reportID }) => {
-  const { formStore, reportStore } = useStore();
+  const { formStore, reportStore, userStore } = useStore();
   const checkMetricForErrors = useCheckMetricForErrors(reportID);
+  const { agencyId } = useParams() as { agencyId: string };
+  const currentAgency = userStore.getAgency(agencyId);
 
   const metricsBySystem = reportStore.reportMetricsBySystem[reportID];
   const showMetricSectionTitles = Object.keys(metricsBySystem).length > 1;
@@ -77,7 +81,12 @@ const PublishConfirmationSummaryPanel: React.FC<{
           return (
             <React.Fragment key={system}>
               {showMetricSectionTitles && (
-                <MetricsSectionTitle>{system}</MetricsSectionTitle>
+                <MetricsSectionTitle>
+                  {formatSystemName(
+                    system as AgencySystems,
+                    currentAgency?.systems
+                  )}
+                </MetricsSectionTitle>
               )}
               {enabledMetrics.map((metric) => {
                 const foundErrors = checkMetricForErrors(metric.key);

--- a/publisher/src/components/Reports/PublishConfirmationSummaryPanel.tsx
+++ b/publisher/src/components/Reports/PublishConfirmationSummaryPanel.tsx
@@ -24,7 +24,7 @@ import { useStore } from "../../stores";
 import { formatSystemName } from "../../utils";
 import checkIcon from "../assets/check-icon.svg";
 import errorIcon from "../assets/status-error-icon.png";
-import { MetricsSectionTitle } from "../Forms";
+import { MetricSummarySectionTitle } from "../Forms";
 import { useCheckMetricForErrors } from "./hooks";
 import {
   ConfirmationSummaryProgressIndicatorWrapper,
@@ -81,12 +81,12 @@ const PublishConfirmationSummaryPanel: React.FC<{
           return (
             <React.Fragment key={system}>
               {showMetricSectionTitles && (
-                <MetricsSectionTitle>
+                <MetricSummarySectionTitle>
                   {formatSystemName(
                     system as AgencySystems,
                     currentAgency?.systems
                   )}
-                </MetricsSectionTitle>
+                </MetricSummarySectionTitle>
               )}
               {enabledMetrics.map((metric) => {
                 const foundErrors = checkMetricForErrors(metric.key);

--- a/publisher/src/components/Reports/ReportSummaryPanel.tsx
+++ b/publisher/src/components/Reports/ReportSummaryPanel.tsx
@@ -268,10 +268,9 @@ const ReportSummaryPanel: React.FC<{
             <React.Fragment key={system}>
               {showMetricSectionTitles ? (
                 <MetricSummarySectionTitle>
-                  {formatSystemName(
-                    system as AgencySystems,
-                    currentAgency?.systems
-                  )}
+                  {formatSystemName(system as AgencySystems, {
+                    allUserSystems: currentAgency?.systems,
+                  })}
                 </MetricSummarySectionTitle>
               ) : null}
               {enabledMetrics.map((metric) => {

--- a/publisher/src/components/Reports/ReportSummaryPanel.tsx
+++ b/publisher/src/components/Reports/ReportSummaryPanel.tsx
@@ -34,7 +34,7 @@ import {
   printElapsedDaysMonthsYearsSinceDate,
 } from "../../utils";
 import errorIcon from "../assets/status-error-icon.png";
-import { MetricsSectionTitle, Title } from "../Forms";
+import { MetricSummarySectionTitle, Title } from "../Forms";
 import { REPORT_CAPITALIZED } from "../Global/constants";
 import { TeamMemberNameWithBadge } from "../primitives";
 import { SubMenuListItem } from "../Settings";
@@ -267,12 +267,12 @@ const ReportSummaryPanel: React.FC<{
           return (
             <React.Fragment key={system}>
               {showMetricSectionTitles ? (
-                <MetricsSectionTitle>
+                <MetricSummarySectionTitle>
                   {formatSystemName(
                     system as AgencySystems,
                     currentAgency?.systems
                   )}
-                </MetricsSectionTitle>
+                </MetricSummarySectionTitle>
               ) : null}
               {enabledMetrics.map((metric) => {
                 const foundErrors = checkMetricForErrors(metric.key);

--- a/publisher/src/components/Reports/ReportSummaryPanel.tsx
+++ b/publisher/src/components/Reports/ReportSummaryPanel.tsx
@@ -21,9 +21,10 @@ import {
   palette,
   typography,
 } from "@justice-counts/common/components/GlobalStyles";
-import { Metric } from "@justice-counts/common/types";
+import { Metric, SupervisionSubsystems } from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
 import React from "react";
+import { useParams } from "react-router-dom";
 import styled from "styled-components/macro";
 
 import { useStore } from "../../stores";
@@ -240,6 +241,7 @@ const ReportSummaryPanel: React.FC<{
   fieldDescription?: FieldDescriptionProps;
 }> = ({ reportID, activeMetric, showDataEntryHelpPage, fieldDescription }) => {
   const { formStore, reportStore, userStore } = useStore();
+  const { agencyId } = useParams();
   const checkMetricForErrors = useCheckMetricForErrors(reportID);
   const {
     editors,
@@ -251,6 +253,14 @@ const ReportSummaryPanel: React.FC<{
 
   const metricsBySystem = reportStore.reportMetricsBySystem[reportID];
   const showMetricSectionTitles = Object.keys(metricsBySystem).length > 1;
+  const currentAgency = userStore.getAgency(agencyId);
+  const hasSupervisionWithSubsystems =
+    currentAgency &&
+    currentAgency.systems?.includes("SUPERVISION") &&
+    currentAgency.systems.length > 1 &&
+    currentAgency.systems.filter((system) =>
+      SupervisionSubsystems.includes(system)
+    ).length > 0;
 
   return (
     <ReportSummaryWrapper showDataEntryHelpPage={showDataEntryHelpPage}>
@@ -263,7 +273,11 @@ const ReportSummaryPanel: React.FC<{
           return (
             <React.Fragment key={system}>
               {showMetricSectionTitles ? (
-                <MetricsSectionTitle>{system}</MetricsSectionTitle>
+                <MetricsSectionTitle>
+                  {system === "SUPERVISION" && hasSupervisionWithSubsystems
+                    ? `${system} (Combined)`
+                    : system}
+                </MetricsSectionTitle>
               ) : null}
               {enabledMetrics.map((metric) => {
                 const foundErrors = checkMetricForErrors(metric.key);

--- a/publisher/src/components/Reports/ReportSummaryPanel.tsx
+++ b/publisher/src/components/Reports/ReportSummaryPanel.tsx
@@ -21,7 +21,7 @@ import {
   palette,
   typography,
 } from "@justice-counts/common/components/GlobalStyles";
-import { Metric, SupervisionSubsystems } from "@justice-counts/common/types";
+import { AgencySystems, Metric } from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
 import React from "react";
 import { useParams } from "react-router-dom";
@@ -29,6 +29,7 @@ import styled from "styled-components/macro";
 
 import { useStore } from "../../stores";
 import {
+  formatSystemName,
   printDateRangeFromMonthYear,
   printElapsedDaysMonthsYearsSinceDate,
 } from "../../utils";
@@ -241,7 +242,8 @@ const ReportSummaryPanel: React.FC<{
   fieldDescription?: FieldDescriptionProps;
 }> = ({ reportID, activeMetric, showDataEntryHelpPage, fieldDescription }) => {
   const { formStore, reportStore, userStore } = useStore();
-  const { agencyId } = useParams();
+  const { agencyId } = useParams() as { agencyId: string };
+  const currentAgency = userStore.getAgency(agencyId);
   const checkMetricForErrors = useCheckMetricForErrors(reportID);
   const {
     editors,
@@ -253,14 +255,6 @@ const ReportSummaryPanel: React.FC<{
 
   const metricsBySystem = reportStore.reportMetricsBySystem[reportID];
   const showMetricSectionTitles = Object.keys(metricsBySystem).length > 1;
-  const currentAgency = userStore.getAgency(agencyId);
-  const hasSupervisionWithSubsystems =
-    currentAgency &&
-    currentAgency.systems?.includes("SUPERVISION") &&
-    currentAgency.systems.length > 1 &&
-    currentAgency.systems.filter((system) =>
-      SupervisionSubsystems.includes(system)
-    ).length > 0;
 
   return (
     <ReportSummaryWrapper showDataEntryHelpPage={showDataEntryHelpPage}>
@@ -274,9 +268,10 @@ const ReportSummaryPanel: React.FC<{
             <React.Fragment key={system}>
               {showMetricSectionTitles ? (
                 <MetricsSectionTitle>
-                  {system === "SUPERVISION" && hasSupervisionWithSubsystems
-                    ? `${system} (Combined)`
-                    : system}
+                  {formatSystemName(
+                    system as AgencySystems,
+                    currentAgency?.systems
+                  )}
                 </MetricsSectionTitle>
               ) : null}
               {enabledMetrics.map((metric) => {

--- a/publisher/src/components/Settings/AgencySettings.styles.tsx
+++ b/publisher/src/components/Settings/AgencySettings.styles.tsx
@@ -68,10 +68,10 @@ export const AgencySettingsBlock = styled.div<{
   withBorder?: boolean;
 }>`
   position: relative;
-  padding 32px 24px;
+  padding: 32px 24px;
   display: flex;
   flex-direction: column;
-  
+
   border: ${({ withBorder }) => withBorder && "1px solid #DCDDDF"};
   width: ${({ withBorder }) =>
     withBorder ? "calc(100% - 88px)" : "calc(100% - 40px)"};
@@ -248,13 +248,14 @@ export const BasicInfoBlockDescription = styled(AgencySettingsBlockDescription)`
   }
 `;
 
-export const BasicInfoRow = styled.div`
+export const BasicInfoRow = styled.div<{ capitalize?: boolean }>`
   ${typography.sizeCSS.large};
   line-height: 32px;
   display: flex;
   flex-direction: column;
   gap: 8px;
   margin-bottom: 24px;
+  ${({ capitalize }) => capitalize && `text-transform: capitalize;`}
 
   span {
     ${typography.sizeCSS.small};

--- a/publisher/src/components/Settings/AgencySettingsBasicInfo.tsx
+++ b/publisher/src/components/Settings/AgencySettingsBasicInfo.tsx
@@ -18,12 +18,12 @@
 import React from "react";
 
 import { useStore } from "../../stores";
+import { formatSystemName } from "../../utils";
 import {
   AgencySettingsBlock,
   BasicInfoBlockDescription,
   BasicInfoRow,
 } from "./AgencySettings.styles";
-import { normalizeSystem } from "./utils";
 
 export const AgencySettingsBasicInfo = () => {
   const { agencyStore } = useStore();
@@ -39,14 +39,14 @@ export const AgencySettingsBasicInfo = () => {
         <span>State</span>
         {currentAgency?.state}
       </BasicInfoRow>
-      <BasicInfoRow>
+      <BasicInfoRow capitalize>
         <span>
           {currentAgencySystems && currentAgencySystems.length > 1
             ? "Systems"
             : "System"}
         </span>
         {currentAgencySystems
-          ?.map((system) => normalizeSystem(system))
+          ?.map((system) => formatSystemName(system, currentAgencySystems))
           .join(", ")}
       </BasicInfoRow>
       <BasicInfoBlockDescription>

--- a/publisher/src/components/Settings/AgencySettingsBasicInfo.tsx
+++ b/publisher/src/components/Settings/AgencySettingsBasicInfo.tsx
@@ -46,7 +46,9 @@ export const AgencySettingsBasicInfo = () => {
             : "System"}
         </span>
         {currentAgencySystems
-          ?.map((system) => formatSystemName(system, currentAgencySystems))
+          ?.map((system) =>
+            formatSystemName(system, { allUserSystems: currentAgencySystems })
+          )
           .join(", ")}
       </BasicInfoRow>
       <BasicInfoBlockDescription>

--- a/publisher/src/utils/helperUtils.ts
+++ b/publisher/src/utils/helperUtils.ts
@@ -241,25 +241,38 @@ export function removeAgencyFromPath(location: string) {
  * Formats system name by removing snakecase and lowercasing
  *
  * @note formats SUPERVISION system name to "Supervision (Combined)" if supervision subsystems detected
- * @param systemName {string} system name
- * @param allUserSystems {string[]} (optional) a list of all systems a user belongs to
+ * @param {String} systemName system name
+ * @param {Object} options optional additional options for formatting system name (allUserSystems, hideCombined)
+ * @param {Array} options.allUserSystems an array of all systems belonging to a user
+ * @param {Boolean} options.hideCombined for supervision system w/ subsystems - overrides and suppresses the addition of the word "(combined)" when true
  * @returns lowercase, non-snakecase string
  *
- * @example formatSystemName("SUPERVISION", ["SUPERVISION", "PAROLE", "PROBATION", "POST_RELEASE"]) returns "supervision (combined)"
- * @example formatSystemName("SUPERVISION", ["SUPERVISION"]) returns "supervision"
- * @example formatSystemName("COURTS_AND_PRETRIAL") returns "courts and pretrial"
+ * @examples formatSystemName("SUPERVISION", ["SUPERVISION", "PAROLE", "PROBATION", "POST_RELEASE"]) returns "supervision (combined)"
+ * formatSystemName("SUPERVISION", ["SUPERVISION"]) returns "supervision"
+ * formatSystemName("COURTS_AND_PRETRIAL") returns "courts and pretrial"
  */
+
 export const formatSystemName = (
   systemName: AgencySystems,
-  allUserSystems?: AgencySystems[]
+  options?: FormatSystemNameOptions
 ) => {
-  if (systemName === "SUPERVISION" && allUserSystems) {
+  if (
+    systemName === "SUPERVISION" &&
+    options?.allUserSystems &&
+    !options.hideCombined
+  ) {
     const hasSubsystems =
-      allUserSystems.filter((system) => SupervisionSubsystems.includes(system))
-        .length > 0;
+      options?.allUserSystems.filter((system) =>
+        SupervisionSubsystems.includes(system)
+      ).length > 0;
     return hasSubsystems
       ? `${removeSnakeCase(systemName.toLowerCase())} (combined)`
       : "supervision";
   }
   return removeSnakeCase(systemName.toLowerCase());
+};
+
+type FormatSystemNameOptions = {
+  allUserSystems?: AgencySystems[];
+  hideCombined?: boolean;
 };

--- a/publisher/src/utils/helperUtils.ts
+++ b/publisher/src/utils/helperUtils.ts
@@ -241,10 +241,10 @@ export function removeAgencyFromPath(location: string) {
  * Formats system name by removing snakecase and lowercasing
  *
  * @note formats SUPERVISION system name to "Supervision (Combined)" if supervision subsystems detected
- * @param {String} systemName system name
- * @param {Object} options optional additional options for formatting system name (allUserSystems, hideCombined)
- * @param {Array} options.allUserSystems an array of all systems belonging to a user
- * @param {Boolean} options.hideCombined for supervision system w/ subsystems - overrides and suppresses the addition of the word "(combined)" when true
+ * @param {String} systemName - system name
+ * @param {Object} options - (optional) additional options for formatting system name (allUserSystems, hideCombined)
+ * @param {Array} options.allUserSystems - an array of all systems belonging to a user
+ * @param {Boolean} options.hideCombined - for supervision system w/ subsystems - overrides and suppresses the addition of the word "(combined)" when true
  * @returns lowercase, non-snakecase string
  *
  * @examples formatSystemName("SUPERVISION", ["SUPERVISION", "PAROLE", "PROBATION", "POST_RELEASE"]) returns "supervision (combined)"

--- a/publisher/src/utils/helperUtils.ts
+++ b/publisher/src/utils/helperUtils.ts
@@ -15,7 +15,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { MetricContext } from "@justice-counts/common/types";
+import {
+  AgencySystems,
+  MetricContext,
+  SupervisionSubsystems,
+} from "@justice-counts/common/types";
 import { debounce, memoize } from "lodash";
 
 export const isPositiveNumber = (value: string | number) => {
@@ -232,3 +236,30 @@ export function removeAgencyFromPath(location: string) {
   const agencyRegex = /\/agency\/\d+\//i;
   return location.replace(agencyRegex, "");
 }
+
+/**
+ * Formats system name by removing snakecase and lowercasing
+ *
+ * @note formats SUPERVISION system name to "Supervision (Combined)" if supervision subsystems detected
+ * @param systemName {string} system name
+ * @param allUserSystems {string[]} (optional) a list of all systems a user belongs to
+ * @returns lowercase, non-snakecase string
+ *
+ * @example formatSystemName("SUPERVISION", ["SUPERVISION", "PAROLE", "PROBATION", "POST_RELEASE"]) returns "supervision (combined)"
+ * @example formatSystemName("SUPERVISION", ["SUPERVISION"]) returns "supervision"
+ * @example formatSystemName("COURTS_AND_PRETRIAL") returns "courts and pretrial"
+ */
+export const formatSystemName = (
+  systemName: AgencySystems,
+  allUserSystems?: AgencySystems[]
+) => {
+  if (systemName === "SUPERVISION" && allUserSystems) {
+    const hasSubsystems =
+      allUserSystems.filter((system) => SupervisionSubsystems.includes(system))
+        .length > 0;
+    return hasSubsystems
+      ? `${removeSnakeCase(systemName.toLowerCase())} (combined)`
+      : "supervision";
+  }
+  return removeSnakeCase(systemName.toLowerCase());
+};


### PR DESCRIPTION
## Description of the change

In general, this formats all areas the render a system name and specifically formats the Supervision system name to "Supervision (Combined)" if the Supervision system has subsystems (e.g. Parole, Probation, etc.)

Thanks to @lilidworkin's suggestion - there's a helper function that helps format the system name and if provided a list of systems can determine whether or not to add "(Combined)" to the Supervision system name. We'll just have to remember any time we're rendering a system name to feed it into the helper function for consistency.

Please let me know if there are areas I may have missed that render the system name. The only areas I was unsure about updating were 3 of the bulk upload screens:

<img width="328" alt="Screenshot 2023-02-03 at 4 21 32 PM" src="https://user-images.githubusercontent.com/59492998/216714566-1fa9b7d9-edf1-4a61-b91e-99b5eabae632.png">

<img width="328" alt="Screenshot 2023-02-03 at 4 21 42 PM" src="https://user-images.githubusercontent.com/59492998/216714592-d501834e-5993-481c-9faa-4bde82d75206.png">

<img width="328" alt="Screenshot 2023-02-03 at 4 23 01 PM" src="https://user-images.githubusercontent.com/59492998/216714600-d73b0eff-98b3-4185-a7dd-85c176936c4c.png">


Demo (Supervision agency with subsystems):

https://user-images.githubusercontent.com/59492998/216714044-7f0bb2e2-f46b-4d52-972d-f2b6c254f046.mov

Playtesting Link: https://mahmoudtest---justice-counts-web-qqec6jbn6a-uc.a.run.app

It's not as straightforward to test a Supervision only agency because with a single system agency, things aren't split up/categorized by system name. Nevertheless, the system names should appear formatted as expected.

## Related issues

Closes #356 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
