### PR TITLE
Remove admin flag for displaying jurisdictions

### DIFF
--- a/publisher/src/components/Settings/AgencySettings.tsx
+++ b/publisher/src/components/Settings/AgencySettings.tsx
@@ -93,12 +93,9 @@ export const AgencySettings: React.FC = observer(() => {
             settingProps={generateSettingProps(ActiveSetting.Supervisions)}
           />
         )}
-        {/* TODO(#306) Allow all users to see this section once Jurisdictions is finished */}
-        {userStore.isJusticeCountsAdmin(agencyId) && (
-          <AgencySettingsJurisdictions
-            settingProps={generateSettingProps(ActiveSetting.Jurisdictions)}
-          />
-        )}
+        <AgencySettingsJurisdictions
+          settingProps={generateSettingProps(ActiveSetting.Jurisdictions)}
+        />
       </AgencySettingsContent>
     </AgencySettingsWrapper>
   );


### PR DESCRIPTION
## Description of the change

> Everyone can see jurisdictions section now in agency settings

## Type of change
Type: Non-breaking refactor

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Closes #306 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
