### PR TITLE
[Bug Bash] Fix "Last modified by" section within a record's summary panel to show the name of the last user who modified the record

### DIFF
--- a/publisher/src/components/Reports/ReportSummaryPanel.tsx
+++ b/publisher/src/components/Reports/ReportSummaryPanel.tsx
@@ -329,9 +329,7 @@ const ReportSummaryPanel: React.FC<{
             lastModifiedAt &&
             `Last modified ${printElapsedDaysMonthsYearsSinceDate(
               lastModifiedAt
-            )} by ${
-              filteredReportEditors[filteredReportEditors.length - 1].name
-            }`}
+            )} by ${filteredReportEditors[0].name}`}
 
           {!filteredReportEditors.length && ``}
         </EditDetailsContent>


### PR DESCRIPTION
## Description of the change

Within a report's Report Summary panel, the "Last modified by X" would always choose the name of the last person on the list of editors instead of the user who actually made the last edit. Since the user who made the last edit is the first on the list, this PR adjusts the `filteredReportEditors` to choose the first user on the editors list instead of the last.

**Before**


https://user-images.githubusercontent.com/59492998/231016133-6b3a2901-43ed-421c-8043-72e7ff7269c7.mov



**After**

https://user-images.githubusercontent.com/59492998/231015134-c362a4c2-a5ec-4107-a9c8-9b9976bdc544.mov

## Related issues

Closes #522 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
