### PR TITLE
[Bug Bash] Fix spacing in Race/Ethnicities grid header

### DIFF
--- a/publisher/src/components/MetricConfiguration/RaceEthnicities.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicities.styles.tsx
@@ -90,6 +90,7 @@ export const GridHeaderContainer = styled.div`
   color: ${palette.highlight.grey5};
   width: 100%;
   display: flex;
+  align-items: center;
   padding-bottom: 10px;
   border-bottom: 1px solid ${palette.highlight.grey4};
 `;
@@ -99,7 +100,8 @@ export const GridRaceHeader = styled.div`
 `;
 export const GridEthnicitiesHeader = styled.div`
   display: flex;
-  gap: 17px;
+  gap: 7px;
+  justify-content: space-between;
 `;
 
 export const EthnicityLabel = styled.div`
@@ -118,7 +120,8 @@ export const EthnicityLabel = styled.div`
 
 export const EthnicityName = styled.div`
   color: ${palette.solid.darkgrey};
-  white-space: nowrap;
+  text-align: center;
+  min-width: 80px;
 `;
 
 export const Description = styled.div`
@@ -148,8 +151,8 @@ export const RaceCell = styled.div``;
 
 export const EthnicitiesRow = styled.div`
   display: flex;
-  margin-right: 17px;
-  gap: 60px;
+  margin-right: 28px;
+  gap: 70px;
 `;
 export const EthnicityCell = styled.div<{ enabled?: boolean }>`
   width: 20px;


### PR DESCRIPTION
## Description of the change

The Ethnicities column titles within the Race/Ethnicities grid header were not properly aligned with the on/off indicator cells beneath (the blue circles). This breaks the words so that they can be better aligned with the cells beneath. The entire Metric Config will be redone any way - so this is more/less a fix until then.

**Before**
<img width="645" alt="Screenshot 2023-04-10 at 3 14 39 PM" src="https://user-images.githubusercontent.com/59492998/231011782-1ac249b1-1b16-47bb-a7cb-672c52ce379d.png">

**After**
<img width="647" alt="Screenshot 2023-04-10 at 3 13 41 PM" src="https://user-images.githubusercontent.com/59492998/231011846-f89449f8-3231-400c-a41a-5c1e96f9e00f.png">

## Related issues

Closes #520  

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
