### PR TITLE
only render uploader name if it's uploaded by a real person

### DIFF
--- a/publisher/src/components/DataUpload/UploadedFiles.tsx
+++ b/publisher/src/components/DataUpload/UploadedFiles.tsx
@@ -64,8 +64,8 @@ export const UploadedFileRow: React.FC<{
     dateUploaded: string;
     dateIngested: string;
     system?: AgencySystems;
-    uploadedByName: string;
-    uploadedByRole: AgencyTeamMemberRole;
+    uploadedByName?: string;
+    uploadedByRole?: AgencyTeamMemberRole;
   };
   deleteUploadedFile: (spreadsheetID: number) => void;
   updateUploadedFileStatus: (
@@ -155,12 +155,18 @@ export const UploadedFileRow: React.FC<{
         <UploadedFilesCell capitalize>
           <UploadedContainer>
             {/* TODO(#334) Hook up admin badges rendering to team member roles API */}
-            <TeamMemberNameWithBadge
-              name={uploadedByName}
-              badgeId={id?.toString()}
-              role={uploadedByRole}
-            />
-            <DateUploaded>{`/ ${dateUploaded}`}</DateUploaded>
+            {uploadedByName && (
+              <TeamMemberNameWithBadge
+                name={uploadedByName}
+                badgeId={id?.toString()}
+                role={uploadedByRole}
+              />
+            )}
+            {uploadedByName ? (
+              <DateUploaded>{`/ ${dateUploaded}`}</DateUploaded>
+            ) : (
+              <>{dateUploaded}</>
+            )}
           </UploadedContainer>
         </UploadedFilesCell>
 


### PR DESCRIPTION
## Description of the change

 When Bulk Upload sends spreadsheet metadata for a spreadsheet uploaded with automatic upload, the uploader information is `"name": None, "role": None`. This PR will only render the date when a workbook is uploaded with automatic upload.  

<img width="1320" alt="Screen Shot 2023-03-29 at 8 29 04 PM" src="https://user-images.githubusercontent.com/19961693/228712687-d5e7d3b0-73db-4200-b472-fca76c8e6978.png">


## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
