### PR TITLE
[Fix] Replace EXCLUDED_SYSTEMS in Data Upload with SupervisionSubsystems

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -33,6 +33,7 @@ export type AgencySystems =
   | "PROBATION"
   | "POST_RELEASE"
   | "PRETRIAL_SUPERVISION"
+  | "DUAL_SUPERVISION"
   | "OTHER_SUPERVISION";
 
 export type AgencyTeam = {
@@ -50,6 +51,7 @@ export const SupervisionSubsystems: AgencySystems[] = [
   "PROBATION",
   "POST_RELEASE",
   "PRETRIAL_SUPERVISION",
+  "DUAL_SUPERVISION",
   "OTHER_SUPERVISION",
 ];
 

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -16,7 +16,10 @@
 // =============================================================================
 
 import { showToast } from "@justice-counts/common/components/Toast";
-import { AgencySystems } from "@justice-counts/common/types";
+import {
+  AgencySystems,
+  SupervisionSubsystems,
+} from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -61,15 +64,6 @@ export type UploadedFile = {
   status: UploadedFileStatus | null;
 };
 
-/**
- * The systems in EXCLUDED_SYSTEMS are sub-systems of the SUPERVISION system,
- * and should not render a separate template & instructions.
- *
- * Example: if an agency has the following systems ["SUPERVISION", "PAROLE", "PROBATION"],
- * the UI should render a template & instructions for the SUPERVISION system.
- */
-export const EXCLUDED_SYSTEMS = ["PAROLE", "PROBATION", "POST_RELEASE"];
-
 export const systemToTemplateSpreadsheetFileName: { [system: string]: string } =
   {
     LAW_ENFORCEMENT: "LAW_ENFORCEMENT.xlsx",
@@ -89,10 +83,16 @@ export const DataUpload: React.FC = observer(() => {
   const navigate = useNavigate();
   const currentAgency = userStore.getAgency(agencyId);
 
+  /**
+   * Sub-systems of the SUPERVISION system should not render a separate template & instructions.
+   *
+   * Example: if an agency has the following systems ["SUPERVISION", "PAROLE", "PROBATION"],
+   * the UI should render a template & instructions for the SUPERVISION system.
+   */
   const userSystems = useMemo(() => {
     return currentAgency
       ? currentAgency.systems.filter(
-          (system) => !EXCLUDED_SYSTEMS.includes(system)
+          (system) => !SupervisionSubsystems.includes(system)
         )
       : [];
   }, [currentAgency]);

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -252,7 +252,7 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
           {selectedSystem && removeSnakeCase(selectedSystem).toLowerCase()}
         </span>{" "}
         system (
-        <a href={`./assets/${systemFileName}`} download={systemFileName}>
+        <a href={`/assets/${systemFileName}`} download={systemFileName}>
           download example
         </a>
         )


### PR DESCRIPTION
## Description of the change

Replacing the old `EXCLUDED_SYSTEMS` array that was a list of supervision subsystems with the `SupervisionSubsystems` constant to prevent a TypeError caught by @nichelle-hall (thank you for catching this!)

<img width="682" alt="Screenshot 2023-02-03 at 6 47 51 PM" src="https://user-images.githubusercontent.com/59492998/216731513-f0845219-e23a-4703-85f8-5b6cb8467350.png">

Test: https://nichelletest---justice-counts-web-qqec6jbn6a-uc.a.run.app/agency/153

Additionally, fixes the reference path to downloading templates from the UploadErrorsWarnings component.

## Related issues

Closes #386 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
