### PR TITLE
Bulk Publishing: Error handling & review page refresh fix

### DIFF
--- a/publisher/src/components/DataUpload/UploadReview.tsx
+++ b/publisher/src/components/DataUpload/UploadReview.tsx
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import { ButtonColor } from "@justice-counts/common/components/Button";
+import { showToast } from "@justice-counts/common/components/Toast";
 import { ReportOverview } from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
 import React, { useState } from "react";
@@ -85,11 +86,20 @@ const UploadReview: React.FC = observer(() => {
 
   const publishMultipleRecords = async () => {
     if (agencyId) {
-      await reportStore.updateMultipleReportStatuses(
+      const response = (await reportStore.updateMultipleReportStatuses(
         existingAndNewRecordIDs,
         agencyId,
         "PUBLISHED"
-      );
+      )) as Response;
+
+      if (response.status !== 200) {
+        showToast({
+          message: `Failed to publish. Please try again.`,
+          color: "red",
+          timeout: 3000,
+        });
+        return;
+      }
       setIsSuccessModalOpen(true);
     }
   };

--- a/publisher/src/components/Reports/BulkActionReview.tsx
+++ b/publisher/src/components/Reports/BulkActionReview.tsx
@@ -73,11 +73,21 @@ const BulkActionReview = () => {
   };
 
   const unpublishMultipleRecords = async () => {
-    await reportStore.updateMultipleReportStatuses(
+    const response = (await reportStore.updateMultipleReportStatuses(
       recordsIds,
       agencyIdString,
       "DRAFT"
-    );
+    )) as Response;
+
+    if (response.status !== 200) {
+      showToast({
+        message: `Failed to publish. Please try again.`,
+        color: "red",
+        timeout: 3000,
+      });
+      return;
+    }
+
     setIsSuccessModalOpen(true);
   };
 

--- a/publisher/src/components/Reports/BulkActionReview.tsx
+++ b/publisher/src/components/Reports/BulkActionReview.tsx
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+import { showToast } from "@justice-counts/common/components/Toast";
 import DatapointsStore from "@justice-counts/common/stores/BaseDatapointsStore";
 import { RawDatapointsByMetric, Report } from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
@@ -54,11 +55,20 @@ const BulkActionReview = () => {
   const [datapoints, setDatapoints] = useState<RawDatapointsByMetric>({});
 
   const publishMultipleRecords = async () => {
-    await reportStore.updateMultipleReportStatuses(
+    const response = (await reportStore.updateMultipleReportStatuses(
       recordsIds,
       agencyIdString,
       "PUBLISHED"
-    );
+    )) as Response;
+
+    if (response.status !== 200) {
+      showToast({
+        message: `Failed to publish. Please try again.`,
+        color: "red",
+        timeout: 3000,
+      });
+      return;
+    }
     setIsSuccessModalOpen(true);
   };
 

--- a/publisher/src/components/Reports/BulkActionReview.tsx
+++ b/publisher/src/components/Reports/BulkActionReview.tsx
@@ -17,7 +17,11 @@
 
 import { showToast } from "@justice-counts/common/components/Toast";
 import DatapointsStore from "@justice-counts/common/stores/BaseDatapointsStore";
-import { RawDatapointsByMetric, Report } from "@justice-counts/common/types";
+import {
+  RawDatapointsByMetric,
+  Report,
+  ReportOverview,
+} from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
@@ -53,6 +57,7 @@ const BulkActionReview = () => {
   const { reportStore } = useStore();
 
   const [datapoints, setDatapoints] = useState<RawDatapointsByMetric>({});
+  const [records, setRecords] = useState<ReportOverview[]>([]);
 
   const publishMultipleRecords = async () => {
     const response = (await reportStore.updateMultipleReportStatuses(
@@ -114,7 +119,7 @@ const BulkActionReview = () => {
           )
         );
       }
-
+      setRecords(reportsWithDatapoints);
       setIsLoading(false);
     };
 
@@ -175,12 +180,8 @@ const BulkActionReview = () => {
         }, [] as ReviewMetric[])
       : [];
 
-  const records = recordsIds.map(
-    (recordID) => reportStore.reportOverviews[recordID]
-  );
   const publishActionTitle = "Review & Publish";
   const unpublishActionTitle = "Review & Unpublish";
-
   const publishActionDescription = (
     <>
       Here’s a breakdown of data you’ve selected to publish. Take a moment to

--- a/publisher/src/components/Reports/DataEntryReview.tsx
+++ b/publisher/src/components/Reports/DataEntryReview.tsx
@@ -109,6 +109,10 @@ const DataEntryReview = () => {
       setLoadingDatapoints(false);
     };
 
+    if (!reportStore.reportOverviews[reportID]) {
+      navigate("/");
+    }
+
     initialize();
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -123,7 +127,10 @@ const DataEntryReview = () => {
     document.body.style.overflow = isSuccessModalOpen ? "hidden" : "unset";
   }, [isSuccessModalOpen]);
 
-  if (reportStore.reportOverviews[reportID].agency_id !== agencyId) {
+  if (
+    reportStore.reportOverviews[reportID] &&
+    reportStore.reportOverviews[reportID].agency_id !== agencyId
+  ) {
     return <NotFound />;
   }
 


### PR DESCRIPTION
## Description of the change

Goal: add basic error handling when publishing is unsuccessful and handle user refresh in the BulkActionReview and DataEntryReview pages

* Adds basic error toast when the bulk publishing is not successful.
<img width="528" alt="Screenshot 2023-04-05 at 4 51 34 PM" src="https://user-images.githubusercontent.com/59492998/230231376-cc656e90-328d-4d42-b7aa-ed10771ec9b2.png">

* Previously, a refresh in the BulkActionReview and DataEntryReview crashed the app. Now, the BulkActionReview can handle a refresh and still persist data. The DataEntryReview will redirect a user back to the data entry form on refresh. I'm thinking there should be a way to persist this too and spent time trying to figure out, but kept coming up empty. I'll keep digging - but for now, we can redirect users back to the data entry form and avoid the crash behavior.
  * Update on persisting the data entry review: 
    * There's no way to do this without making another call to the backend. When a user goes through the Records Overview -> ReportDataEntry > DataEntryForm there is a call to `getReports` in `ReportDataEntry` which gets a report + its metrics and stores it - so by the time the review page looks for report metrics, it's ready and available in the store. When you refresh in the Data Entry review page, the component that called `getReports` doesn't remount and thus nothing is available in the store.

## Related issues

Closes #XXXX

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
