### PR TITLE
Bulk Publishing: Replace calls to `datapointsStore.getDatapoints(agencyId)` w/ the updated `get_reports_by_id` endpoint

### DIFF
--- a/common/stores/BaseDatapointsStore.ts
+++ b/common/stores/BaseDatapointsStore.ts
@@ -114,7 +114,11 @@ abstract class DatapointsStore {
   }
 
   get rawDatapointsByMetric(): RawDatapointsByMetric {
-    return this.rawDatapoints.reduce((res: RawDatapointsByMetric, dp) => {
+    return DatapointsStore.keyRawDatapointsByMetric(this.rawDatapoints);
+  }
+
+  static keyRawDatapointsByMetric = (rawDatapoints: RawDatapoint[]) => {
+    return rawDatapoints.reduce((res: RawDatapointsByMetric, dp) => {
       if (!res[dp.metric_definition_key]) {
         res[dp.metric_definition_key] = [dp];
       } else {
@@ -123,7 +127,7 @@ abstract class DatapointsStore {
 
       return res;
     }, {});
-  }
+  };
 
   abstract getDatapoints(agencyId: number): Promise<void | Error>;
 

--- a/common/types.ts
+++ b/common/types.ts
@@ -118,6 +118,7 @@ export interface ReportOverview {
 
 export interface Report extends ReportOverview {
   metrics: Metric[];
+  datapoints: RawDatapoint[];
 }
 
 export type MetricWithErrors = Metric & {

--- a/publisher/src/components/Reports/DataEntryReview.tsx
+++ b/publisher/src/components/Reports/DataEntryReview.tsx
@@ -16,7 +16,12 @@
 // =============================================================================
 
 import { showToast } from "@justice-counts/common/components/Toast";
-import { MetricWithErrors } from "@justice-counts/common/types";
+import DatapointsStore from "@justice-counts/common/stores/BaseDatapointsStore";
+import {
+  MetricWithErrors,
+  RawDatapointsByMetric,
+  Report,
+} from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -45,8 +50,7 @@ const DataEntryReview = () => {
   const [isPublishable, setIsPublishable] = useState(false);
   const [metricsPreview, setMetricsPreview] = useState<MetricWithErrors[]>();
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
-  const { reportStore, formStore, userStore, guidanceStore, datapointsStore } =
-    useStore();
+  const { reportStore, formStore, userStore, guidanceStore } = useStore();
   const checkMetricForErrors = useCheckMetricForErrors(reportID);
 
   const publishReport = async () => {
@@ -86,10 +90,25 @@ const DataEntryReview = () => {
     }
   };
 
+  const [datapoints, setDatapoints] = useState<RawDatapointsByMetric>({});
+  const [loadingDatapoints, setLoadingDatapoints] = useState(true);
+
   useEffect(() => {
     const initialize = async () => {
       formStore.validatePreviouslySavedInputs(reportID);
-      await datapointsStore.getDatapoints(agencyId);
+      const [reportWithDatapoints] =
+        (await reportStore.getMultipleReportsWithDatapoints(
+          [reportID],
+          String(agencyId)
+        )) as Report[];
+
+      setDatapoints(
+        DatapointsStore.keyRawDatapointsByMetric(
+          reportWithDatapoints.datapoints
+        )
+      );
+
+      setLoadingDatapoints(false);
     };
 
     initialize();
@@ -109,24 +128,22 @@ const DataEntryReview = () => {
     document.body.style.overflow = isSuccessModalOpen ? "hidden" : "unset";
   }, [isSuccessModalOpen]);
 
-  if (datapointsStore.loading)
+  if (reportStore.reportOverviews[reportID].agency_id !== agencyId) {
+    return <NotFound />;
+  }
+
+  if (loadingDatapoints)
     return (
       <PageWrapper>
         <Loading />
       </PageWrapper>
     );
 
-  if (reportStore.reportOverviews[reportID].agency_id !== agencyId) {
-    return <NotFound />;
-  }
-
   // review component props
   const metrics = metricsPreview
     ? metricsPreview.reduce((acc, metric) => {
         const reviewMetric = {
-          datapoints: datapointsStore.rawDatapointsByMetric[metric.key].filter(
-            (dp) => dp.report_id === reportID
-          ),
+          datapoints: datapoints[metric.key],
           display_name: metric.display_name,
           key: metric.key,
           metricHasError: checkMetricForErrors(metric.key),

--- a/publisher/src/pages/Reports.tsx
+++ b/publisher/src/pages/Reports.tsx
@@ -177,6 +177,11 @@ const Reports: React.FC = () => {
 
   useEffect(() => {
     const initialize = async () => {
+      // const hi = await reportStore.getMultipleReportsWithDatapoints(
+      //   [2213],
+      //   agencyId
+      // );
+      // console.log("HI:: ", hi);
       reportStore.resetState();
       const result = await reportStore.getReportOverviews(agencyId);
       if (result instanceof Error) {

--- a/publisher/src/stores/ReportStore.ts
+++ b/publisher/src/stores/ReportStore.ts
@@ -160,10 +160,10 @@ class ReportStore {
     }
   }
 
-  async getMultipleReports(
+  async getMultipleReportsWithDatapoints(
     reportIDs: number[],
     currentAgencyId: string
-  ): Promise<void | Error> {
+  ): Promise<Report[] | Error | void> {
     try {
       const response = (await this.api.request({
         path: `/api/reports?agency_id=${parseInt(
@@ -180,9 +180,7 @@ class ReportStore {
 
       const reports = (await response.json()) as Report[];
 
-      reports.forEach((report) => {
-        this.storeMetricDetails(report.id, report.metrics);
-      });
+      return reports;
     } catch (error) {
       if (error instanceof Error) return new Error(error.message);
     } finally {


### PR DESCRIPTION
## Description of the change

Calling the `/datapoints` endpoint is too expensive for what we need to power the review pages. The updated `get_reports_by_id` should return a list of datapoints (instead of metrics) for each report provided to it. This way, we only get the relevant datapoints we need for the reports that have been selected by the user and not the entire set of datapoints.

## Related issues

Closes #529

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
