### PR TITLE
Adjust ReportStore tests to reduce the run time to < 5s

### DIFF
--- a/publisher/src/stores/ReportStore.test.tsx
+++ b/publisher/src/stores/ReportStore.test.tsx
@@ -92,7 +92,7 @@ test("displayed reports", async () => {
     </StoreProvider>
   );
 
-  await act(() => {
+  act(() => {
     runInAction(() => {
       rootStore.reportStore.loadingOverview = false;
       rootStore.reportStore.reportOverviews = mockUnorderedReportsMap;

--- a/publisher/src/stores/ReportStore.test.tsx
+++ b/publisher/src/stores/ReportStore.test.tsx
@@ -92,7 +92,7 @@ test("displayed reports", async () => {
     </StoreProvider>
   );
 
-  await act(() => {
+  await act(async () => {
     runInAction(() => {
       rootStore.reportStore.loadingOverview = false;
       rootStore.reportStore.reportOverviews = mockUnorderedReportsMap;

--- a/publisher/src/stores/ReportStore.test.tsx
+++ b/publisher/src/stores/ReportStore.test.tsx
@@ -92,7 +92,7 @@ test("displayed reports", async () => {
     </StoreProvider>
   );
 
-  await act(async () => {
+  await act(() => {
     runInAction(() => {
       rootStore.reportStore.loadingOverview = false;
       rootStore.reportStore.reportOverviews = mockUnorderedReportsMap;


### PR DESCRIPTION
## Description of the change

Simplifies and removes `async` in one of our tests to prevent it from taking longer than 5 seconds to pass (which fails the CI test).

## Related issues

Closes #377

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
