### PR TITLE
Metric Configuration Overview: show "Annually" instead of "Annual

### DIFF
--- a/publisher/src/components/MetricConfiguration/MetricBox.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricBox.tsx
@@ -55,7 +55,7 @@ export const MetricBox: React.FC<MetricBoxProps> = observer(
     const displayFrequency = customFrequency
       ? customFrequency.toLowerCase()
       : frequency.toLowerCase();
-    console.log("displayFrequency", displayFrequency);
+
     return (
       <MetricBoxContainer onClick={handleMetricBoxClick} enabled={enabled}>
         <MetricName>{displayName}</MetricName>

--- a/publisher/src/components/MetricConfiguration/MetricBox.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricBox.tsx
@@ -55,6 +55,7 @@ export const MetricBox: React.FC<MetricBoxProps> = observer(
     const displayFrequency = customFrequency
       ? customFrequency.toLowerCase()
       : frequency.toLowerCase();
+    console.log("displayFrequency", displayFrequency);
     return (
       <MetricBoxContainer onClick={handleMetricBoxClick} enabled={enabled}>
         <MetricName>{displayName}</MetricName>
@@ -65,7 +66,12 @@ export const MetricBox: React.FC<MetricBoxProps> = observer(
             disabled={!enabled}
             noMargin
           >
-            {!enabled ? "Inactive" : displayFrequency}
+            {!enabled && "Inactive"}
+            {enabled && (
+              <>
+                {displayFrequency === "annual" ? "Annually" : displayFrequency}
+              </>
+            )}
           </Badge>
         </MetricNameBadgeWrapper>
       </MetricBoxContainer>


### PR DESCRIPTION
## Description of the change

Updates Metric Config overview metric boxes to show "Annually" instead of "Annual".

Before:
![image](https://user-images.githubusercontent.com/59492998/223777163-9a8e775e-68aa-41e0-bfa4-c7685902213e.png)

After
<img width="1439" alt="Screenshot 2023-03-08 at 10 52 20 AM" src="https://user-images.githubusercontent.com/59492998/223777295-99a56910-ac7a-43c1-8653-968d751be1dc.png">


## Related issues

Contributes to #296 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
