### PR TITLE
[Bug Bash] Remove overlay on top of a metric's definitions when a metric has no availability set  

### DIFF
--- a/publisher/src/components/MetricConfiguration/MetricBreakdownAvailabilityDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricBreakdownAvailabilityDefinitions.tsx
@@ -297,7 +297,9 @@ export const MetricBreakdownAvailabilityDefinitions: React.FC<MetricDefinitionsP
 
     return (
       <DefinitionsDisplayContainer>
-        <DefinitionsDisplay enabled={metrics[systemMetricKey]?.enabled}>
+        <DefinitionsDisplay
+          enabled={metrics[systemMetricKey]?.enabled !== false}
+        >
           <DefinitionsTitle>
             {activeMetricOrDimensionDisplayName}
           </DefinitionsTitle>

--- a/publisher/src/components/MetricConfiguration/MetricBreakdownAvailabilityDefinitions.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricBreakdownAvailabilityDefinitions.tsx
@@ -49,6 +49,7 @@ import {
   IncludesExcludesDescription,
   MetricSettings,
   MiniButton,
+  OverlayWrapper,
   RevertToDefaultTextButton,
   RevertToDefaultTextButtonWrapper,
 } from ".";
@@ -297,9 +298,7 @@ export const MetricBreakdownAvailabilityDefinitions: React.FC<MetricDefinitionsP
 
     return (
       <DefinitionsDisplayContainer>
-        <DefinitionsDisplay
-          enabled={metrics[systemMetricKey]?.enabled !== false}
-        >
+        <DefinitionsDisplay>
           <DefinitionsTitle>
             {activeMetricOrDimensionDisplayName}
           </DefinitionsTitle>
@@ -307,198 +306,205 @@ export const MetricBreakdownAvailabilityDefinitions: React.FC<MetricDefinitionsP
             {activeMetricOrDimensionDescription}
           </BreakdownAvailabilityDescription>
 
-          {/* Breakdown Availability */}
-          {activeDimensionKey && (
-            <>
-              <BreakdownAvailabilitySubTitle>
-                Confirm breakdown availability
-              </BreakdownAvailabilitySubTitle>
-              <BreakdownAvailabilityDescription>
-                Can you share data for this breakdown?
-              </BreakdownAvailabilityDescription>
+          <OverlayWrapper enabled={metrics[systemMetricKey]?.enabled}>
+            {/* Breakdown Availability */}
+            {activeDimensionKey && (
+              <>
+                <BreakdownAvailabilitySubTitle>
+                  Confirm breakdown availability
+                </BreakdownAvailabilitySubTitle>
+                <BreakdownAvailabilityDescription>
+                  Can you share data for this breakdown?
+                </BreakdownAvailabilityDescription>
 
-              <BreakdownAvailabilityMiniButtonWrapper>
-                <MiniButton
-                  selected={currentDimension?.enabled === false}
-                  onClick={() => {
-                    if (
-                      currentDimension?.enabled ||
-                      currentDimension?.enabled === null
-                    )
-                      handleDimensionEnabledStatus(false);
-                  }}
-                >
-                  Unavailable
-                </MiniButton>
-                <MiniButton
-                  selected={currentDimension?.enabled}
-                  onClick={() => {
-                    if (!currentDimension?.enabled)
-                      handleDimensionEnabledStatus(true);
-                  }}
-                >
-                  Available
-                </MiniButton>
-              </BreakdownAvailabilityMiniButtonWrapper>
-            </>
-          )}
-
-          {Boolean(activeSettingsKeys?.length) && (
-            <DefinitionsWrapper
-              enabled={
-                !metrics[systemMetricKey]?.enabled ||
-                !activeDimensionKey ||
-                (metrics[systemMetricKey]?.enabled && currentDimension?.enabled)
-              }
-            >
-              <DefinitionsSubTitle
-                onClick={() => {
-                  if (windowWidth <= MIN_TABLET_WIDTH) {
-                    setIsDefinitionsOpen(!isDefinitionsOpen);
-                  }
-                }}
-              >
-                {windowWidth <= MIN_TABLET_WIDTH && (
-                  <DefinitionsSubTitleDropdownArrow
-                    src={dropdownArrow}
-                    alt=""
-                    isOpen={isDefinitionsOpen}
-                  />
-                )}
-                {activeDimensionKey ? "Breakdown" : "Metric"} Definitions
-              </DefinitionsSubTitle>
-              <DefinitionsDescription isHiddenInMobileView={!isDefinitionsOpen}>
-                Indicate which of the following categories your agency considers
-                to be part of this {activeDimensionKey ? "breakdown" : "metric"}
-                .
-                <span>
-                  You are NOT required to {REPORT_VERB_LOWERCASE} data for these
-                  specific categories.
-                </span>
-              </DefinitionsDescription>
-
-              {/* Definition Settings (Includes/Excludes) */}
-              <Definitions isHiddenInMobileView={!isDefinitionsOpen}>
-                {activeSettingsKeys?.map((includesExcludesKey) => {
-                  if (!activeDisaggregationKey) return null;
-                  const currentIncludesExcludes = isMetricDefinitionSettings
-                    ? metricDefinitionSettings[systemMetricKey][
-                        includesExcludesKey
-                      ]
-                    : dimensionDefinitionSettings[systemMetricKey][
-                        activeDisaggregationKey
-                      ][activeDimensionKey][includesExcludesKey];
-
-                  return (
-                    <>
-                      {currentIncludesExcludes.description && (
-                        <IncludesExcludesDescription>
-                          {currentIncludesExcludes.description}
-                        </IncludesExcludesDescription>
-                      )}
-                      {Object.keys(currentIncludesExcludes.settings).map(
-                        (settingKey) => {
-                          const currentSetting = (
-                            isMetricDefinitionSettings
-                              ? metricDefinitionSettings[systemMetricKey][
-                                  includesExcludesKey
-                                ].settings[settingKey]
-                              : activeDisaggregationKey &&
-                                activeDimensionKey &&
-                                dimensionDefinitionSettings[systemMetricKey][
-                                  activeDisaggregationKey
-                                ][activeDimensionKey][includesExcludesKey]
-                                  .settings[settingKey]
-                          ) as {
-                            included?:
-                              | MetricConfigurationSettingsOptions
-                              | undefined;
-                            default?:
-                              | MetricConfigurationSettingsOptions
-                              | undefined;
-                            label?: string | undefined;
-                          };
-
-                          return (
-                            <DefinitionItem key={settingKey}>
-                              <DefinitionDisplayName>
-                                {currentSetting.label}
-                              </DefinitionDisplayName>
-
-                              <DefinitionSelection>
-                                {metricConfigurationSettingsOptions.map(
-                                  (option) => (
-                                    <Fragment key={option}>
-                                      <MiniButton
-                                        selected={
-                                          showDefaultSettings
-                                            ? currentSetting.default === option
-                                            : currentSetting.included === option
-                                        }
-                                        showDefault={showDefaultSettings}
-                                        onClick={() =>
-                                          handleUpdateMetricDefinitionSetting(
-                                            includesExcludesKey,
-                                            settingKey,
-                                            option
-                                          )
-                                        }
-                                      >
-                                        {option}
-                                      </MiniButton>
-                                    </Fragment>
-                                  )
-                                )}
-                              </DefinitionSelection>
-                            </DefinitionItem>
-                          );
-                        }
-                      )}
-                    </>
-                  );
-                })}
-              </Definitions>
-
-              {/* Revert To Default Definition Settings */}
-              <RevertToDefaultTextButtonWrapper
-                isHiddenInMobileView={!isDefinitionsOpen}
-              >
-                <RevertToDefaultTextButton
-                  onClick={() => {
-                    setShowDefaultSettings(false);
-                    revertToAndSaveDefaultValues();
-                  }}
-                  onMouseEnter={() =>
-                    !showDefaultSettings && setShowDefaultSettings(true)
-                  }
-                  onMouseLeave={() => setShowDefaultSettings(false)}
-                >
-                  Choose Justice Counts Preferred Definition
-                </RevertToDefaultTextButton>
-              </RevertToDefaultTextButtonWrapper>
-            </DefinitionsWrapper>
-          )}
-          {/* Display when user is viewing a dimension & there are no settings available */}
-          {noSettingsAvailable &&
-            !hasMinOneDimensionContext &&
-            !hasMinOneMetricLevelContext && (
-              <DefinitionsSubTitle isHiddenInMobileView={!isDefinitionsOpen}>
-                There are no definitions to configure for this{" "}
-                {activeDimensionKey ? "breakdown." : "metric yet."}
-              </DefinitionsSubTitle>
+                <BreakdownAvailabilityMiniButtonWrapper>
+                  <MiniButton
+                    selected={currentDimension?.enabled === false}
+                    onClick={() => {
+                      if (
+                        currentDimension?.enabled ||
+                        currentDimension?.enabled === null
+                      )
+                        handleDimensionEnabledStatus(false);
+                    }}
+                  >
+                    Unavailable
+                  </MiniButton>
+                  <MiniButton
+                    selected={currentDimension?.enabled}
+                    onClick={() => {
+                      if (!currentDimension?.enabled)
+                        handleDimensionEnabledStatus(true);
+                    }}
+                  >
+                    Available
+                  </MiniButton>
+                </BreakdownAvailabilityMiniButtonWrapper>
+              </>
             )}
 
-          {/* Display when dimension has additional contexts */}
-          {dimensionContextsMap && (
-            <DimensionContexts
-              dimensionContextsMap={dimensionContextsMap}
-              activeDisaggregationKey={activeDisaggregationKey}
-              activeDimensionKey={activeDimensionKey}
-              isShown={
-                windowWidth <= MIN_TABLET_WIDTH ? isDefinitionsOpen : true
-              }
-            />
-          )}
+            {Boolean(activeSettingsKeys?.length) && (
+              <DefinitionsWrapper
+                enabled={
+                  !metrics[systemMetricKey]?.enabled ||
+                  !activeDimensionKey ||
+                  (metrics[systemMetricKey]?.enabled &&
+                    currentDimension?.enabled)
+                }
+              >
+                <DefinitionsSubTitle
+                  onClick={() => {
+                    if (windowWidth <= MIN_TABLET_WIDTH) {
+                      setIsDefinitionsOpen(!isDefinitionsOpen);
+                    }
+                  }}
+                >
+                  {windowWidth <= MIN_TABLET_WIDTH && (
+                    <DefinitionsSubTitleDropdownArrow
+                      src={dropdownArrow}
+                      alt=""
+                      isOpen={isDefinitionsOpen}
+                    />
+                  )}
+                  {activeDimensionKey ? "Breakdown" : "Metric"} Definitions
+                </DefinitionsSubTitle>
+                <DefinitionsDescription
+                  isHiddenInMobileView={!isDefinitionsOpen}
+                >
+                  Indicate which of the following categories your agency
+                  considers to be part of this{" "}
+                  {activeDimensionKey ? "breakdown" : "metric"}.
+                  <span>
+                    You are NOT required to {REPORT_VERB_LOWERCASE} data for
+                    these specific categories.
+                  </span>
+                </DefinitionsDescription>
+
+                {/* Definition Settings (Includes/Excludes) */}
+                <Definitions isHiddenInMobileView={!isDefinitionsOpen}>
+                  {activeSettingsKeys?.map((includesExcludesKey) => {
+                    if (!activeDisaggregationKey) return null;
+                    const currentIncludesExcludes = isMetricDefinitionSettings
+                      ? metricDefinitionSettings[systemMetricKey][
+                          includesExcludesKey
+                        ]
+                      : dimensionDefinitionSettings[systemMetricKey][
+                          activeDisaggregationKey
+                        ][activeDimensionKey][includesExcludesKey];
+
+                    return (
+                      <>
+                        {currentIncludesExcludes.description && (
+                          <IncludesExcludesDescription>
+                            {currentIncludesExcludes.description}
+                          </IncludesExcludesDescription>
+                        )}
+                        {Object.keys(currentIncludesExcludes.settings).map(
+                          (settingKey) => {
+                            const currentSetting = (
+                              isMetricDefinitionSettings
+                                ? metricDefinitionSettings[systemMetricKey][
+                                    includesExcludesKey
+                                  ].settings[settingKey]
+                                : activeDisaggregationKey &&
+                                  activeDimensionKey &&
+                                  dimensionDefinitionSettings[systemMetricKey][
+                                    activeDisaggregationKey
+                                  ][activeDimensionKey][includesExcludesKey]
+                                    .settings[settingKey]
+                            ) as {
+                              included?:
+                                | MetricConfigurationSettingsOptions
+                                | undefined;
+                              default?:
+                                | MetricConfigurationSettingsOptions
+                                | undefined;
+                              label?: string | undefined;
+                            };
+
+                            return (
+                              <DefinitionItem key={settingKey}>
+                                <DefinitionDisplayName>
+                                  {currentSetting.label}
+                                </DefinitionDisplayName>
+
+                                <DefinitionSelection>
+                                  {metricConfigurationSettingsOptions.map(
+                                    (option) => (
+                                      <Fragment key={option}>
+                                        <MiniButton
+                                          selected={
+                                            showDefaultSettings
+                                              ? currentSetting.default ===
+                                                option
+                                              : currentSetting.included ===
+                                                option
+                                          }
+                                          showDefault={showDefaultSettings}
+                                          onClick={() =>
+                                            handleUpdateMetricDefinitionSetting(
+                                              includesExcludesKey,
+                                              settingKey,
+                                              option
+                                            )
+                                          }
+                                        >
+                                          {option}
+                                        </MiniButton>
+                                      </Fragment>
+                                    )
+                                  )}
+                                </DefinitionSelection>
+                              </DefinitionItem>
+                            );
+                          }
+                        )}
+                      </>
+                    );
+                  })}
+                </Definitions>
+
+                {/* Revert To Default Definition Settings */}
+                <RevertToDefaultTextButtonWrapper
+                  isHiddenInMobileView={!isDefinitionsOpen}
+                >
+                  <RevertToDefaultTextButton
+                    onClick={() => {
+                      setShowDefaultSettings(false);
+                      revertToAndSaveDefaultValues();
+                    }}
+                    onMouseEnter={() =>
+                      !showDefaultSettings && setShowDefaultSettings(true)
+                    }
+                    onMouseLeave={() => setShowDefaultSettings(false)}
+                  >
+                    Choose Justice Counts Preferred Definition
+                  </RevertToDefaultTextButton>
+                </RevertToDefaultTextButtonWrapper>
+              </DefinitionsWrapper>
+            )}
+            {/* Display when user is viewing a dimension & there are no settings available */}
+            {noSettingsAvailable &&
+              !hasMinOneDimensionContext &&
+              !hasMinOneMetricLevelContext && (
+                <DefinitionsSubTitle isHiddenInMobileView={!isDefinitionsOpen}>
+                  There are no definitions to configure for this{" "}
+                  {activeDimensionKey ? "breakdown." : "metric yet."}
+                </DefinitionsSubTitle>
+              )}
+
+            {/* Display when dimension has additional contexts */}
+            {dimensionContextsMap && (
+              <DimensionContexts
+                dimensionContextsMap={dimensionContextsMap}
+                activeDisaggregationKey={activeDisaggregationKey}
+                activeDimensionKey={activeDimensionKey}
+                isShown={
+                  windowWidth <= MIN_TABLET_WIDTH ? isDefinitionsOpen : true
+                }
+              />
+            )}
+          </OverlayWrapper>
         </DefinitionsDisplay>
         {/* Additional Context (only appears on overall metric settings and not individual dimension settings) */}
         {!activeDimensionKey && (

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -34,7 +34,7 @@ const METRICS_VIEW_CONTAINER_BREAKPOINT = 1200;
 const INNER_PANEL_LEFT_CONTAINER_MAX_WIDTH = 314;
 const STICKY_HEADER_WITH_PADDING_HEIGHT = 48;
 const DROPDOWN_WITH_MARGIN_HEIGHT = 79;
-const baseDisabledFadedOverlayCSS = `
+export const baseDisabledFadedOverlayCSS = `
   &:after {
     content: "";
     width: 100%;
@@ -899,11 +899,9 @@ export const DefinitionsDisplayContainer = styled.div`
   }
 `;
 
-export const DefinitionsDisplay = styled.div<{ enabled?: boolean | null }>`
+export const DefinitionsDisplay = styled.div`
   width: 100%;
   position: relative;
-
-  ${({ enabled }) => !enabled && baseDisabledFadedOverlayCSS}
 `;
 
 export const DefinitionsWrapper = styled.div<{ enabled?: boolean | null }>`
@@ -1189,4 +1187,9 @@ export const IncludesExcludesDescription = styled.div`
     padding-top: 16px;
     margin: 16px 0;
   }
+`;
+
+export const OverlayWrapper = styled.div<{ enabled?: boolean | null }>`
+  position: relative;
+  ${({ enabled }) => !enabled && baseDisabledFadedOverlayCSS}
 `;

--- a/publisher/src/components/MetricConfiguration/MetricContextConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricContextConfiguration.tsx
@@ -80,7 +80,9 @@ export const ContextConfiguration: React.FC<{ isShown: boolean }> = observer(
     if (activeContextKeys.length === 0 || !isShown) return null;
 
     return (
-      <MetricContextContainer enabled={metrics[systemMetricKey]?.enabled}>
+      <MetricContextContainer
+        enabled={metrics[systemMetricKey]?.enabled !== false}
+      >
         {activeContextKeys.map((contextKey) => {
           const currentContext = contexts[systemMetricKey][contextKey];
 

--- a/publisher/src/components/MetricConfiguration/MetricContextConfiguration.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricContextConfiguration.tsx
@@ -80,9 +80,7 @@ export const ContextConfiguration: React.FC<{ isShown: boolean }> = observer(
     if (activeContextKeys.length === 0 || !isShown) return null;
 
     return (
-      <MetricContextContainer
-        enabled={metrics[systemMetricKey]?.enabled !== false}
-      >
+      <MetricContextContainer enabled={metrics[systemMetricKey]?.enabled}>
         {activeContextKeys.map((contextKey) => {
           const currentContext = contexts[systemMetricKey][contextKey];
 

--- a/publisher/src/components/MetricConfiguration/RaceEthnicities.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/RaceEthnicities.styles.tsx
@@ -24,11 +24,11 @@ import styled, { css } from "styled-components/macro";
 
 import { BinaryRadioGroupWrapper } from "../Forms";
 import {
+  baseDisabledFadedOverlayCSS,
   DefinitionDisplayName,
   DefinitionItem,
   Definitions,
   DefinitionsDescription,
-  DefinitionsDisplay,
   DefinitionsDisplayContainer,
   DefinitionSelection,
   DefinitionsTitle,
@@ -168,7 +168,13 @@ export const RaceEthnicitiesContainer = styled(DefinitionsDisplayContainer)`
     padding-bottom: 0;
   }
 `;
-export const RaceEthnicitiesDisplay = styled(DefinitionsDisplay)``;
+
+export const RaceEthnicitiesDisplay = styled.div<{ enabled?: boolean | null }>`
+  width: 100%;
+  position: relative;
+  ${({ enabled }) => !enabled && baseDisabledFadedOverlayCSS}
+`;
+
 export const RaceEthnicitiesTitle = styled(DefinitionsTitle)``;
 export const RaceEthnicitiesDescription = styled(DefinitionsDescription)`
   @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {


### PR DESCRIPTION
## Description of the change

When a metric's availability is in a `null` state (no selection has been made), the metric's title & description on the right panel are under an overlay that greys them out. This PR removes that overlay from the metric title & description so they are always visible.

**Before**
<img width="1728" alt="Screenshot 2023-04-10 at 5 48 31 PM" src="https://user-images.githubusercontent.com/59492998/231013820-729866e6-5709-44be-9a16-904a2ca561ff.png">


---

**After**

https://user-images.githubusercontent.com/59492998/231305555-895953f3-52ca-4902-9e9f-aabd6a45afd4.mov



## Related issues

Closes #525

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
