### PR TITLE
[Bulk Upload] Adjust title / definition of a successfully saved metric 

### DIFF
--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -161,8 +161,7 @@ export const DataUpload: React.FC = observer(() => {
   ): ErrorsWarningsMetrics => {
     const errorsWarningsAndSuccessfulMetrics = data.metrics.reduce(
       (acc, metric) => {
-        const isSuccessfulMetric = metric.datapoints.length > 0;
-        // console.log(isSuccessfulMetric);
+        const isSuccessfulMetric = metric.successful_ingest;
 
         /**
          * If there are no errors and only warnings, we still want to show the

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -161,7 +161,13 @@ export const DataUpload: React.FC = observer(() => {
   ): ErrorsWarningsMetrics => {
     const errorsWarningsAndSuccessfulMetrics = data.metrics.reduce(
       (acc, metric) => {
-        const isSuccessfulMetric = metric.successful_ingest;
+        const noSheetErrorsFound =
+          metric.metric_errors.filter(
+            (sheet) =>
+              sheet.messages.filter((msg) => msg.type === "ERROR")?.length > 0
+          ).length === 0;
+        const isSuccessfulMetric =
+          noSheetErrorsFound && metric.datapoints.length > 0;
 
         /**
          * If there are no errors and only warnings, we still want to show the

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -161,13 +161,6 @@ export const DataUpload: React.FC = observer(() => {
   ): ErrorsWarningsMetrics => {
     const errorsWarningsAndSuccessfulMetrics = data.metrics.reduce(
       (acc, metric) => {
-        // const noSheetErrorsFound =
-        //   metric.metric_errors.filter(
-        //     (sheet) =>
-        //       sheet.messages.filter((msg) => msg.type === "ERROR")?.length > 0
-        //   ).length === 0;
-        // const isSuccessfulMetric =
-        //   metric.metric_errors.length === 0 || noSheetErrorsFound;
         const isSuccessfulMetric = metric.datapoints.length > 0;
         // console.log(isSuccessfulMetric);
 

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -25,11 +25,6 @@ import { observer } from "mobx-react-lite";
 import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { useStore } from "../../stores";
-import logoImg from "../assets/jc-logo-vector-new.svg";
-import { REPORTS_LOWERCASE } from "../Global/constants";
-import { Logo, LogoContainer } from "../Header";
-import { Loader } from "../Loading";
 import {
   Button,
   DataUploadContainer,
@@ -40,6 +35,11 @@ import {
   SystemSelection,
   UploadFile,
 } from ".";
+import { useStore } from "../../stores";
+import logoImg from "../assets/jc-logo-vector-new.svg";
+import { REPORTS_LOWERCASE } from "../Global/constants";
+import { Logo, LogoContainer } from "../Header";
+import { Loader } from "../Loading";
 import {
   DataUploadResponseBody,
   ErrorsWarningsMetrics,
@@ -161,13 +161,15 @@ export const DataUpload: React.FC = observer(() => {
   ): ErrorsWarningsMetrics => {
     const errorsWarningsAndSuccessfulMetrics = data.metrics.reduce(
       (acc, metric) => {
-        const noSheetErrorsFound =
-          metric.metric_errors.filter(
-            (sheet) =>
-              sheet.messages.filter((msg) => msg.type === "ERROR")?.length > 0
-          ).length === 0;
-        const isSuccessfulMetric =
-          metric.metric_errors.length === 0 || noSheetErrorsFound;
+        // const noSheetErrorsFound =
+        //   metric.metric_errors.filter(
+        //     (sheet) =>
+        //       sheet.messages.filter((msg) => msg.type === "ERROR")?.length > 0
+        //   ).length === 0;
+        // const isSuccessfulMetric =
+        //   metric.metric_errors.length === 0 || noSheetErrorsFound;
+        const isSuccessfulMetric = metric.datapoints.length > 0;
+        // console.log(isSuccessfulMetric);
 
         /**
          * If there are no errors and only warnings, we still want to show the

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -25,6 +25,11 @@ import { observer } from "mobx-react-lite";
 import React, { useEffect, useMemo, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
+import { useStore } from "../../stores";
+import logoImg from "../assets/jc-logo-vector-new.svg";
+import { REPORTS_LOWERCASE } from "../Global/constants";
+import { Logo, LogoContainer } from "../Header";
+import { Loader } from "../Loading";
 import {
   Button,
   DataUploadContainer,
@@ -35,11 +40,6 @@ import {
   SystemSelection,
   UploadFile,
 } from ".";
-import { useStore } from "../../stores";
-import logoImg from "../assets/jc-logo-vector-new.svg";
-import { REPORTS_LOWERCASE } from "../Global/constants";
-import { Logo, LogoContainer } from "../Header";
-import { Loader } from "../Loading";
 import {
   DataUploadResponseBody,
   ErrorsWarningsMetrics,

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -221,7 +221,7 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
           </>
         )}
 
-        {/* Case 2: More than 1 metric was saved */}
+        {/* Case 2: 1 or more metrics were saved */}
         {successfulMetricsCount > 0 && (
           <>
             <BlueText>{successfulMetricsCount}</BlueText> metric

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -20,11 +20,6 @@ import { AgencySystems } from "@justice-counts/common/types";
 import React, { Fragment } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { useStore } from "../../stores";
-import { formatSystemName } from "../../utils";
-import { ReactComponent as ErrorIcon } from "../assets/error-icon.svg";
-import { ReactComponent as WarningIcon } from "../assets/warning-icon.svg";
-import { SYSTEM_LOWERCASE } from "../Global/constants";
 import {
   BlueText,
   Button,
@@ -46,6 +41,11 @@ import {
   Title,
   Wrapper,
 } from ".";
+import { useStore } from "../../stores";
+import { formatSystemName } from "../../utils";
+import { ReactComponent as ErrorIcon } from "../assets/error-icon.svg";
+import { ReactComponent as WarningIcon } from "../assets/warning-icon.svg";
+import { SYSTEM_LOWERCASE } from "../Global/constants";
 import {
   ErrorsWarningsMetrics,
   ErrorWarningMessage,
@@ -211,22 +211,22 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
   const renderErrorWarningTitle = () => {
     return (
       <>
-        {/* Case 1: Only Warnings (which means all metrics were successfully ingested) */}
-        {errorCount === 0 && successfulMetricsCount > 0 && (
-          <>
-            <BlueText>{successfulMetricsCount}</BlueText> metric
-            {successfulMetricsCount === 0 || successfulMetricsCount > 1
-              ? "s"
-              : ""}{" "}
-            were saved successfully
-            {errorsWarningsAndSuccessfulMetrics.hasWarnings &&
-              " (with warnings)"}
-            .
-          </>
-        )}
+        {/* Section 1: Show number of metrics successfully ingested */}
+        {/* {errorCount === 0 && successfulMetricsCount > 0 && ( */}
+        <>
+          <BlueText>{successfulMetricsCount}</BlueText> metric
+          {successfulMetricsCount === 0 || successfulMetricsCount > 1
+            ? "s"
+            : ""}{" "}
+          were saved successfully
+          {errorsWarningsAndSuccessfulMetrics.hasWarnings && " (with warnings)"}
+          .
+        </>
+        {/* )} */}
 
-        {/* Case 2: Has Errors Only */}
-        {errorCount > 0 && successfulMetricsCount === 0 && (
+        {/* Section 2: Show number of metrics with errors */}
+        {/* {errorCount > 0 && successfulMetricsCount === 0 && ( */}
+        {errorCount > 0 && (
           <>
             We encountered <RedText>{errorCount}</RedText> error
             {errorCount > 1 ? "s" : ""}.
@@ -234,7 +234,7 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
         )}
 
         {/* Case 3: Has Errors and Successes */}
-        {errorCount > 0 && successfulMetricsCount > 0 && (
+        {/* {errorCount > 0 && successfulMetricsCount > 0 && (
           <>
             We encountered <RedText>{errorCount}</RedText> error
             {errorCount > 1 ? "s" : ""}, and{" "}
@@ -247,7 +247,7 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
               " (with warnings)"}
             .
           </>
-        )}
+        )} */}
       </>
     );
   };

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -212,15 +212,26 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
     return (
       <>
         {/* Section 1: Show number of metrics successfully ingested */}
-        <>
-          <BlueText>{successfulMetricsCount}</BlueText> metric
-          {successfulMetricsCount === 0 || successfulMetricsCount > 1
-            ? "s"
-            : ""}{" "}
-          were saved successfully
-          {errorsWarningsAndSuccessfulMetrics.hasWarnings && " (with warnings)"}
-          .
-        </>
+        {/* Case 1: 0 metrics was saved */}
+        {successfulMetricsCount === 0 && (
+          <>
+            <BlueText>{successfulMetricsCount}</BlueText> metrics were saved
+            successfully.
+            <br />
+          </>
+        )}
+
+        {/* Case 2: More than 1 metric was saved */}
+        {successfulMetricsCount > 0 && (
+          <>
+            <BlueText>{successfulMetricsCount}</BlueText> metric
+            {successfulMetricsCount === 1 ? " was" : "s were"} saved
+            successfully
+            {errorsWarningsAndSuccessfulMetrics.hasWarnings &&
+              " (with warnings)"}
+            .<br />
+          </>
+        )}
 
         {/* Section 2: Show number of metrics with errors */}
         {errorCount > 0 && (

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -20,6 +20,11 @@ import { AgencySystems } from "@justice-counts/common/types";
 import React, { Fragment } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
+import { useStore } from "../../stores";
+import { formatSystemName } from "../../utils";
+import { ReactComponent as ErrorIcon } from "../assets/error-icon.svg";
+import { ReactComponent as WarningIcon } from "../assets/warning-icon.svg";
+import { SYSTEM_LOWERCASE } from "../Global/constants";
 import {
   BlueText,
   Button,
@@ -41,11 +46,6 @@ import {
   Title,
   Wrapper,
 } from ".";
-import { useStore } from "../../stores";
-import { formatSystemName } from "../../utils";
-import { ReactComponent as ErrorIcon } from "../assets/error-icon.svg";
-import { ReactComponent as WarningIcon } from "../assets/warning-icon.svg";
-import { SYSTEM_LOWERCASE } from "../Global/constants";
 import {
   ErrorsWarningsMetrics,
   ErrorWarningMessage,

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -212,7 +212,6 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
     return (
       <>
         {/* Section 1: Show number of metrics successfully ingested */}
-        {/* {errorCount === 0 && successfulMetricsCount > 0 && ( */}
         <>
           <BlueText>{successfulMetricsCount}</BlueText> metric
           {successfulMetricsCount === 0 || successfulMetricsCount > 1
@@ -222,32 +221,14 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
           {errorsWarningsAndSuccessfulMetrics.hasWarnings && " (with warnings)"}
           .
         </>
-        {/* )} */}
 
         {/* Section 2: Show number of metrics with errors */}
-        {/* {errorCount > 0 && successfulMetricsCount === 0 && ( */}
         {errorCount > 0 && (
           <>
             We encountered <RedText>{errorCount}</RedText> error
             {errorCount > 1 ? "s" : ""}.
           </>
         )}
-
-        {/* Case 3: Has Errors and Successes */}
-        {/* {errorCount > 0 && successfulMetricsCount > 0 && (
-          <>
-            We encountered <RedText>{errorCount}</RedText> error
-            {errorCount > 1 ? "s" : ""}, and{" "}
-            <BlueText>{successfulMetricsCount}</BlueText> metric
-            {successfulMetricsCount === 0 || successfulMetricsCount > 1
-              ? "s"
-              : ""}{" "}
-            were saved successfully
-            {errorsWarningsAndSuccessfulMetrics.hasWarnings &&
-              " (with warnings)"}
-            .
-          </>
-        )} */}
       </>
     );
   };

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -212,11 +212,10 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
     return (
       <>
         {/* Section 1: Show number of metrics successfully ingested */}
-        {/* Case 1: 0 metrics was saved */}
+        {/* Case 1: 0 metrics were saved */}
         {successfulMetricsCount === 0 && (
           <>
-            <BlueText>{successfulMetricsCount}</BlueText> metrics were saved
-            successfully.
+            No metrics were saved successfully.
             <br />
           </>
         )}

--- a/publisher/src/components/DataUpload/types.ts
+++ b/publisher/src/components/DataUpload/types.ts
@@ -27,6 +27,7 @@ export interface UploadedMetric {
   display_name: string;
   key: string;
   metric_errors: MetricErrors[];
+  successful_ingest: boolean;
 }
 
 export type ErrorWarningMessage = {

--- a/publisher/src/components/DataUpload/types.ts
+++ b/publisher/src/components/DataUpload/types.ts
@@ -27,7 +27,6 @@ export interface UploadedMetric {
   display_name: string;
   key: string;
   metric_errors: MetricErrors[];
-  successful_ingest: boolean;
 }
 
 export type ErrorWarningMessage = {


### PR DESCRIPTION
## Description of the change

Previously, we considered metrics as being saved successfully via bulk upload if no errors were associated with those metrics. For example, the title below is shown when an empty template is uploaded (no data is saved).
![image](https://user-images.githubusercontent.com/82831800/226750237-e9edf404-7395-4cd4-a9a3-577e6be524f4.png)

We want to change this logic so that we consider metrics as being saved successfully via bulk upload if they are associated with datapoints in the database (if we actually persisted some data) and no errors were associated with those metrics.

Now, when an empty template is uploaded, the user sees the following:
<img width="763" alt="Screenshot 2023-03-23 at 10 50 06 AM" src="https://user-images.githubusercontent.com/82831800/227260107-50151a1d-02c0-4717-91f1-df66e901c416.png">
When 1 metric was uploaded:
<img width="784" alt="Screenshot 2023-03-22 at 11 51 09 AM" src="https://user-images.githubusercontent.com/82831800/226979413-95e29ad3-57ed-487a-bfa6-f5f0bcec84fc.png">
When 2 (or more) metrics were uploaded:
<img width="780" alt="Screenshot 2023-03-22 at 11 51 24 AM" src="https://user-images.githubusercontent.com/82831800/226979440-5646ace6-8083-40ab-8f30-abb7d901c05b.png">

## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Related to [#19584](https://github.com/Recidiviz/recidiviz-data/issues/19584)

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
