### PR TITLE
[Fix] Disaggregation and dimensions out of sync with the backend

### DIFF
--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -418,6 +418,8 @@ class MetricConfigStore {
       this.dimensions[systemMetricKey][disaggregationKey][dimensionKey] = {};
     }
 
+    this.dimensions[systemMetricKey][disaggregationKey][dimensionKey].enabled =
+      dimensionData.enabled;
     this.dimensions[systemMetricKey][disaggregationKey][dimensionKey].label =
       dimensionData.label;
     this.dimensions[systemMetricKey][disaggregationKey][dimensionKey].key =

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -20,6 +20,7 @@ import {
   AgencySystems,
   FormError,
   Metric,
+  MetricConfigurationSettings,
   MetricConfigurationSettingsOptions,
   MetricContext,
   MetricDisaggregationDimensions,
@@ -56,11 +57,7 @@ class MetricConfigStore {
 
   metricDefinitionSettings: {
     [systemMetricKey: string]: {
-      [settingKey: string]: {
-        included?: MetricConfigurationSettingsOptions;
-        default?: MetricConfigurationSettingsOptions;
-        label?: string;
-      };
+      [settingKey: string]: Partial<MetricConfigurationSettings>;
     };
   };
 
@@ -90,7 +87,6 @@ class MetricConfigStore {
       [disaggregationKey: string]: {
         [dimensionKey: string]: {
           enabled?: boolean;
-          contexts?: { key: string; value: string }[];
           label?: string;
           description?: string;
           key?: string;
@@ -358,7 +354,7 @@ class MetricConfigStore {
     system: AgencySystems,
     metricKey: string,
     settingKey: string,
-    metricDefinitionSettings: { [key: string]: string }
+    metricDefinitionSettings: Partial<MetricConfigurationSettings>
   ) => {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
@@ -434,6 +430,42 @@ class MetricConfigStore {
         dimensionKey
       ].ethnicity = dimensionData.ethnicity as Ethnicities;
     }
+  };
+
+  initializeDimensionDefinitionSetting = (
+    system: AgencySystems,
+    metricKey: string,
+    disaggregationKey: string,
+    dimensionKey: string,
+    settingKey: string,
+    dimensionDefinitionSettings: Partial<MetricConfigurationSettings>
+  ) => {
+    const systemMetricKey = MetricConfigStore.getSystemMetricKey(
+      system,
+      metricKey
+    );
+
+    if (!this.dimensionDefinitionSettings[systemMetricKey]) {
+      this.dimensionDefinitionSettings[systemMetricKey] = {};
+    }
+
+    if (!this.dimensionDefinitionSettings[systemMetricKey][disaggregationKey]) {
+      this.dimensionDefinitionSettings[systemMetricKey][disaggregationKey] = {};
+    }
+
+    if (
+      !this.dimensionDefinitionSettings[systemMetricKey][disaggregationKey][
+        dimensionKey
+      ]
+    ) {
+      this.dimensionDefinitionSettings[systemMetricKey][disaggregationKey][
+        dimensionKey
+      ] = {};
+    }
+
+    this.dimensionDefinitionSettings[systemMetricKey][disaggregationKey][
+      dimensionKey
+    ][settingKey] = dimensionDefinitionSettings;
   };
 
   initializeDimensionContexts = (
@@ -716,42 +748,6 @@ class MetricConfigStore {
         },
       ],
     };
-  };
-
-  initializeDimensionDefinitionSetting = (
-    system: AgencySystems,
-    metricKey: string,
-    disaggregationKey: string,
-    dimensionKey: string,
-    settingKey: string,
-    dimensionDefinitionSettings: { [key: string]: string }
-  ) => {
-    const systemMetricKey = MetricConfigStore.getSystemMetricKey(
-      system,
-      metricKey
-    );
-
-    if (!this.dimensionDefinitionSettings[systemMetricKey]) {
-      this.dimensionDefinitionSettings[systemMetricKey] = {};
-    }
-
-    if (!this.dimensionDefinitionSettings[systemMetricKey][disaggregationKey]) {
-      this.dimensionDefinitionSettings[systemMetricKey][disaggregationKey] = {};
-    }
-
-    if (
-      !this.dimensionDefinitionSettings[systemMetricKey][disaggregationKey][
-        dimensionKey
-      ]
-    ) {
-      this.dimensionDefinitionSettings[systemMetricKey][disaggregationKey][
-        dimensionKey
-      ] = {};
-    }
-
-    this.dimensionDefinitionSettings[systemMetricKey][disaggregationKey][
-      dimensionKey
-    ][settingKey] = dimensionDefinitionSettings;
   };
 
   updateDimensionDefinitionSetting = (


### PR DESCRIPTION
## Description of the change

The disaggregation toggles appear to always default to on (checked) and the dimensions off (unchecked) for every breakdown and saving doesn't appear to persist on the FE. The issue was in the initialization of the metric config store dimensions - there was no `enabled` property included in the store's dimensions object for the FE to read from. The fix is adding back the storage of `.enabled` property in the `initializeDimension` function.

Demo of out-of-sync behavior:

https://user-images.githubusercontent.com/59492998/220479226-1e9ab8de-ba7a-4308-84bd-e8a6d201cbcc.mov

--

Demo of correction:

https://user-images.githubusercontent.com/59492998/220479215-5173d92e-a011-445a-8b9f-da6764f82ef8.mov


## Related issues

Closes #420 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
