### PR TITLE
[Bug] Supervision agency with no subsystems still shows disaggregation/combined options

### DIFF
--- a/publisher/src/components/MetricConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricConfiguration/Configuration.tsx
@@ -145,6 +145,8 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
         }
         return system.charAt(0).toUpperCase() + system.slice(1);
       }) || [];
+    const hasEnabledSupervisionSubsystems =
+      enabledSupervisionSubsystems && enabledSupervisionSubsystems?.length > 0;
 
     useEffect(
       () => {
@@ -358,6 +360,7 @@ export const Configuration: React.FC<MetricConfigurationProps> = observer(
 
           {/* Supervision Subsystem Disaggregation Selection (Supervision Systems ONLY) */}
           {systemSearchParam &&
+            hasEnabledSupervisionSubsystems &&
             (systemSearchParam === SupervisionSystem ||
               SupervisionSubsystems.includes(systemSearchParam)) && (
               <PromptWrapper>


### PR DESCRIPTION
## Description of the change

Removes Supervision subsystem disaggregation selection from Supervision agencies that do not have subsystems.

Demo:

First example is a Supervision agency with no subsystems, the second is a Supervision agency with Parole & Probation subsystems.

https://user-images.githubusercontent.com/59492998/223559598-df94bdbb-d253-4089-a750-dcdba0d13912.mov

## Related issues

Closes #482

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
