### PR TITLE
Allow JC Admins to access Records / Bulk Upload during Guidance

### DIFF
--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -253,7 +253,9 @@ const Menu: React.FC = () => {
         )}
 
         {/* Reports */}
-        {(hasCompletedOnboarding || isAddDataOrPublishDataStep) && (
+        {(userStore.isJusticeCountsAdmin(agencyId) ||
+          hasCompletedOnboarding ||
+          isAddDataOrPublishDataStep) && (
           <MenuItem
             onClick={() => {
               navigate(REPORTS_LOWERCASE);
@@ -370,12 +372,14 @@ const Menu: React.FC = () => {
           Log Out
         </MenuItem>
 
-        {(hasCompletedOnboarding ||
+        {(userStore.isJusticeCountsAdmin(agencyId) ||
+          hasCompletedOnboarding ||
           (hasCompletedOnboarding === false &&
             currentTopicID !== "WELCOME")) && (
           <MenuItem id="upload" buttonPadding>
             <HeaderUploadButton
               type={
+                userStore.isJusticeCountsAdmin(agencyId) ||
                 hasCompletedOnboarding ||
                 (!hasCompletedOnboarding && isAddDataOrPublishDataStep)
                   ? "blue"
@@ -383,6 +387,7 @@ const Menu: React.FC = () => {
               }
               onClick={() => {
                 if (
+                  userStore.isJusticeCountsAdmin(agencyId) ||
                   hasCompletedOnboarding ||
                   (!hasCompletedOnboarding && isAddDataOrPublishDataStep)
                 )
@@ -390,6 +395,7 @@ const Menu: React.FC = () => {
                 handleCloseMobileMenu();
               }}
               enabledDuringOnboarding={
+                userStore.isJusticeCountsAdmin(agencyId) ||
                 hasCompletedOnboarding ||
                 (!hasCompletedOnboarding && isAddDataOrPublishDataStep)
               }

--- a/publisher/src/router/Router.tsx
+++ b/publisher/src/router/Router.tsx
@@ -83,7 +83,8 @@ export const Router = () => {
             <Route path="/settings/*" element={<Settings />} />
           )}
 
-          {(hasCompletedOnboarding ||
+          {(userStore.isJusticeCountsAdmin(agencyId) ||
+            hasCompletedOnboarding ||
             (!hasCompletedOnboarding && isAddDataOrPublishDataStep)) && (
             <>
               <Route path={`/${REPORTS_LOWERCASE}`} element={<Reports />} />


### PR DESCRIPTION
## Description of the change

Allows JC Admins to access the Records page and the Bulk Upload component (and see them actively in the nav bar) throughout each step of the Guidance flow.

Note: to test the guidance flow as a user would experience it, you'll need to use a non-JC admin account.


https://user-images.githubusercontent.com/59492998/228670294-70d8938c-46c6-4a20-8dd8-535720f6d074.mov



## Related issues

Closes #528 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
