### PR TITLE
Guidance: Gate feature for non-JC Admins

### DIFF
--- a/publisher/src/stores/GuidanceStore.ts
+++ b/publisher/src/stores/GuidanceStore.ts
@@ -117,7 +117,7 @@ class GuidanceStore {
            * If you are not a JC Admin, your guidance progress is marked as completed for all topics.
            * If you are a JC Admin, your guidance progress is based on your actual guidance progress from the DB.
            *
-           * TODO(#) ungate guidance flow for all users
+           * TODO(#496) ungate guidance flow for all users
            */
           acc[topic.topicID] = !this.userStore.isJusticeCountsAdmin(agencyId)
             ? true

--- a/publisher/src/stores/GuidanceStore.ts
+++ b/publisher/src/stores/GuidanceStore.ts
@@ -111,7 +111,17 @@ class GuidanceStore {
     runInAction(() => {
       this.onboardingTopicsStatuses =
         onboardingTopicsStatuses.guidance_progress.reduce((acc, topic) => {
-          acc[topic.topicID] = topic.topicCompleted;
+          /**
+           * NOTE:
+           * This gates the guidance flow for users who are not JC Admins.
+           * If you are not a JC Admin, your guidance progress is marked as completed for all topics.
+           * If you are a JC Admin, your guidance progress is based on your actual guidance progress from the DB.
+           *
+           * TODO(#) ungate guidance flow for all users
+           */
+          acc[topic.topicID] = !this.userStore.isJusticeCountsAdmin(agencyId)
+            ? true
+            : topic.topicCompleted;
           return acc;
         }, {} as { [topicID: string]: boolean });
       this.isInitialized = true;


### PR DESCRIPTION
## Description of the change

Gates the guidance feature for all users who are **not** Justice Counts Admins. This is accomplished by setting all non-JC Admin's guidance progress to completed for all topics. JC Admins will have their guidance progress read from the DB as usual.

## Related issues

Contributes to #495

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
