### PR TITLE
Guidance: adjust the step-completion logic for ADD DATA step

### DIFF
--- a/publisher/src/components/Guidance/Guidance.tsx
+++ b/publisher/src/components/Guidance/Guidance.tsx
@@ -182,16 +182,19 @@ export const Guidance = observer(() => {
       reportStore.resetState();
       await reportStore.getReportOverviews(agencyId);
 
-      const hasMinimumOneReport =
+      const hasMinimumOneReportStarted =
         currentTopicID === "ADD_DATA" &&
-        Object.keys(reportStore.reportOverviews).length > 0;
+        Object.values(reportStore.reportOverviews).find(
+          (report) => report.status !== "NOT_STARTED"
+        );
+
       const hasMinimumOnePublishedReport =
         currentTopicID === "PUBLISH_DATA" &&
         Object.values(reportStore.reportOverviews).find(
           (report) => report.status === "PUBLISHED"
         );
 
-      if (hasMinimumOneReport) {
+      if (hasMinimumOneReportStarted) {
         saveOnboardingTopicsStatuses(
           {
             topicID: "ADD_DATA",


### PR DESCRIPTION
## Description of the change

Adjusts the completion logic for the ADD DATA step to only mark it complete if there is at least one draft report. Users who only have reports in `NOT STARTED` status will not have completed this step unless they input data in one of the reports (or explicitly save a report as draft).

Demo:

https://user-images.githubusercontent.com/59492998/225458167-353c8f55-6dd0-40c9-9506-83956fef0b1b.mov

(I created a report in this one - but this also works when there's already a report/s in the user's account in NOT STARTED status)

## Related issues

Closes #503

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
