### PR TITLE
Remove permissions for agency dropdown menu

### DIFF
--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -295,40 +295,36 @@ const Menu: React.FC = () => {
           )}
 
         {/* Agencies Dropdown */}
-        {userStore.isJusticeCountsAdmin(agencyId) &&
-          userStore.userAgencies &&
-          userStore.userAgencies.length > 1 && (
-            <MenuItem>
-              <Dropdown>
-                <ExtendedDropdownToggle kind="borderless">
-                  Agencies
-                </ExtendedDropdownToggle>
-                <ExtendedDropdownMenu
-                  alignment={windowWidth > MIN_TABLET_WIDTH ? "right" : "left"}
-                >
-                  {userStore.userAgencies
-                    .slice()
-                    .sort((a, b) => a.name.localeCompare(b.name))
-                    .map((agency) => {
-                      return (
-                        <ExtendedDropdownMenuItem
-                          key={agency.id}
-                          onClick={() => {
-                            navigate(
-                              `/agency/${agency.id}/${pathWithoutAgency}`
-                            );
-                            handleCloseMobileMenu();
-                          }}
-                          highlight={agency.id === currentAgency?.id}
-                        >
-                          {agency.name}
-                        </ExtendedDropdownMenuItem>
-                      );
-                    })}
-                </ExtendedDropdownMenu>
-              </Dropdown>
-            </MenuItem>
-          )}
+        {userStore.userAgencies && userStore.userAgencies.length > 1 && (
+          <MenuItem>
+            <Dropdown>
+              <ExtendedDropdownToggle kind="borderless">
+                Agencies
+              </ExtendedDropdownToggle>
+              <ExtendedDropdownMenu
+                alignment={windowWidth > MIN_TABLET_WIDTH ? "right" : "left"}
+              >
+                {userStore.userAgencies
+                  .slice()
+                  .sort((a, b) => a.name.localeCompare(b.name))
+                  .map((agency) => {
+                    return (
+                      <ExtendedDropdownMenuItem
+                        key={agency.id}
+                        onClick={() => {
+                          navigate(`/agency/${agency.id}/${pathWithoutAgency}`);
+                          handleCloseMobileMenu();
+                        }}
+                        highlight={agency.id === currentAgency?.id}
+                      >
+                        {agency.name}
+                      </ExtendedDropdownMenuItem>
+                    );
+                  })}
+              </ExtendedDropdownMenu>
+            </Dropdown>
+          </MenuItem>
+        )}
 
         {/* Settings */}
         {(hasCompletedOnboarding ||


### PR DESCRIPTION
## Description of the change

Removes permissions for agency dropdown menu (this was originally in place per PR #414 and was unintentionally restricted again).

## Related issues

Closes #509 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
