### PR TITLE
Guidance: Playtesting Followups - Breakdowns

### DIFF
--- a/publisher/src/components/Guidance/Guidance.styles.tsx
+++ b/publisher/src/components/Guidance/Guidance.styles.tsx
@@ -242,8 +242,8 @@ export const CheckIconWrapper = styled.div`
   border: 1px solid rgba(255, 255, 255, 0.2);
 `;
 
-export const CheckIcon = styled.img`
-  width: 20px;
+export const CheckIcon = styled.img<{ width?: number }>`
+  width: ${({ width }) => (width ? `${width}px` : "20px")};
 `;
 
 export const ProgressTooltipToast = styled.div<{ showToast?: boolean }>`

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -446,7 +446,9 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                   </DisaggregationHeader>
 
                   {/* Dimensions (Enable/Disable) */}
-                  {disaggregationKey === RACE_ETHNICITY_DISAGGREGATION_KEY ? (
+                  {disaggregationKey === RACE_ETHNICITY_DISAGGREGATION_KEY &&
+                  (currentDisaggregation.enabled ||
+                    currentDisaggregation.enabled === null) ? (
                     <RaceEthnicitiesGrid
                       disaggregationEnabled={
                         currentDisaggregation.enabled === true
@@ -462,48 +464,51 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                     currentDimensions?.map((dimension) => {
                       return (
                         <Fragment key={dimension.key}>
-                          <Dimension
-                            enabled={
-                              !metricEnabled ||
-                              currentDisaggregation.enabled ||
-                              currentDisaggregation.enabled === null
-                            }
-                            inView={dimension.key === activeDimensionKey}
-                            onClick={() => {
-                              setActiveDisaggregationKey(disaggregationKey);
-                              setActiveDimensionKey(dimension.key);
-                            }}
-                          >
-                            <DimensionTitleWrapper>
-                              <DimensionTitle
-                                enabled={currentDisaggregation.enabled}
-                              >
-                                {dimension?.label}
-                              </DimensionTitle>
-                              <ActionStatusTitle
-                                enabled={
-                                  currentDisaggregation.enabled &&
-                                  dimension.enabled === null
-                                }
-                                inView={dimension.key === activeDimensionKey}
-                              >
-                                {dimension.enabled && (
-                                  <AvailableWithCheckWrapper>
-                                    <BlueText>Available</BlueText>
-                                    <CheckIcon
-                                      src={checkmarkIcon}
-                                      alt=""
-                                      width={11}
-                                    />
-                                  </AvailableWithCheckWrapper>
-                                )}
-                                {dimension.enabled === false && "Unavailable"}
-                                {dimension.enabled === null &&
-                                  "Action Required"}
-                              </ActionStatusTitle>
-                              <RightArrowIcon />
-                            </DimensionTitleWrapper>
-                          </Dimension>
+                          {(currentDisaggregation.enabled ||
+                            currentDisaggregation.enabled === null) && (
+                            <Dimension
+                              enabled={
+                                !metricEnabled ||
+                                currentDisaggregation.enabled ||
+                                currentDisaggregation.enabled === null
+                              }
+                              inView={dimension.key === activeDimensionKey}
+                              onClick={() => {
+                                setActiveDisaggregationKey(disaggregationKey);
+                                setActiveDimensionKey(dimension.key);
+                              }}
+                            >
+                              <DimensionTitleWrapper>
+                                <DimensionTitle
+                                  enabled={currentDisaggregation.enabled}
+                                >
+                                  {dimension?.label}
+                                </DimensionTitle>
+                                <ActionStatusTitle
+                                  enabled={
+                                    currentDisaggregation.enabled &&
+                                    dimension.enabled === null
+                                  }
+                                  inView={dimension.key === activeDimensionKey}
+                                >
+                                  {dimension.enabled && (
+                                    <AvailableWithCheckWrapper>
+                                      <BlueText>Available</BlueText>
+                                      <CheckIcon
+                                        src={checkmarkIcon}
+                                        alt=""
+                                        width={11}
+                                      />
+                                    </AvailableWithCheckWrapper>
+                                  )}
+                                  {dimension.enabled === false && "Unavailable"}
+                                  {dimension.enabled === null &&
+                                    "Action Required"}
+                                </ActionStatusTitle>
+                                <RightArrowIcon />
+                              </DimensionTitleWrapper>
+                            </Dimension>
+                          )}
                         </Fragment>
                       );
                     })

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -30,12 +30,16 @@ import { monthsByName, removeSnakeCase } from "../../utils";
 import { ReactComponent as CalendarIconDark } from "../assets/calendar-icon-dark.svg";
 import { ReactComponent as CalendarIconLight } from "../assets/calendar-icon-light.svg";
 import { ReactComponent as RightArrowIcon } from "../assets/right-arrow.svg";
+import checkmarkIcon from "../assets/status-check-icon.png";
+import { BlueText } from "../DataUpload";
 import { BinaryRadioButton } from "../Forms";
 import { REPORT_VERB_LOWERCASE } from "../Global/constants";
+import { CheckIcon } from "../Guidance";
 import { ExtendedDropdownMenu, ExtendedDropdownMenuItem } from "../Menu";
 import { getActiveSystemMetricKey, useSettingsSearchParams } from "../Settings";
 import {
   ActionStatusTitle,
+  AvailableWithCheckWrapper,
   BlueLinkSpan,
   BreakdownHeader,
   Dimension,
@@ -483,7 +487,16 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
                                 }
                                 inView={dimension.key === activeDimensionKey}
                               >
-                                {dimension.enabled && "Available"}
+                                {dimension.enabled && (
+                                  <AvailableWithCheckWrapper>
+                                    <BlueText>Available</BlueText>
+                                    <CheckIcon
+                                      src={checkmarkIcon}
+                                      alt=""
+                                      width={11}
+                                    />
+                                  </AvailableWithCheckWrapper>
+                                )}
                                 {dimension.enabled === false && "Unavailable"}
                                 {dimension.enabled === null &&
                                   "Action Required"}

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -33,7 +33,7 @@ import { ReactComponent as RightArrowIcon } from "../assets/right-arrow.svg";
 import checkmarkIcon from "../assets/status-check-icon.png";
 import { BlueText } from "../DataUpload";
 import { BinaryRadioButton } from "../Forms";
-import { REPORT_VERB_LOWERCASE } from "../Global/constants";
+import { REPORT_VERB_LOWERCASE, REPORTED_LOWERCASE } from "../Global/constants";
 import { CheckIcon } from "../Guidance";
 import { ExtendedDropdownMenu, ExtendedDropdownMenuItem } from "../Menu";
 import { getActiveSystemMetricKey, useSettingsSearchParams } from "../Settings";
@@ -398,8 +398,9 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
             <Subheader>
               Turn “on” the breakdowns that your agency will be able to{" "}
               {REPORT_VERB_LOWERCASE}. Click into each category to indicate
-              whether or not the breakdown is available to be reported and to
-              configure the definition for that category.
+              whether or not the breakdown is available to be{" "}
+              {REPORTED_LOWERCASE} and to configure the definition for that
+              category.
             </Subheader>
 
             {/* Disaggregations (Enable/Disable) */}

--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -392,9 +392,10 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
           <MetricDisaggregations enabled={metricEnabled}>
             <BreakdownHeader>Breakdowns</BreakdownHeader>
             <Subheader>
-              Mark (using the checkmark) each of the breakdowns below that your
-              agency will be able to {REPORT_VERB_LOWERCASE}. Click the arrow to
-              edit the definition for each breakdown.
+              Turn “on” the breakdowns that your agency will be able to{" "}
+              {REPORT_VERB_LOWERCASE}. Click into each category to indicate
+              whether or not the breakdown is available to be reported and to
+              configure the definition for that category.
             </Subheader>
 
             {/* Disaggregations (Enable/Disable) */}

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -881,3 +881,9 @@ export const DisaggregationHeader = styled.div`
   margin-top: 48px;
   border-bottom: 1px solid ${palette.highlight.grey5};
 `;
+
+export const AvailableWithCheckWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 7px;
+`;

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -422,6 +422,8 @@ class MetricConfigStore {
       this.dimensions[systemMetricKey][disaggregationKey][dimensionKey] = {};
     }
 
+    this.dimensions[systemMetricKey][disaggregationKey][dimensionKey].enabled =
+      dimensionData.enabled;
     this.dimensions[systemMetricKey][disaggregationKey][dimensionKey].label =
       dimensionData.label;
     this.dimensions[systemMetricKey][disaggregationKey][dimensionKey].key =


### PR DESCRIPTION
## Description of the change

Addresses the following playtesting feedback related to breakdowns:
* (P0) Update breakdown help text copy
* (P0) For breakdowns - find another option aside from gray and similar styling to make it easy to scan
* (P0) More easily see which breakdowns are available/not available
* (P1) Collapse breakdown section when disabled

https://user-images.githubusercontent.com/59492998/220957156-154884a6-0f19-4618-b563-936e71dd4294.mov

Note: the logo missing on the top left is fixed by #417

## Related issues

Closes #433 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
