### PR TITLE
add logout button to the no agencies screen

### DIFF
--- a/publisher/src/pages/NoAgencies.tsx
+++ b/publisher/src/pages/NoAgencies.tsx
@@ -23,6 +23,8 @@ import React from "react";
 import styled from "styled-components/macro";
 
 import logo from "../components/assets/jc-logo-green-vector.png";
+import { VerificationLogoutButton } from "../components/Auth/VerificationPage";
+import { useStore } from "../stores/StoreProvider";
 
 const Wrapper = styled.div`
   width: 100vw;
@@ -30,8 +32,8 @@ const Wrapper = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  flex-direction: column;
 `;
-
 const Content = styled.div`
   width: 100%;
   max-width: 660px;
@@ -87,6 +89,8 @@ const SupportLink = styled.a`
 `;
 
 export const NoAgencies = () => {
+  const { authStore } = useStore();
+  const handleLogout = () => authStore.logoutUser();
   return (
     <Wrapper>
       <Content>
@@ -105,6 +109,13 @@ export const NoAgencies = () => {
           </SupportLink>{" "}
           for support.
         </InfoBlock>
+
+        <VerificationLogoutButton
+          onClick={handleLogout}
+          style={{ marginTop: 65 }}
+        >
+          Logout
+        </VerificationLogoutButton>
       </Content>
     </Wrapper>
   );


### PR DESCRIPTION
## Description of the change

Adds a logout button to the no agencies screen - this is a follow up to the Team Management playtesting section. 

<img width="1724" alt="Screen Shot 2023-02-07 at 1 15 19 PM" src="https://user-images.githubusercontent.com/19961693/217359945-d0982380-2216-4146-a103-8d131ef195a9.png">


## Related issues

Closes #18444

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
