### PR TITLE
Guidance: Playtesting II Followups - Metric Configuration Toast Checklist

### DIFF
--- a/publisher/src/components/Guidance/Guidance.tsx
+++ b/publisher/src/components/Guidance/Guidance.tsx
@@ -59,6 +59,7 @@ import {
   ProgressItemName,
   ProgressItemWrapper,
   ProgressStepBubble,
+  ProgressSteps,
   ProgressStepsContainer,
   ProgressTooltipContainer,
   ReportsOverviewContainer,
@@ -403,21 +404,50 @@ export const Guidance = observer(() => {
                                   {/* Progress Tooltip */}
                                   <ProgressTooltipContainer>
                                     {metricConfigurationProgressSteps.map(
-                                      (step) => (
-                                        <ProgressItemWrapper key={step}>
-                                          <CheckIconWrapper>
-                                            {metricCompletionProgress[step] && (
-                                              <CheckIcon
-                                                src={checkmarkIcon}
-                                                alt=""
-                                              />
-                                            )}
-                                          </CheckIconWrapper>
-                                          <ProgressItemName>
-                                            {step}
-                                          </ProgressItemName>
-                                        </ProgressItemWrapper>
-                                      )
+                                      (step) => {
+                                        // When all disaggregations are disabled, the "Confirm breakdown definitions" are no longer required.
+                                        if (
+                                          step ===
+                                          ProgressSteps.CONFIRM_BREAKDOWN_DEFINITIONS
+                                        ) {
+                                          const allDisaggregationsDisabled =
+                                            metricConfigStore.disaggregations[
+                                              systemMetricKey
+                                            ] &&
+                                            Object.values(
+                                              metricConfigStore.disaggregations[
+                                                systemMetricKey
+                                              ]
+                                            ).filter(
+                                              (disaggregation) =>
+                                                disaggregation.enabled ===
+                                                  true ||
+                                                disaggregation.enabled === null
+                                            ).length === 0;
+                                          if (allDisaggregationsDisabled) {
+                                            return null;
+                                          }
+                                        }
+
+                                        return (
+                                          <ProgressItemWrapper key={step}>
+                                            <CheckIconWrapper>
+                                              {metricCompletionProgress &&
+                                                metricCompletionProgress[
+                                                  step
+                                                ] && (
+                                                  <CheckIcon
+                                                    src={checkmarkIcon}
+                                                    alt=""
+                                                  />
+                                                )}
+                                            </CheckIconWrapper>
+                                            <ProgressItemName>
+                                              {step}
+                                            </ProgressItemName>
+                                          </ProgressItemWrapper>
+                                        );
+                                      }
                                     )}
                                   </ProgressTooltipContainer>
                                 </Metric>


### PR DESCRIPTION
## Description of the change

Adjusts the rendering of the toast checklist when:
* a metric is disabled
  * when a metric is disabled, no other steps are required
  * this removes the other 3 required checklist items and only leaves the "Confirm metric availability" in the toast checklist

* all breakdowns are disabled
  * when a breakdown is disabled, setting its definitions is no longer a required step
  * this removes the "Confirm breakdown definitions" from the toast checklist

Demo:

https://user-images.githubusercontent.com/59492998/223276638-7d6e18c3-aba3-4526-a704-81af999a3231.mov



## Related issues

Closes #472 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
