### PR TITLE
[Team Management] toast for error when user is already a part of an agency

### DIFF
--- a/publisher/src/components/Settings/AgencySettingsTeamManagement.tsx
+++ b/publisher/src/components/Settings/AgencySettingsTeamManagement.tsx
@@ -73,15 +73,17 @@ export const AgencySettingsTeamManagement = observer(() => {
     setTeamMemberEditMenuActiveEmail(undefined);
     setIsModalOpen(false);
   };
-  const handleInviteTeamMamber = (name: string, email: string) => {
+  const handleInviteTeamMamber = async (name: string, email: string) => {
     if (name && email) {
-      inviteTeamMember(name, email);
-      inviteTeamMemberRequest(
+      const result = await inviteTeamMemberRequest(
         { invite_name: name, invite_email: email },
         agencyId
       );
-      setNameValue("");
-      setEmailValue("");
+      if (!(result instanceof Error)) {
+        setNameValue("");
+        setEmailValue("");
+        inviteTeamMember(name, email);
+      }
     }
   };
   const handleTeamMemberAdminStatus = (

--- a/publisher/src/stores/AgencyStore.ts
+++ b/publisher/src/stores/AgencyStore.ts
@@ -233,20 +233,28 @@ class AgencyStore {
   inviteTeamMemberRequest = async (
     body: { invite_name: string; invite_email: string },
     agencyId: string
-  ): Promise<void> => {
+  ): Promise<void | Error> => {
     const response = (await this.api.request({
       path: `/api/agencies/${agencyId}/users`,
       body,
       method: "POST",
     })) as Response;
-
     if (response.status !== 200) {
+      const result = await response.json();
+      if (result.code === "user_reinvited_to_agency") {
+        showToast({
+          message: result.description,
+          color: "red",
+          timeout: 4000,
+        });
+        return new Error(result.description);
+      }
       showToast({
         message: "Failed to invite user.",
         color: "red",
         timeout: 4000,
       });
-      throw new Error("There was an issue inviting a user.");
+      return new Error("There was an issue inviting a user.");
     }
 
     showToast({


### PR DESCRIPTION
## Description of the change

Throws toast when user is added to an agency that they are already a part of. 

[Loom](https://www.loom.com/share/c8d74036d7ca4a4a9e844aee54c889a9)


## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
