### PR TITLE
Metric Config: Update copy for confirming breakdown availability

### DIFF
--- a/publisher/src/components/MetricConfiguration/MetricBreakdownAvailabilityDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricBreakdownAvailabilityDefinitions.tsx
@@ -312,7 +312,7 @@ export const MetricBreakdownAvailabilityDefinitions: React.FC<MetricDefinitionsP
                 Confirm breakdown availability
               </BreakdownAvailabilitySubTitle>
               <BreakdownAvailabilityDescription>
-                Are you currently able to share any part of this metric?
+                Can you share data for this breakdown?
               </BreakdownAvailabilityDescription>
 
               <BreakdownAvailabilityMiniButtonWrapper>


### PR DESCRIPTION
## Description of the change

Updates copy for Confirming breakdown availability from "Are you currently able to share any part of this metric?" to "Can you share data for this breakdown?"

<img width="341" alt="Screenshot 2023-03-29 at 4 26 26 PM" src="https://user-images.githubusercontent.com/59492998/228671512-69cb9469-101e-4041-9c14-a845fcc24fab.png">

Question: revisiting Matt's suggestion - is it strange to have the options as "Available"/"Unavailable" in response to this copy change? The previous copy with these options looks strange too now.

## Related issues

Closes #527 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
