### PR TITLE
Update sorting logic for DataViz legend

### DIFF
--- a/common/components/DataViz/utils.ts
+++ b/common/components/DataViz/utils.ts
@@ -77,16 +77,16 @@ export const getDatapointDimensions = (datapoint: Datapoint) =>
 
 export const sortDatapointDimensions = (dimA: string, dimB: string) => {
   // sort alphabetically, except put "Other" and "Unknown" at the end.
-  if (dimA === "Other" && dimB === "Unknown") {
+  if (dimA.includes("Other") && dimB.includes("Unknown")) {
     return -1;
   }
-  if (dimB === "Other" && dimA === "Unknown") {
+  if (dimB.includes("Other") && dimA.includes("Unknown")) {
     return 1;
   }
-  if (dimA === "Other" || dimA === "Unknown") {
+  if (dimA.includes("Other") || dimA.includes("Unknown")) {
     return 1;
   }
-  if (dimB === "Other" || dimB === "Unknown") {
+  if (dimB.includes("Other") || dimB.includes("Unknown")) {
     return -1;
   }
   return dimA.localeCompare(dimB);


### PR DESCRIPTION
## Description of the change

Updates sorting logic for DataViz legend. Previously, we had "Unknown" and "Other" dimensions - solely. Now, the "Unknown" and "Other" dimensions are more specific (e.g. "Other Funding", "Unknown Staff", etc.) and that requires us to update the sorting logic to not strictly check equality of the strings "Unknown"/"Other" but whether or not those words are included in the string.

## Related issues

Closes #491

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
