### PR TITLE
[Bug] Update the FE names for races and ethnicities to match what the backend sends

### DIFF
--- a/publisher/src/components/Forms/TabbedDisaggregations.tsx
+++ b/publisher/src/components/Forms/TabbedDisaggregations.tsx
@@ -188,11 +188,11 @@ export const TabbedDisaggregations: React.FC<{
         (acc, dimension) => {
           /** Include only enabled dimensions OR all dimensions when disaggregation is disabled (to avoid showing nothing)  */
           if (dimension.enabled || !raceEthnicityDisaggregation.enabled) {
-            if (dimension.ethnicity === "Hispanic") {
-              acc.Hispanic.push(dimension);
+            if (dimension.ethnicity === "Hispanic or Latino") {
+              acc["Hispanic or Latino"].push(dimension);
             }
-            if (dimension.ethnicity === "Not Hispanic") {
-              acc["Not Hispanic"].push(dimension);
+            if (dimension.ethnicity === "Not Hispanic or Latino") {
+              acc["Not Hispanic or Latino"].push(dimension);
             }
             if (dimension.ethnicity === "Unknown Ethnicity") {
               acc["Unknown Ethnicity"].push(dimension);
@@ -201,8 +201,8 @@ export const TabbedDisaggregations: React.FC<{
           return acc;
         },
         {
-          Hispanic: [],
-          "Not Hispanic": [],
+          "Hispanic or Latino": [],
+          "Not Hispanic or Latino": [],
           "Unknown Ethnicity": [],
         } as { [key: string]: MetricDisaggregationDimensions[] }
       ) || {};
@@ -215,9 +215,7 @@ export const TabbedDisaggregations: React.FC<{
         {dimensionsGroupedByEthnicityEntries.map(([ethnicity, dimensions]) => (
           <Fragment key={dimensions[0]?.key + ethnicity}>
             {dimensions.length > 0 && (
-              <EthnicityHeader>
-                {ethnicity === "Hispanic" ? "Hispanic or Latino" : ethnicity}
-              </EthnicityHeader>
+              <EthnicityHeader>{ethnicity}</EthnicityHeader>
             )}
             {dimensions.map((dimension) => renderDimension({ dimension }))}
           </Fragment>

--- a/publisher/src/components/Forms/TabbedDisaggregations.tsx
+++ b/publisher/src/components/Forms/TabbedDisaggregations.tsx
@@ -28,7 +28,10 @@ import { useStore } from "../../stores";
 import dropdownArrow from "../assets/dropdown-arrow.svg";
 import errorIcon from "../assets/status-error-icon.png";
 import { ExtendedDropdownMenuItem } from "../Menu";
-import { RACE_ETHNICITY_DISAGGREGATION_KEY } from "../MetricConfiguration";
+import {
+  Ethnicity,
+  RACE_ETHNICITY_DISAGGREGATION_KEY,
+} from "../MetricConfiguration";
 import {
   DisaggregationsDropdownContainer,
   DisaggregationsDropdownMenu,
@@ -188,22 +191,22 @@ export const TabbedDisaggregations: React.FC<{
         (acc, dimension) => {
           /** Include only enabled dimensions OR all dimensions when disaggregation is disabled (to avoid showing nothing)  */
           if (dimension.enabled || !raceEthnicityDisaggregation.enabled) {
-            if (dimension.ethnicity === "Hispanic or Latino") {
-              acc["Hispanic or Latino"].push(dimension);
+            if (dimension.ethnicity === Ethnicity.HISPANIC_OR_LATINO) {
+              acc[Ethnicity.HISPANIC_OR_LATINO].push(dimension);
             }
-            if (dimension.ethnicity === "Not Hispanic or Latino") {
-              acc["Not Hispanic or Latino"].push(dimension);
+            if (dimension.ethnicity === Ethnicity.NOT_HISPANIC_OR_LATINO) {
+              acc[Ethnicity.NOT_HISPANIC_OR_LATINO].push(dimension);
             }
-            if (dimension.ethnicity === "Unknown Ethnicity") {
-              acc["Unknown Ethnicity"].push(dimension);
+            if (dimension.ethnicity === Ethnicity.UNKNOWN_ETHNICITY) {
+              acc[Ethnicity.UNKNOWN_ETHNICITY].push(dimension);
             }
           }
           return acc;
         },
         {
-          "Hispanic or Latino": [],
-          "Not Hispanic or Latino": [],
-          "Unknown Ethnicity": [],
+          [Ethnicity.HISPANIC_OR_LATINO]: [],
+          [Ethnicity.NOT_HISPANIC_OR_LATINO]: [],
+          [Ethnicity.UNKNOWN_ETHNICITY]: [],
         } as { [key: string]: MetricDisaggregationDimensions[] }
       ) || {};
     const dimensionsGroupedByEthnicityEntries = Object.entries(

--- a/publisher/src/components/MetricConfiguration/RaceEthnicities.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicities.styles.tsx
@@ -116,7 +116,7 @@ export const EthnicityLabel = styled.div`
   }
 `;
 
-export const Ethnicity = styled.div`
+export const EthnicityName = styled.div`
   color: ${palette.solid.darkgrey};
   white-space: nowrap;
 `;
@@ -172,7 +172,7 @@ export const RaceEthnicitiesDisplay = styled(DefinitionsDisplay)``;
 export const RaceEthnicitiesTitle = styled(DefinitionsTitle)``;
 export const RaceEthnicitiesDescription = styled(DefinitionsDescription)``;
 export const RaceContainer = styled(Definitions)``;
-export const Race = styled(DefinitionItem)``;
+export const RaceWrapper = styled(DefinitionItem)``;
 export const RaceDisplayName = styled(DefinitionDisplayName)``;
 export const RaceSelection = styled(DefinitionSelection)``;
 export const RaceSelectionButton = styled(MiniButton)``;

--- a/publisher/src/components/MetricConfiguration/RaceEthnicitiesForm.tsx
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicitiesForm.tsx
@@ -24,6 +24,7 @@ import { useStore } from "../../stores";
 import { BinaryRadioButton } from "../Forms";
 import { getActiveSystemMetricKey, useSettingsSearchParams } from "../Settings";
 import {
+  Ethnicity,
   Header,
   RaceContainer,
   RaceDisplayName,
@@ -71,9 +72,9 @@ export const RaceEthnicitiesForm = observer(() => {
     ethnicitiesByRaceArray.filter(([_, ethnicities]) => {
       /** At least one Race where all three Ethnicities are enabled */
       return (
-        ethnicities["Hispanic or Latino"].enabled &&
-        ethnicities["Not Hispanic or Latino"].enabled &&
-        ethnicities["Unknown Ethnicity"].enabled
+        ethnicities[Ethnicity.HISPANIC_OR_LATINO].enabled &&
+        ethnicities[Ethnicity.NOT_HISPANIC_OR_LATINO].enabled &&
+        ethnicities[Ethnicity.UNKNOWN_ETHNICITY].enabled
       );
     }).length > 0;
 
@@ -82,8 +83,8 @@ export const RaceEthnicitiesForm = observer(() => {
       /** Unknown Race has both Hispanic and Not Hispanic enabled */
       return (
         race === "Unknown" &&
-        ethnicities["Hispanic or Latino"].enabled &&
-        ethnicities["Not Hispanic or Latino"].enabled
+        ethnicities[Ethnicity.HISPANIC_OR_LATINO].enabled &&
+        ethnicities[Ethnicity.NOT_HISPANIC_OR_LATINO].enabled
       );
     }).length > 0;
 
@@ -158,9 +159,10 @@ export const RaceEthnicitiesForm = observer(() => {
 
         <SpecifyEthnicityWrapper>
           <Header>
-            Are you able to record an individual’s <strong>ethnicity</strong>{" "}
-            (Hispanic or Latino, Not Hispanic or Latino, or Unknown) separately
-            from their race in your case management system?
+            Are you able to record an individual’s <strong>ethnicity</strong> (
+            {Ethnicity.HISPANIC_OR_LATINO}, {Ethnicity.NOT_HISPANIC_OR_LATINO},
+            or {Ethnicity.UNKNOWN_ETHNICITY}) separately from their race in your
+            case management system?
           </Header>
 
           <RadioButtonGroupWrapper>
@@ -205,7 +207,7 @@ export const RaceEthnicitiesForm = observer(() => {
           {/* Hispanic/Latino as Race (if user cannot specify ethnicity) */}
           {!canSpecifyEthnicity && (
             <RaceWrapper>
-              <RaceDisplayName>Hispanic or Latino</RaceDisplayName>
+              <RaceDisplayName>{Ethnicity.HISPANIC_OR_LATINO}</RaceDisplayName>
               <RaceSelection>
                 <RaceEthnicityRadioButtonGroupWrapper>
                   <BinaryRadioButton

--- a/publisher/src/components/MetricConfiguration/RaceEthnicitiesForm.tsx
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicitiesForm.tsx
@@ -71,9 +71,9 @@ export const RaceEthnicitiesForm = observer(() => {
     ethnicitiesByRaceArray.filter(([_, ethnicities]) => {
       /** At least one Race where all three Ethnicities are enabled */
       return (
-        ethnicities.Hispanic?.enabled &&
-        ethnicities["Not Hispanic"]?.enabled &&
-        ethnicities["Unknown Ethnicity"]?.enabled
+        ethnicities["Hispanic or Latino"].enabled &&
+        ethnicities["Not Hispanic or Latino"].enabled &&
+        ethnicities["Unknown Ethnicity"].enabled
       );
     }).length > 0;
 
@@ -82,8 +82,8 @@ export const RaceEthnicitiesForm = observer(() => {
       /** Unknown Race has both Hispanic and Not Hispanic enabled */
       return (
         race === "Unknown" &&
-        ethnicities.Hispanic?.enabled &&
-        ethnicities["Not Hispanic"]?.enabled
+        ethnicities["Hispanic or Latino"].enabled &&
+        ethnicities["Not Hispanic or Latino"].enabled
       );
     }).length > 0;
 

--- a/publisher/src/components/MetricConfiguration/RaceEthnicitiesForm.tsx
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicitiesForm.tsx
@@ -25,7 +25,6 @@ import { BinaryRadioButton } from "../Forms";
 import { getActiveSystemMetricKey, useSettingsSearchParams } from "../Settings";
 import {
   Header,
-  Race,
   RaceContainer,
   RaceDisplayName,
   RaceEthnicitiesContainer,
@@ -35,6 +34,7 @@ import {
   raceEthnicityGridStates,
   RaceEthnicityRadioButtonGroupWrapper,
   RaceSelection,
+  RaceWrapper,
   RadioButtonGroupWrapper,
   sortRaces,
   SpecifyEthnicityWrapper,
@@ -204,7 +204,7 @@ export const RaceEthnicitiesForm = observer(() => {
         <RaceContainer>
           {/* Hispanic/Latino as Race (if user cannot specify ethnicity) */}
           {!canSpecifyEthnicity && (
-            <Race>
+            <RaceWrapper>
               <RaceDisplayName>Hispanic or Latino</RaceDisplayName>
               <RaceSelection>
                 <RaceEthnicityRadioButtonGroupWrapper>
@@ -240,7 +240,7 @@ export const RaceEthnicitiesForm = observer(() => {
                   />
                 </RaceEthnicityRadioButtonGroupWrapper>
               </RaceSelection>
-            </Race>
+            </RaceWrapper>
           )}
 
           {/* Races (Enable/Disable) */}
@@ -254,7 +254,7 @@ export const RaceEthnicitiesForm = observer(() => {
               );
 
               return (
-                <Race key={race}>
+                <RaceWrapper key={race}>
                   <RaceDisplayName>{race}</RaceDisplayName>
                   <RaceSelection>
                     <RaceEthnicityRadioButtonGroupWrapper>
@@ -282,7 +282,7 @@ export const RaceEthnicitiesForm = observer(() => {
                       />
                     </RaceEthnicityRadioButtonGroupWrapper>
                   </RaceSelection>
-                </Race>
+                </RaceWrapper>
               );
             })}
         </RaceContainer>

--- a/publisher/src/components/MetricConfiguration/RaceEthnicitiesGrid.tsx
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicitiesGrid.tsx
@@ -25,6 +25,7 @@ import {
   CalloutBox,
   Description,
   EthnicitiesRow,
+  Ethnicity,
   EthnicityCell,
   EthnicityLabel,
   EthnicityName,
@@ -72,9 +73,9 @@ export const RaceEthnicitiesGrid: React.FC<{
           <EthnicityLabel>
             Ethnicity <RightArrowIcon />
           </EthnicityLabel>
-          <EthnicityName>Hispanic or Latino</EthnicityName>
-          <EthnicityName>Not Hispanic</EthnicityName>
-          <EthnicityName>Unknown</EthnicityName>
+          <EthnicityName>{Ethnicity.HISPANIC_OR_LATINO}</EthnicityName>
+          <EthnicityName>{Ethnicity.NOT_HISPANIC_OR_LATINO}</EthnicityName>
+          <EthnicityName>{Ethnicity.UNKNOWN_ETHNICITY}</EthnicityName>
         </GridEthnicitiesHeader>
       </GridHeaderContainer>
 

--- a/publisher/src/components/MetricConfiguration/RaceEthnicitiesGrid.tsx
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicitiesGrid.tsx
@@ -25,9 +25,9 @@ import {
   CalloutBox,
   Description,
   EthnicitiesRow,
-  Ethnicity,
   EthnicityCell,
   EthnicityLabel,
+  EthnicityName,
   GridEthnicitiesHeader,
   GridHeaderContainer,
   GridRaceHeader,
@@ -72,9 +72,9 @@ export const RaceEthnicitiesGrid: React.FC<{
           <EthnicityLabel>
             Ethnicity <RightArrowIcon />
           </EthnicityLabel>
-          <Ethnicity>Hispanic or Latino</Ethnicity>
-          <Ethnicity>Not Hispanic</Ethnicity>
-          <Ethnicity>Unknown</Ethnicity>
+          <EthnicityName>Hispanic or Latino</EthnicityName>
+          <EthnicityName>Not Hispanic</EthnicityName>
+          <EthnicityName>Unknown</EthnicityName>
         </GridEthnicitiesHeader>
       </GridHeaderContainer>
 

--- a/publisher/src/components/MetricConfiguration/RaceEthnicitiesGridStates.ts
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicitiesGridStates.ts
@@ -44,128 +44,128 @@ export type RaceEthnicitiesGridStates = {
  */
 export const raceEthnicityGridStates = {
   CAN_SPECIFY_ETHNICITY: {
-    "American Indian / Alaskan Native": {
-      Hispanic: true,
-      "Not Hispanic": true,
+    "American Indian or Alaska Native": {
+      "Hispanic or Latino": true,
+      "Not Hispanic or Latino": true,
       "Unknown Ethnicity": true,
     },
     Asian: {
-      Hispanic: true,
-      "Not Hispanic": true,
+      "Hispanic or Latino": true,
+      "Not Hispanic or Latino": true,
       "Unknown Ethnicity": true,
     },
     Black: {
-      Hispanic: true,
-      "Not Hispanic": true,
+      "Hispanic or Latino": true,
+      "Not Hispanic or Latino": true,
       "Unknown Ethnicity": true,
     },
     "More than one race": {
-      Hispanic: true,
-      "Not Hispanic": true,
+      "Hispanic or Latino": true,
+      "Not Hispanic or Latino": true,
       "Unknown Ethnicity": true,
     },
-    "Native Hawaiian / Pacific Islander": {
-      Hispanic: true,
-      "Not Hispanic": true,
+    "Native Hawaiian or Pacific Islander": {
+      "Hispanic or Latino": true,
+      "Not Hispanic or Latino": true,
       "Unknown Ethnicity": true,
     },
     White: {
-      Hispanic: true,
-      "Not Hispanic": true,
+      "Hispanic or Latino": true,
+      "Not Hispanic or Latino": true,
       "Unknown Ethnicity": true,
     },
     Other: {
-      Hispanic: true,
-      "Not Hispanic": true,
+      "Hispanic or Latino": true,
+      "Not Hispanic or Latino": true,
       "Unknown Ethnicity": true,
     },
     Unknown: {
-      Hispanic: true,
-      "Not Hispanic": true,
+      "Hispanic or Latino": true,
+      "Not Hispanic or Latino": true,
       "Unknown Ethnicity": true,
     },
   },
   NO_ETHNICITY_HISPANIC_AS_RACE: {
-    "American Indian / Alaskan Native": {
-      Hispanic: false,
-      "Not Hispanic": true,
+    "American Indian or Alaska Native": {
+      "Hispanic or Latino": false,
+      "Not Hispanic or Latino": true,
       "Unknown Ethnicity": false,
     },
     Asian: {
-      Hispanic: false,
-      "Not Hispanic": true,
+      "Hispanic or Latino": false,
+      "Not Hispanic or Latino": true,
       "Unknown Ethnicity": false,
     },
     Black: {
-      Hispanic: false,
-      "Not Hispanic": true,
+      "Hispanic or Latino": false,
+      "Not Hispanic or Latino": true,
       "Unknown Ethnicity": false,
     },
     "More than one race": {
-      Hispanic: false,
-      "Not Hispanic": true,
+      "Hispanic or Latino": false,
+      "Not Hispanic or Latino": true,
       "Unknown Ethnicity": false,
     },
-    "Native Hawaiian / Pacific Islander": {
-      Hispanic: false,
-      "Not Hispanic": true,
+    "Native Hawaiian or Pacific Islander": {
+      "Hispanic or Latino": false,
+      "Not Hispanic or Latino": true,
       "Unknown Ethnicity": false,
     },
     White: {
-      Hispanic: false,
-      "Not Hispanic": true,
+      "Hispanic or Latino": false,
+      "Not Hispanic or Latino": true,
       "Unknown Ethnicity": false,
     },
     Other: {
-      Hispanic: false,
-      "Not Hispanic": true,
+      "Hispanic or Latino": false,
+      "Not Hispanic or Latino": true,
       "Unknown Ethnicity": false,
     },
     Unknown: {
-      Hispanic: true,
-      "Not Hispanic": true,
+      "Hispanic or Latino": true,
+      "Not Hispanic or Latino": true,
       "Unknown Ethnicity": false,
     },
   },
   NO_ETHNICITY_HISPANIC_NOT_SPECIFIED: {
-    "American Indian / Alaskan Native": {
-      Hispanic: false,
-      "Not Hispanic": false,
+    "American Indian or Alaska Native": {
+      "Hispanic or Latino": false,
+      "Not Hispanic or Latino": false,
       "Unknown Ethnicity": true,
     },
     Asian: {
-      Hispanic: false,
-      "Not Hispanic": false,
+      "Hispanic or Latino": false,
+      "Not Hispanic or Latino": false,
       "Unknown Ethnicity": true,
     },
     Black: {
-      Hispanic: false,
-      "Not Hispanic": false,
+      "Hispanic or Latino": false,
+      "Not Hispanic or Latino": false,
       "Unknown Ethnicity": true,
     },
     "More than one race": {
-      Hispanic: false,
-      "Not Hispanic": false,
+      "Hispanic or Latino": false,
+      "Not Hispanic or Latino": false,
       "Unknown Ethnicity": true,
     },
-    "Native Hawaiian / Pacific Islander": {
-      Hispanic: false,
-      "Not Hispanic": false,
+    "Native Hawaiian or Pacific Islander": {
+      "Hispanic or Latino": false,
+      "Not Hispanic or Latino": false,
       "Unknown Ethnicity": true,
     },
     White: {
-      Hispanic: false,
-      "Not Hispanic": false,
+      "Hispanic or Latino": false,
+      "Not Hispanic or Latino": false,
       "Unknown Ethnicity": true,
     },
     Other: {
-      Hispanic: false,
-      "Not Hispanic": false,
+      "Hispanic or Latino": false,
+      "Not Hispanic or Latino": false,
       "Unknown Ethnicity": true,
     },
     Unknown: {
-      Hispanic: false,
-      "Not Hispanic": false,
+      "Hispanic or Latino": false,
+      "Not Hispanic or Latino": false,
       "Unknown Ethnicity": true,
     },
   },

--- a/publisher/src/components/MetricConfiguration/RaceEthnicitiesGridStates.ts
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicitiesGridStates.ts
@@ -15,6 +15,25 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+// import { Ethnicity, Race } from ".";
+
+export const Race = {
+  AMERICAN_INDIAN_OR_ALASKAN_NATIVE: "American Indian or Alaska Native",
+  ASIAN: "Asian",
+  BLACK: "Black",
+  NATIVE_HAWAIIAN_OR_PACIFIC_ISLANDER: "Native Hawaiian or Pacific Islander",
+  WHITE: "White",
+  MORE_THAN_ONE_RACE: "More than one race",
+  OTHER: "Other",
+  UNKNOWN: "Unknown",
+};
+
+export const Ethnicity = {
+  HISPANIC_OR_LATINO: "Hispanic or Latino",
+  NOT_HISPANIC_OR_LATINO: "Not Hispanic or Latino",
+  UNKNOWN_ETHNICITY: "Unknown Ethnicity",
+};
+
 export type StateKeys = keyof typeof raceEthnicityGridStates;
 
 export type RaceEthnicitiesGridStates = {
@@ -42,131 +61,132 @@ export type RaceEthnicitiesGridStates = {
  * State 2 has only 9 available dimensions (Race x Not Hispanic/Latino Ethnicity, Unknown Race x Hispanic/Latino Ethnicity) - the other 15 dimensions are disabled.
  * State 3 has only 8 available dimensions (Race x Unknown Ethnicity) - the other 16 dimensions are disabled.
  */
+
 export const raceEthnicityGridStates = {
   CAN_SPECIFY_ETHNICITY: {
-    "American Indian or Alaska Native": {
-      "Hispanic or Latino": true,
-      "Not Hispanic or Latino": true,
-      "Unknown Ethnicity": true,
+    [Race.AMERICAN_INDIAN_OR_ALASKAN_NATIVE]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: true,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: true,
+      [Ethnicity.UNKNOWN_ETHNICITY]: true,
     },
-    Asian: {
-      "Hispanic or Latino": true,
-      "Not Hispanic or Latino": true,
-      "Unknown Ethnicity": true,
+    [Race.ASIAN]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: true,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: true,
+      [Ethnicity.UNKNOWN_ETHNICITY]: true,
     },
-    Black: {
-      "Hispanic or Latino": true,
-      "Not Hispanic or Latino": true,
-      "Unknown Ethnicity": true,
+    [Race.BLACK]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: true,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: true,
+      [Ethnicity.UNKNOWN_ETHNICITY]: true,
     },
-    "More than one race": {
-      "Hispanic or Latino": true,
-      "Not Hispanic or Latino": true,
-      "Unknown Ethnicity": true,
+    [Race.MORE_THAN_ONE_RACE]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: true,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: true,
+      [Ethnicity.UNKNOWN_ETHNICITY]: true,
     },
-    "Native Hawaiian or Pacific Islander": {
-      "Hispanic or Latino": true,
-      "Not Hispanic or Latino": true,
-      "Unknown Ethnicity": true,
+    [Race.NATIVE_HAWAIIAN_OR_PACIFIC_ISLANDER]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: true,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: true,
+      [Ethnicity.UNKNOWN_ETHNICITY]: true,
     },
-    White: {
-      "Hispanic or Latino": true,
-      "Not Hispanic or Latino": true,
-      "Unknown Ethnicity": true,
+    [Race.WHITE]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: true,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: true,
+      [Ethnicity.UNKNOWN_ETHNICITY]: true,
     },
-    Other: {
-      "Hispanic or Latino": true,
-      "Not Hispanic or Latino": true,
-      "Unknown Ethnicity": true,
+    [Race.OTHER]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: true,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: true,
+      [Ethnicity.UNKNOWN_ETHNICITY]: true,
     },
-    Unknown: {
-      "Hispanic or Latino": true,
-      "Not Hispanic or Latino": true,
-      "Unknown Ethnicity": true,
+    [Race.UNKNOWN]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: true,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: true,
+      [Ethnicity.UNKNOWN_ETHNICITY]: true,
     },
   },
   NO_ETHNICITY_HISPANIC_AS_RACE: {
-    "American Indian or Alaska Native": {
-      "Hispanic or Latino": false,
-      "Not Hispanic or Latino": true,
-      "Unknown Ethnicity": false,
+    [Race.AMERICAN_INDIAN_OR_ALASKAN_NATIVE]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: false,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: true,
+      [Ethnicity.UNKNOWN_ETHNICITY]: false,
     },
-    Asian: {
-      "Hispanic or Latino": false,
-      "Not Hispanic or Latino": true,
-      "Unknown Ethnicity": false,
+    [Race.ASIAN]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: false,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: true,
+      [Ethnicity.UNKNOWN_ETHNICITY]: false,
     },
-    Black: {
-      "Hispanic or Latino": false,
-      "Not Hispanic or Latino": true,
-      "Unknown Ethnicity": false,
+    [Race.BLACK]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: false,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: true,
+      [Ethnicity.UNKNOWN_ETHNICITY]: false,
     },
-    "More than one race": {
-      "Hispanic or Latino": false,
-      "Not Hispanic or Latino": true,
-      "Unknown Ethnicity": false,
+    [Race.MORE_THAN_ONE_RACE]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: false,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: true,
+      [Ethnicity.UNKNOWN_ETHNICITY]: false,
     },
-    "Native Hawaiian or Pacific Islander": {
-      "Hispanic or Latino": false,
-      "Not Hispanic or Latino": true,
-      "Unknown Ethnicity": false,
+    [Race.NATIVE_HAWAIIAN_OR_PACIFIC_ISLANDER]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: false,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: true,
+      [Ethnicity.UNKNOWN_ETHNICITY]: false,
     },
-    White: {
-      "Hispanic or Latino": false,
-      "Not Hispanic or Latino": true,
-      "Unknown Ethnicity": false,
+    [Race.WHITE]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: false,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: true,
+      [Ethnicity.UNKNOWN_ETHNICITY]: false,
     },
-    Other: {
-      "Hispanic or Latino": false,
-      "Not Hispanic or Latino": true,
-      "Unknown Ethnicity": false,
+    [Race.OTHER]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: false,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: true,
+      [Ethnicity.UNKNOWN_ETHNICITY]: false,
     },
-    Unknown: {
-      "Hispanic or Latino": true,
-      "Not Hispanic or Latino": true,
-      "Unknown Ethnicity": false,
+    [Race.UNKNOWN]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: true,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: true,
+      [Ethnicity.UNKNOWN_ETHNICITY]: false,
     },
   },
   NO_ETHNICITY_HISPANIC_NOT_SPECIFIED: {
-    "American Indian or Alaska Native": {
-      "Hispanic or Latino": false,
-      "Not Hispanic or Latino": false,
-      "Unknown Ethnicity": true,
+    [Race.AMERICAN_INDIAN_OR_ALASKAN_NATIVE]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: false,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: false,
+      [Ethnicity.UNKNOWN_ETHNICITY]: true,
     },
-    Asian: {
-      "Hispanic or Latino": false,
-      "Not Hispanic or Latino": false,
-      "Unknown Ethnicity": true,
+    [Race.ASIAN]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: false,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: false,
+      [Ethnicity.UNKNOWN_ETHNICITY]: true,
     },
-    Black: {
-      "Hispanic or Latino": false,
-      "Not Hispanic or Latino": false,
-      "Unknown Ethnicity": true,
+    [Race.BLACK]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: false,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: false,
+      [Ethnicity.UNKNOWN_ETHNICITY]: true,
     },
-    "More than one race": {
-      "Hispanic or Latino": false,
-      "Not Hispanic or Latino": false,
-      "Unknown Ethnicity": true,
+    [Race.MORE_THAN_ONE_RACE]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: false,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: false,
+      [Ethnicity.UNKNOWN_ETHNICITY]: true,
     },
-    "Native Hawaiian or Pacific Islander": {
-      "Hispanic or Latino": false,
-      "Not Hispanic or Latino": false,
-      "Unknown Ethnicity": true,
+    [Race.NATIVE_HAWAIIAN_OR_PACIFIC_ISLANDER]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: false,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: false,
+      [Ethnicity.UNKNOWN_ETHNICITY]: true,
     },
-    White: {
-      "Hispanic or Latino": false,
-      "Not Hispanic or Latino": false,
-      "Unknown Ethnicity": true,
+    [Race.WHITE]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: false,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: false,
+      [Ethnicity.UNKNOWN_ETHNICITY]: true,
     },
-    Other: {
-      "Hispanic or Latino": false,
-      "Not Hispanic or Latino": false,
-      "Unknown Ethnicity": true,
+    [Race.OTHER]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: false,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: false,
+      [Ethnicity.UNKNOWN_ETHNICITY]: true,
     },
-    Unknown: {
-      "Hispanic or Latino": false,
-      "Not Hispanic or Latino": false,
-      "Unknown Ethnicity": true,
+    [Race.UNKNOWN]: {
+      [Ethnicity.HISPANIC_OR_LATINO]: false,
+      [Ethnicity.NOT_HISPANIC_OR_LATINO]: false,
+      [Ethnicity.UNKNOWN_ETHNICITY]: true,
     },
   },
 };

--- a/publisher/src/components/MetricConfiguration/types.ts
+++ b/publisher/src/components/MetricConfiguration/types.ts
@@ -61,10 +61,10 @@ export type UpdatedDisaggregation = {
 };
 
 export const races = [
-  "American Indian / Alaskan Native",
+  "American Indian or Alaskan Native",
   "Asian",
   "Black",
-  "Native Hawaiian / Pacific Islander",
+  "Native Hawaiian or Pacific Islander",
   "White",
   "More than one race",
   "Other",
@@ -73,8 +73,8 @@ export const races = [
 export type Races = typeof races[number];
 
 export const ethnicities = [
-  "Hispanic",
-  "Not Hispanic",
+  "Hispanic or Latino",
+  "Not Hispanic or Latino",
   "Unknown Ethnicity",
 ] as const;
 export type Ethnicities = typeof ethnicities[number];

--- a/publisher/src/components/MetricConfiguration/types.ts
+++ b/publisher/src/components/MetricConfiguration/types.ts
@@ -60,23 +60,27 @@ export type UpdatedDisaggregation = {
   }[];
 };
 
-export const races = [
-  "American Indian or Alaskan Native",
-  "Asian",
-  "Black",
-  "Native Hawaiian or Pacific Islander",
-  "White",
-  "More than one race",
-  "Other",
-  "Unknown",
-] as const;
+export const Race = {
+  AMERICAN_INDIAN_OR_ALASKAN_NATIVE: "American Indian or Alaskan Native",
+  ASIAN: "Asian",
+  BLACK: "Black",
+  NATIVE_HAWAIIAN_OR_PACIFIC_ISLANDER: "Native Hawaiian or Pacific Islander",
+  WHITE: "White",
+  MORE_THAN_ONE_RACE: "More than one race",
+  OTHER: "Other",
+  UNKNOWN: "Unknown",
+};
+
+export const Ethnicity = {
+  HISPANIC_OR_LATINO: "Hispanic or Latino",
+  NOT_HISPANIC_OR_LATINO: "Not Hispanic or Latino",
+  UNKNOWN_ETHNICITY: "Unknown Ethnicity",
+};
+
+export const races = [...Object.values(Race)] as const;
 export type Races = typeof races[number];
 
-export const ethnicities = [
-  "Hispanic or Latino",
-  "Not Hispanic or Latino",
-  "Unknown Ethnicity",
-] as const;
+export const ethnicities = [...Object.values(Ethnicity)] as const;
 export type Ethnicities = typeof ethnicities[number];
 
 export enum ChartView {

--- a/publisher/src/components/MetricConfiguration/types.ts
+++ b/publisher/src/components/MetricConfiguration/types.ts
@@ -22,6 +22,8 @@ import {
   ReportFrequency,
 } from "@justice-counts/common/types";
 
+import { Ethnicity, Race } from ".";
+
 export type MetricSettings = {
   key: string;
   enabled?: boolean;
@@ -58,23 +60,6 @@ export type UpdatedDisaggregation = {
     key: string;
     dimensions: UpdatedDimension[];
   }[];
-};
-
-export const Race = {
-  AMERICAN_INDIAN_OR_ALASKAN_NATIVE: "American Indian or Alaskan Native",
-  ASIAN: "Asian",
-  BLACK: "Black",
-  NATIVE_HAWAIIAN_OR_PACIFIC_ISLANDER: "Native Hawaiian or Pacific Islander",
-  WHITE: "White",
-  MORE_THAN_ONE_RACE: "More than one race",
-  OTHER: "Other",
-  UNKNOWN: "Unknown",
-};
-
-export const Ethnicity = {
-  HISPANIC_OR_LATINO: "Hispanic or Latino",
-  NOT_HISPANIC_OR_LATINO: "Not Hispanic or Latino",
-  UNKNOWN_ETHNICITY: "Unknown Ethnicity",
 };
 
 export const races = [...Object.values(Race)] as const;

--- a/publisher/src/components/Reports/PublishConfirmation.tsx
+++ b/publisher/src/components/Reports/PublishConfirmation.tsx
@@ -76,11 +76,11 @@ const RaceEthnicitiesGroupedByEthnicity: React.FC<{
   const dimensionsGroupedByEthnicity =
     dimensions.reduce(
       (acc, dimension) => {
-        if (dimension.ethnicity === "Hispanic") {
-          acc.Hispanic.push(dimension);
+        if (dimension.ethnicity === "Hispanic or Latino") {
+          acc["Hispanic or Latino"].push(dimension);
         }
-        if (dimension.ethnicity === "Not Hispanic") {
-          acc["Not Hispanic"].push(dimension);
+        if (dimension.ethnicity === "Not Hispanic or Latino") {
+          acc["Not Hispanic or Latino"].push(dimension);
         }
         if (dimension.ethnicity === "Unknown Ethnicity") {
           acc["Unknown Ethnicity"].push(dimension);
@@ -88,8 +88,8 @@ const RaceEthnicitiesGroupedByEthnicity: React.FC<{
         return acc;
       },
       {
-        Hispanic: [],
-        "Not Hispanic": [],
+        "Hispanic or Latino": [],
+        "Not Hispanic or Latino": [],
         "Unknown Ethnicity": [],
       } as { [key: string]: MetricDisaggregationDimensionsWithErrors[] }
     ) || {};
@@ -103,7 +103,7 @@ const RaceEthnicitiesGroupedByEthnicity: React.FC<{
         ([ethnicity, groupedDimensions]) => (
           <>
             <MetricSubTitleContainer secondary>
-              {ethnicity === "Hispanic" ? "Hispanic or Latino" : ethnicity}
+              {ethnicity}
             </MetricSubTitleContainer>
             <DisaggregationBreakdownContainer>
               {groupedDimensions.map((dimension) => (

--- a/publisher/src/components/Reports/PublishConfirmation.tsx
+++ b/publisher/src/components/Reports/PublishConfirmation.tsx
@@ -38,7 +38,10 @@ import {
   REPORTS_LOWERCASE,
 } from "../Global/constants";
 import { Logo, LogoContainer } from "../Header";
-import { RACE_ETHNICITY_DISAGGREGATION_KEY } from "../MetricConfiguration";
+import {
+  Ethnicity,
+  RACE_ETHNICITY_DISAGGREGATION_KEY,
+} from "../MetricConfiguration";
 import { Heading, Subheading } from "../ReviewMetrics/ReviewMetrics.styles";
 import { useCheckMetricForErrors } from "./hooks";
 import {
@@ -76,21 +79,21 @@ const RaceEthnicitiesGroupedByEthnicity: React.FC<{
   const dimensionsGroupedByEthnicity =
     dimensions.reduce(
       (acc, dimension) => {
-        if (dimension.ethnicity === "Hispanic or Latino") {
-          acc["Hispanic or Latino"].push(dimension);
+        if (dimension.ethnicity === Ethnicity.HISPANIC_OR_LATINO) {
+          acc[Ethnicity.HISPANIC_OR_LATINO].push(dimension);
         }
-        if (dimension.ethnicity === "Not Hispanic or Latino") {
-          acc["Not Hispanic or Latino"].push(dimension);
+        if (dimension.ethnicity === Ethnicity.NOT_HISPANIC_OR_LATINO) {
+          acc[Ethnicity.NOT_HISPANIC_OR_LATINO].push(dimension);
         }
-        if (dimension.ethnicity === "Unknown Ethnicity") {
-          acc["Unknown Ethnicity"].push(dimension);
+        if (dimension.ethnicity === Ethnicity.UNKNOWN_ETHNICITY) {
+          acc[Ethnicity.UNKNOWN_ETHNICITY].push(dimension);
         }
         return acc;
       },
       {
-        "Hispanic or Latino": [],
-        "Not Hispanic or Latino": [],
-        "Unknown Ethnicity": [],
+        [Ethnicity.HISPANIC_OR_LATINO]: [],
+        [Ethnicity.NOT_HISPANIC_OR_LATINO]: [],
+        [Ethnicity.UNKNOWN_ETHNICITY]: [],
       } as { [key: string]: MetricDisaggregationDimensionsWithErrors[] }
     ) || {};
   const dimensionsGroupedByEthnicityEntries = Object.entries(

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -32,6 +32,7 @@ import { makeAutoObservable, runInAction } from "mobx";
 import {
   Ethnicities,
   ethnicities,
+  Ethnicity,
   MetricInfo,
   MetricSettings,
   RACE_ETHNICITY_DISAGGREGATION_KEY,
@@ -903,8 +904,9 @@ class MetricConfigStore {
      * re-enable the Unknown Race dimensions for the NO_ETHNICITY_HISPANIC_AS_RACE state.
      */
     if (unknownRaceDisabled && state === "NO_ETHNICITY_HISPANIC_AS_RACE") {
-      ethnicitiesByRace.Unknown["Hispanic or Latino"].enabled = true;
-      ethnicitiesByRace.Unknown["Not Hispanic or Latino"].enabled = true;
+      ethnicitiesByRace.Unknown[Ethnicity.HISPANIC_OR_LATINO].enabled = true;
+      ethnicitiesByRace.Unknown[Ethnicity.NOT_HISPANIC_OR_LATINO].enabled =
+        true;
       sanitizedState = state;
     }
     /** Update dimensions to match the specified default grid state */

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -884,6 +884,7 @@ class MetricConfigStore {
     metricKey: string
   ): UpdatedDisaggregation => {
     const ethnicitiesByRace = this.getEthnicitiesByRace(system, metricKey);
+
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -902,11 +903,10 @@ class MetricConfigStore {
      * re-enable the Unknown Race dimensions for the NO_ETHNICITY_HISPANIC_AS_RACE state.
      */
     if (unknownRaceDisabled && state === "NO_ETHNICITY_HISPANIC_AS_RACE") {
-      ethnicitiesByRace.Unknown.Hispanic.enabled = true;
-      ethnicitiesByRace.Unknown["Not Hispanic"].enabled = true;
+      ethnicitiesByRace.Unknown["Hispanic or Latino"].enabled = true;
+      ethnicitiesByRace.Unknown["Not Hispanic or Latino"].enabled = true;
       sanitizedState = state;
     }
-
     /** Update dimensions to match the specified default grid state */
     Object.keys(ethnicitiesByRace).forEach((race) => {
       const raceIsEnabled = Boolean(


### PR DESCRIPTION
## Description of the change

Bug: Race/Ethnicities breakdowns do not update and intermittently crash when trying to access an invalid race/ethnicity.

Fix: Update the names for races & ethnicities to conform to what the backend sends.
* "Hispanic" is now "Hispanic or Latino"
* "Not Hispanic" is now "Not Hispanic or Latino"
* "American Indian / Alaskan Native" is now "American Indian or Alaska Native" 
  * curious - should it be **Alaska** Native or **Alaskan** Native?
* "Native Hawaiian / Pacific Islander" is now "Native Hawaiian or Pacific Islander"

## Related issues

Closes #467

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
