### PR TITLE
Guidance: Support switching agencies

### DIFF
--- a/publisher/src/components/Guidance/Guidance.styles.tsx
+++ b/publisher/src/components/Guidance/Guidance.styles.tsx
@@ -321,6 +321,7 @@ export const MetricListContainer = styled.div`
 
 export const MetricName = styled.div`
   ${typography.sizeCSS.large}
+  text-align: left;
 `;
 
 export const MetricStatus = styled.div<{ greyText?: boolean }>`
@@ -331,6 +332,7 @@ export const MetricStatus = styled.div<{ greyText?: boolean }>`
     greyText ? palette.highlight.grey10 : palette.solid.blue};
   opacity: 1;
   transition: opacity 0.2s ease;
+  white-space: nowrap;
 
   ${Metric}:hover & {
     opacity: 0;

--- a/publisher/src/components/Guidance/Guidance.styles.tsx
+++ b/publisher/src/components/Guidance/Guidance.styles.tsx
@@ -264,7 +264,7 @@ export const ProgressItemName = styled.div`
 
 export const MetricContentContainer = styled(ContentContainer)`
   width: 100%;
-  height: 54%;
+  max-height: 515px;
   max-width: 550px;
   gap: unset;
   justify-content: flex-start;

--- a/publisher/src/components/Guidance/Guidance.tsx
+++ b/publisher/src/components/Guidance/Guidance.tsx
@@ -127,7 +127,10 @@ export const Guidance = observer(() => {
     ([key]) => getMetricCompletionValue(key) === 4
   ).length;
 
-  useEffect(() => metricConfigStore.resetStore(), [agencyId]);
+  useEffect(
+    () => metricConfigStore.resetStore(),
+    [agencyId, metricConfigStore]
+  );
 
   useEffect(() => {
     const initialize = async () => {

--- a/publisher/src/components/Guidance/Guidance.tsx
+++ b/publisher/src/components/Guidance/Guidance.tsx
@@ -127,10 +127,11 @@ export const Guidance = observer(() => {
     ([key]) => getMetricCompletionValue(key) === 4
   ).length;
 
+  useEffect(() => metricConfigStore.resetStore(), [agencyId]);
+
   useEffect(() => {
     const initialize = async () => {
       reportStore.resetState();
-      metricConfigStore.resetStore();
       await reportStore.getReportOverviews(agencyId);
       if (currentTopicID === "METRIC_CONFIG")
         await metricConfigStore.initializeMetricConfigStoreValues(agencyId);

--- a/publisher/src/components/Guidance/Guidance.tsx
+++ b/publisher/src/components/Guidance/Guidance.tsx
@@ -130,6 +130,7 @@ export const Guidance = observer(() => {
   useEffect(() => {
     const initialize = async () => {
       reportStore.resetState();
+      metricConfigStore.resetStore();
       await reportStore.getReportOverviews(agencyId);
       if (currentTopicID === "METRIC_CONFIG")
         await metricConfigStore.initializeMetricConfigStoreValues(agencyId);

--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -171,7 +171,7 @@ const Menu: React.FC = () => {
               <MenuItem
                 style={{ position: "relative" }}
                 active={pathWithoutAgency === "getting-started"}
-                onClick={() => navigate("/")}
+                onClick={() => navigate(`/agency/${agencyId}/getting-started`)}
               >
                 Get Started
                 {/* Guidance: Metric Configuration Progress Toast */}

--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -143,7 +143,7 @@ const Menu: React.FC = () => {
   useEffect(() => {
     const initOnboardingTopicStatuses = async () => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      await guidanceStore.getOnboardingTopicsStatuses();
+      await guidanceStore.getOnboardingTopicsStatuses(agencyId);
     };
 
     initOnboardingTopicStatuses();

--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -286,7 +286,8 @@ const Menu: React.FC = () => {
                   navigate("upload");
               }}
               enabledDuringOnboarding={
-                !hasCompletedOnboarding && isAddDataOrPublishDataStep
+                hasCompletedOnboarding ||
+                (!hasCompletedOnboarding && isAddDataOrPublishDataStep)
               }
             >
               Upload Data

--- a/publisher/src/stores/GuidanceStore.test.tsx
+++ b/publisher/src/stores/GuidanceStore.test.tsx
@@ -1138,7 +1138,7 @@ test("Metric enabled, metric definition settings and metric breakdown availabili
     "LAW_ENFORCEMENT-LAW_ENFORCEMENT_FUNDING"
   );
 
-  expect(metricDisabledCompletionValue).toEqual(3);
+  expect(metricDisabledCompletionValue).toEqual(4);
   expect.hasAssertions();
 });
 

--- a/publisher/src/stores/GuidanceStore.ts
+++ b/publisher/src/stores/GuidanceStore.ts
@@ -292,7 +292,6 @@ class GuidanceStore {
 
       if (
         nullDimensionDefinitionSettings.length === 0 &&
-        dimensionDefinitionSettingsValues.length !== 0 &&
         metrics[systemMetricKey]?.enabled
       ) {
         result[systemMetricKey][ProgressSteps.CONFIRM_BREAKDOWN_DEFINITIONS] =

--- a/publisher/src/stores/GuidanceStore.ts
+++ b/publisher/src/stores/GuidanceStore.ts
@@ -89,11 +89,11 @@ class GuidanceStore {
     return topicID;
   }
 
-  getOnboardingTopicsStatuses = async (): Promise<
-    OnboardingTopicsStatuses[]
-  > => {
+  getOnboardingTopicsStatuses = async (
+    agencyId: string
+  ): Promise<OnboardingTopicsStatuses[]> => {
     const response = (await this.api.request({
-      path: `/api/users/guidance`,
+      path: `/api/users/agencies/${agencyId}/guidance`,
       method: "GET",
     })) as Response;
 
@@ -123,7 +123,7 @@ class GuidanceStore {
     agencyID: string
   ): Promise<Response | Error> => {
     const response = (await this.api.request({
-      path: `/api/users/guidance`,
+      path: `/api/users/agencies/${agencyID}/guidance`,
       body: { updated_topic: updatedTopic },
       method: "PUT",
     })) as Response;

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -154,6 +154,18 @@ class MetricConfigStore {
     return { system, metricKey };
   }
 
+  resetStore = () => {
+    runInAction(() => {
+      this.metrics = {};
+      this.metricDefinitionSettings = {};
+      this.disaggregations = {};
+      this.dimensions = {};
+      this.dimensionDefinitionSettings = {};
+      this.contexts = {};
+      this.dimensionContexts = {};
+    });
+  };
+
   getMetricsBySystem = (systemName: AgencySystems | undefined) => {
     if (systemName) {
       const metrics = Object.entries(this.metrics).reduce(


### PR DESCRIPTION
## Description of the change

Allows users to switch agencies during the guidance flow.

Other small adjustments made:
* Bug with overflow container in metric configuration overview
* Alignment of long text in metric configuration overview
* Upload Data button text color bug when onboarding is complete
* Bug with disabling disaggregations and progress tracking (dimensions were still counted towards progress which prevented user for proceeding)

## Related issues

Closes #450

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
