### PR TITLE
[Bug] Resolve persistent error message in Reports overview page

### DIFF
--- a/publisher/src/pages/Reports.tsx
+++ b/publisher/src/pages/Reports.tsx
@@ -136,6 +136,8 @@ const Reports: React.FC = () => {
       const result = await reportStore.getReportOverviews(agencyId);
       if (result instanceof Error) {
         setLoadingError(result.message);
+      } else {
+        setLoadingError(undefined);
       }
     };
 


### PR DESCRIPTION
## Description of the change

Fixes persistent loading error message in Reports overview page. When there is an error in the Reports overview page, the error message persists when you switch to an agency that has no errors. This resets the `loadingError` back to `undefined` when there is no longer an error.

<img width="528" alt="Screenshot 2023-02-21 at 3 08 22 PM" src="https://user-images.githubusercontent.com/59492998/220458829-0835a4c2-df54-4e0e-ba0f-e664cf18eb43.png">

**Test:**
https://mahmoudtest---justice-counts-web-qqec6jbn6a-uc.a.run.app/

(Agency 161 is currently erroring and displaying an error message -- when you switch to a different agency, the error message goes away and the respective reports load.)

## Related issues

Closes #426 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
