### PR TITLE
Bulk Publishing: Update Bulk Upload Publish Confirmation (List of Reports + Warning Modal)

### DIFF
--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -143,7 +143,10 @@ export const DataUpload: React.FC = observer(() => {
 
       const data: DataUploadResponseBody = await response?.json();
 
-      /** After upload, the response may include newly created reports and/or updated existing report IDs (for overwrites) */
+      /**
+       * After upload, the response will include newly created reports and/or
+       * updated existing report IDs (for reports w/ overwrites)
+       */
       setNewAndUpdatedReports({
         newReports: data.new_reports || [],
         updatedReportIDs: data.updated_report_ids || [],

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -132,9 +132,11 @@ export const DataUpload: React.FC = observer(() => {
           color: "red",
         });
       }
-
       /** Errors and/or Warnings Encountered During Upload -- Show Interstitial instead of Confirmation Page */
       const data: DataUploadResponseBody = await response?.json();
+
+      console.log("new_reports", data.new_reports);
+      console.log("updated_report_ids", data.updated_report_ids);
 
       const errorsWarningsAndMetrics = processUploadResponseBody(data);
       const hasErrorsOrWarnings =

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import checkIcon from "@justice-counts/common/assets/status-check-icon.png";
-import { AgencySystems } from "@justice-counts/common/types";
+import { AgencySystems, ReportOverview } from "@justice-counts/common/types";
 import React, { Fragment } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
@@ -58,12 +58,17 @@ type UploadErrorsWarningsProps = {
   selectedSystem: AgencySystems | undefined;
   resetToNewUpload: () => void;
   fileName?: string;
+  newAndUpdatedReports: {
+    newReports: ReportOverview[];
+    updatedReportIDs: number[];
+  };
 };
 export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
   errorsWarningsMetrics,
   selectedSystem,
   resetToNewUpload,
   fileName,
+  newAndUpdatedReports,
 }) => {
   const navigate = useNavigate();
   const { agencyId } = useParams() as { agencyId: string };
@@ -373,7 +378,12 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
           <Button
             onClick={() =>
               navigate("review-metrics", {
-                state: { uploadedMetrics: metrics, fileName },
+                state: {
+                  uploadedMetrics: metrics,
+                  fileName,
+                  newReports: newAndUpdatedReports.newReports,
+                  updatedReportIDs: newAndUpdatedReports.updatedReportIDs,
+                },
                 replace: true,
               })
             }

--- a/publisher/src/components/DataUpload/UploadReview.tsx
+++ b/publisher/src/components/DataUpload/UploadReview.tsx
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+import { ReportOverview } from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
 import React, { useState } from "react";
 import {
@@ -24,6 +25,7 @@ import {
   useParams,
 } from "react-router-dom";
 
+import { useStore } from "../../stores";
 import { REPORTS_LOWERCASE } from "../Global/constants";
 import {
   ReviewHeaderActionButton,
@@ -36,9 +38,12 @@ import { UploadedMetric } from "./types";
 const UploadReview: React.FC = observer(() => {
   const { agencyId } = useParams();
   const { state } = useLocation();
-  const { uploadedMetrics, fileName } = state as {
+  const { reportStore } = useStore();
+  const { uploadedMetrics, fileName, newReports, updatedReportIDs } = state as {
     uploadedMetrics: UploadedMetric[] | null;
     fileName: string;
+    newReports: ReportOverview[];
+    updatedReportIDs: number[];
   };
   const navigate = useNavigate();
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
@@ -48,6 +53,10 @@ const UploadReview: React.FC = observer(() => {
   }
 
   // review component props
+  const existingRecords = updatedReportIDs.map(
+    (id) => reportStore.reportOverviews[id]
+  );
+  const existingAndNewRecords = [...existingRecords, ...newReports];
   const metrics = uploadedMetrics
     .map((metric) => ({
       ...metric,
@@ -106,6 +115,7 @@ const UploadReview: React.FC = observer(() => {
         buttons={buttons}
         metrics={metrics}
         metricOverwrites={overwrites}
+        records={existingAndNewRecords}
       />
     </>
   );

--- a/publisher/src/components/DataUpload/UploadReview.tsx
+++ b/publisher/src/components/DataUpload/UploadReview.tsx
@@ -56,9 +56,9 @@ const UploadReview: React.FC = observer(() => {
   }
 
   // review component props
-  const existingReports = updatedReportIDs.map(
-    (id) => reportStore.reportOverviews[id]
-  );
+  const existingReports = updatedReportIDs
+    .map((id) => reportStore.reportOverviews[id])
+    .filter((report) => report);
   const existingAndNewRecords = [...existingReports, ...newReports];
   const existingAndNewRecordIDs = existingAndNewRecords.map(
     (record) => record.id

--- a/publisher/src/components/DataUpload/UploadReview.tsx
+++ b/publisher/src/components/DataUpload/UploadReview.tsx
@@ -78,7 +78,7 @@ const UploadReview: React.FC = observer(() => {
       name: "Proceed with Publishing",
       color: "green",
       onClick: () => {
-        // setExistingReportWarningOpen(false);
+        setExistingReportWarningOpen(false);
         publishMultipleRecords();
       },
     },
@@ -91,7 +91,6 @@ const UploadReview: React.FC = observer(() => {
         agencyId,
         "PUBLISHED"
       );
-      setExistingReportWarningOpen(false);
       setIsSuccessModalOpen(true);
     }
   };

--- a/publisher/src/components/DataUpload/UploadReview.tsx
+++ b/publisher/src/components/DataUpload/UploadReview.tsx
@@ -60,10 +60,9 @@ const UploadReview: React.FC = observer(() => {
     (id) => reportStore.reportOverviews[id]
   );
   const existingAndNewRecords = [...existingReports, ...newReports];
-  const existingAndNewRecordIDs =
-    existingAndNewRecords.length > 0
-      ? existingAndNewRecords.map((record) => record.id)
-      : [];
+  const existingAndNewRecordIDs = existingAndNewRecords.map(
+    (record) => record.id
+  );
   const isPublishingExistingReports = updatedReportIDs.length > 0;
   const publishingExistingReportsButtons: {
     name: string;

--- a/publisher/src/components/DataUpload/types.ts
+++ b/publisher/src/components/DataUpload/types.ts
@@ -15,11 +15,13 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { RawDatapoint } from "@justice-counts/common/types";
+import { RawDatapoint, ReportOverview } from "@justice-counts/common/types";
 
 export interface DataUploadResponseBody {
   metrics: UploadedMetric[];
   non_metric_errors?: ErrorWarningMessage[];
+  new_reports: ReportOverview[];
+  updated_report_ids: number[];
 }
 
 export interface UploadedMetric {

--- a/publisher/src/components/Reports/Reports.styles.tsx
+++ b/publisher/src/components/Reports/Reports.styles.tsx
@@ -127,10 +127,12 @@ export const ReportActions = styled.div`
   display: flex;
 `;
 
+export type ReportActionsButtonColors = "red" | "green" | "blue" | "orange";
+
 export const ReportActionsButton = styled.div<{
   disabled?: boolean;
   textColor?: "blue";
-  buttonColor?: "red" | "green" | "blue" | "orange";
+  buttonColor?: ReportActionsButtonColors;
 }>`
   position: relative;
   border: ${({ buttonColor }) =>

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
@@ -275,6 +275,9 @@ export const ReviewPublishModalHint = styled(RemoveRecordsModalHint)`
   display: flex;
   text-align: center;
   max-width: 264px;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
 `;
 export const ReviewPublishModalButtonsContainer = styled(
   RemoveRecordsModalButtonsContainer
@@ -287,3 +290,14 @@ export const ReviewPublishModalButton = styled(ReportActionsButton)`
 export const NoDatapointsMessage = styled.div`
   margin: auto auto;
 `;
+
+export const ListOfReportsContainer = styled.div`
+  width: 100%;
+  max-height: 120px;
+  overflow: auto;
+  margin-top: 15px;
+  padding: 0 15px;
+  color: ${palette.highlight.grey9};
+`;
+
+export const ModifiedReportTitle = styled.div``;

--- a/publisher/src/components/ReviewMetrics/ReviewMetricsModal.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetricsModal.tsx
@@ -75,6 +75,11 @@ export const ReviewMetricsModal: React.FC<{
 
   return (
     <ReviewPublishModalWrapper>
+      {/**
+       * Warning/Success Modal
+       *  * Warning modal: appears after a user uploads a spreadsheet that modifies existing reports, and the user attempts to publish
+       *  * Success modal: typically appears after a user successfully publishes a report
+       */}
       {isExistingReportWarningModalOpen ? (
         <ReviewPublishModalContainer>
           <ReviewPublishModalIcon

--- a/publisher/src/components/ReviewMetrics/ReviewMetricsModal.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetricsModal.tsx
@@ -26,6 +26,8 @@ import warningIcon from "../assets/warning-icon.svg";
 import { REPORT_LOWERCASE, REPORTS_LOWERCASE } from "../Global/constants";
 import { ReportActionsButtonColors } from "../Reports";
 import {
+  ListOfReportsContainer,
+  ModifiedReportTitle,
   ReviewPublishModalButton,
   ReviewPublishModalButtonsContainer,
   ReviewPublishModalContainer,
@@ -33,7 +35,6 @@ import {
   ReviewPublishModalIcon,
   ReviewPublishModalTitle,
   ReviewPublishModalWrapper,
-  SummarySectionLine,
 } from "./ReviewMetrics.styles";
 
 export const ReviewMetricsModal: React.FC<{
@@ -86,17 +87,22 @@ export const ReviewMetricsModal: React.FC<{
           <ReviewPublishModalHint>
             The following existing reports will also be published. Are you sure
             you want to proceed?
+            <ListOfReportsContainer>
+              {existingReports?.map((record) => (
+                <ModifiedReportTitle key={record.id}>
+                  {printReportTitle(
+                    record.month,
+                    record.year,
+                    record.frequency
+                  )}
+                </ModifiedReportTitle>
+              ))}
+            </ListOfReportsContainer>
           </ReviewPublishModalHint>
-          <div>
-            {existingReports?.map((record) => (
-              <SummarySectionLine key={record.id}>
-                {printReportTitle(record.month, record.year, record.frequency)}
-              </SummarySectionLine>
-            ))}
-          </div>
           <ReviewPublishModalButtonsContainer>
             {publishingExistingReportsButtons?.map((button) => (
               <ReviewPublishModalButton
+                key={button.name}
                 buttonColor={button.color as ReportActionsButtonColors}
                 onClick={button.onClick}
               >

--- a/publisher/src/components/ReviewMetrics/ReviewMetricsModal.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetricsModal.tsx
@@ -15,12 +15,16 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+import { ReportOverview } from "@justice-counts/common/types";
+import { printReportTitle } from "@justice-counts/common/utils";
 import React from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { RecordsBulkAction } from "../../pages/Reports";
 import bigBlueCheck from "../assets/big-blue-check.png";
+import warningIcon from "../assets/warning-icon.svg";
 import { REPORT_LOWERCASE, REPORTS_LOWERCASE } from "../Global/constants";
+import { ReportActionsButtonColors } from "../Reports";
 import {
   ReviewPublishModalButton,
   ReviewPublishModalButtonsContainer,
@@ -29,6 +33,7 @@ import {
   ReviewPublishModalIcon,
   ReviewPublishModalTitle,
   ReviewPublishModalWrapper,
+  SummarySectionLine,
 } from "./ReviewMetrics.styles";
 
 export const ReviewMetricsModal: React.FC<{
@@ -37,12 +42,22 @@ export const ReviewMetricsModal: React.FC<{
   recordsCount?: number;
   fileName?: string;
   action?: RecordsBulkAction;
+  isExistingReportWarningModalOpen?: boolean;
+  existingReports?: ReportOverview[];
+  publishingExistingReportsButtons?: {
+    name: string;
+    color?: string;
+    onClick: () => void;
+  }[];
 }> = ({
   systemSearchParam,
   metricSearchParam,
   recordsCount,
   fileName,
   action,
+  isExistingReportWarningModalOpen,
+  existingReports,
+  publishingExistingReportsButtons,
 }) => {
   const { agencyId } = useParams();
   const navigate = useNavigate();
@@ -56,42 +71,78 @@ export const ReviewMetricsModal: React.FC<{
       navigate(`/agency/${agencyId}/data`);
     }
   };
+
   return (
     <ReviewPublishModalWrapper>
-      <ReviewPublishModalContainer>
-        <ReviewPublishModalIcon src={bigBlueCheck} alt="" />
-        <ReviewPublishModalTitle>
-          {recordsCount && (
-            <>
-              <span>{recordsCount}</span>{" "}
-              {recordsCount > 1 ? REPORTS_LOWERCASE : REPORT_LOWERCASE}{" "}
-              {action === "publish" && "published!"}
-              {action === "unpublish" && "unpublished!"}
-            </>
-          )}
-          {fileName && (
-            <>
-              Data from <span>{fileName}</span> published!
-            </>
-          )}
-          {!recordsCount && !fileName && "Data published!"}
-        </ReviewPublishModalTitle>
-        <ReviewPublishModalHint>
-          {action === "unpublish"
-            ? `Data has been successfully unpublished.`
-            : "You can view the published data in the Data tab."}
-        </ReviewPublishModalHint>
-        <ReviewPublishModalButtonsContainer>
-          <ReviewPublishModalButton
-            onClick={() => navigate(`/agency/${agencyId}/${REPORTS_LOWERCASE}`)}
-          >
-            Go to Records
-          </ReviewPublishModalButton>
-          <ReviewPublishModalButton buttonColor="blue" onClick={goToDataPage}>
-            Go to Data
-          </ReviewPublishModalButton>
-        </ReviewPublishModalButtonsContainer>
-      </ReviewPublishModalContainer>
+      {isExistingReportWarningModalOpen ? (
+        <ReviewPublishModalContainer>
+          <ReviewPublishModalIcon
+            src={warningIcon}
+            alt=""
+            width={20}
+            height={20}
+          />
+          <ReviewPublishModalTitle>Wait!</ReviewPublishModalTitle>
+          <ReviewPublishModalHint>
+            The following existing reports will also be published. Are you sure
+            you want to proceed?
+          </ReviewPublishModalHint>
+          <div>
+            {existingReports?.map((record) => (
+              <SummarySectionLine key={record.id}>
+                {printReportTitle(record.month, record.year, record.frequency)}
+              </SummarySectionLine>
+            ))}
+          </div>
+          <ReviewPublishModalButtonsContainer>
+            {publishingExistingReportsButtons?.map((button) => (
+              <ReviewPublishModalButton
+                buttonColor={button.color as ReportActionsButtonColors}
+                onClick={button.onClick}
+              >
+                {button.name}
+              </ReviewPublishModalButton>
+            ))}
+          </ReviewPublishModalButtonsContainer>
+        </ReviewPublishModalContainer>
+      ) : (
+        <ReviewPublishModalContainer>
+          <ReviewPublishModalIcon src={bigBlueCheck} alt="" />
+          <ReviewPublishModalTitle>
+            {recordsCount && (
+              <>
+                <span>{recordsCount}</span>{" "}
+                {recordsCount > 1 ? REPORTS_LOWERCASE : REPORT_LOWERCASE}{" "}
+                {action === "publish" && "published!"}
+                {action === "unpublish" && "unpublished!"}
+              </>
+            )}
+            {fileName && (
+              <>
+                Data from <span>{fileName}</span> published!
+              </>
+            )}
+            {!recordsCount && !fileName && "Data published!"}
+          </ReviewPublishModalTitle>
+          <ReviewPublishModalHint>
+            {action === "unpublish"
+              ? `Data has been successfully unpublished.`
+              : "You can view the published data in the Data tab."}
+          </ReviewPublishModalHint>
+          <ReviewPublishModalButtonsContainer>
+            <ReviewPublishModalButton
+              onClick={() =>
+                navigate(`/agency/${agencyId}/${REPORTS_LOWERCASE}`)
+              }
+            >
+              Go to Records
+            </ReviewPublishModalButton>
+            <ReviewPublishModalButton buttonColor="blue" onClick={goToDataPage}>
+              Go to Data
+            </ReviewPublishModalButton>
+          </ReviewPublishModalButtonsContainer>
+        </ReviewPublishModalContainer>
+      )}
     </ReviewPublishModalWrapper>
   );
 };


### PR DESCRIPTION
## Description of the change

Update the Bulk Upload review page to:
* display a list of reports being reviewed after ingest on the left side panel
* display a warning modal when a user attempts to publish if they have existing (modified) reports that will also be published

Demo:

User has existing reports that are modified by spreadsheet upload:

https://user-images.githubusercontent.com/59492998/229591843-8498458e-7594-4444-932c-1136842b9a36.mov

---

User has _**NO**_ existing reports that are modified by spreadsheet upload:

https://user-images.githubusercontent.com/59492998/229592092-da4662dc-2a25-476d-8b0a-32463f4ddbf2.mov


## Related issues

Closes #540 
Closes #559 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
