### PR TITLE
[Bug Bash] Data Page: Show the first enabled metric for an agency on load and handle no enabled metrics case

### DIFF
--- a/common/components/DataViz/DatapointsView.styles.tsx
+++ b/common/components/DataViz/DatapointsView.styles.tsx
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import {
+  HEADER_BAR_HEIGHT,
   MIN_DESKTOP_WIDTH,
   MIN_TABLET_WIDTH,
   palette,
@@ -93,10 +94,14 @@ export const ExtendedDropdownMenuItem = styled(DropdownMenuItem)<{
   }
 `;
 
-export const DatapointsViewContainer = styled.div`
+export const DatapointsViewContainer = styled.div<{
+  maxHeightViewport?: boolean;
+}>`
   display: flex;
   flex-direction: column;
   flex-grow: 1;
+  ${({ maxHeightViewport }) =>
+    maxHeightViewport && `max-height: calc(100vh - ${HEADER_BAR_HEIGHT}px)`}
 `;
 
 export const DatapointsViewHeaderWrapper = styled.div`

--- a/common/components/DataViz/DatapointsView.tsx
+++ b/common/components/DataViz/DatapointsView.tsx
@@ -108,6 +108,7 @@ export const DatapointsView: React.FC<{
   showTitle?: boolean;
   showBottomMetricInsights?: boolean;
   resizeHeight?: boolean;
+  maxHeightViewport?: boolean;
 }> = ({
   datapointsGroupedByAggregateAndDisaggregations,
   dimensionNamesByDisaggregation,
@@ -125,6 +126,7 @@ export const DatapointsView: React.FC<{
   showTitle = false,
   showBottomMetricInsights = false,
   resizeHeight = false,
+  maxHeightViewport = false,
 }) => {
   const [mobileSelectMetricsVisible, setMobileSelectMetricsVisible] =
     React.useState<boolean>(false);
@@ -266,7 +268,7 @@ export const DatapointsView: React.FC<{
   const shouldShowMobileFiltersModal = mobileFiltersVisible && metricName;
 
   return (
-    <DatapointsViewContainer>
+    <DatapointsViewContainer maxHeightViewport={maxHeightViewport}>
       <DatapointsViewHeaderWrapper>
         {showTitle && (
           <MetricHeaderWrapper>

--- a/publisher/src/components/DataViz/ConnectedDatapointsView.tsx
+++ b/publisher/src/components/DataViz/ConnectedDatapointsView.tsx
@@ -80,6 +80,7 @@ const ConnectedDatapointsView: React.FC<{
           resizeHeight
           showTitle
           showBottomMetricInsights={windowWidth <= MIN_DESKTOP_WIDTH}
+          maxHeightViewport
         />
       )}
       {dataView === ChartView.Table && (

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -1193,3 +1193,8 @@ export const OverlayWrapper = styled.div<{ enabled?: boolean | null }>`
   position: relative;
   ${({ enabled }) => !enabled && baseDisabledFadedOverlayCSS}
 `;
+
+export const NoEnabledMetricsMessage = styled.div`
+  min-height: 100%;
+  margin: auto auto;
+`;

--- a/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricConfiguration.styles.tsx
@@ -141,18 +141,6 @@ export const SystemName = styled.span`
   text-transform: capitalize;
 `;
 
-export const SystemNamePlusSign = styled.span<{ isSystemActive: boolean }>`
-  display: none;
-
-  &::after {
-    content: "+";
-  }
-
-  ${SystemNameContainer}:hover && {
-    display: ${({ isSystemActive }) => (isSystemActive ? "none" : "block")};
-  }
-`;
-
 export const MetricsItemsContainer = styled.div<{ isSystemActive: boolean }>`
   display: flex;
   flex-direction: column;

--- a/publisher/src/components/MetricConfiguration/MetricsView.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricsView.tsx
@@ -219,7 +219,7 @@ export const MetricsView: React.FC = observer(() => {
                       </SystemName>
                     </SystemNameContainer>
                   ) : (
-                    <SystemNameContainer isSystemActive={false}>
+                    <SystemNameContainer isSystemActive>
                       <SystemName>
                         {metrics[0].system.display_name} (No enabled metrics)
                       </SystemName>

--- a/publisher/src/components/MetricConfiguration/MetricsView.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricsView.tsx
@@ -62,7 +62,6 @@ import {
   PanelRightTopButtonsContainer,
   SystemName,
   SystemNameContainer,
-  SystemNamePlusSign,
   SystemsContainer,
 } from ".";
 
@@ -92,12 +91,13 @@ export const MetricsView: React.FC = observer(() => {
       return setLoadingError(result.message);
     }
 
-    const defaultSystemSearchParam = Object.keys(result)[0]
+    const firstEnabledMetric = Object.values(result)
+      ?.flat()
+      .find((metric) => metric.enabled);
+    const defaultSystemSearchParam = firstEnabledMetric?.system.key
       .toLowerCase()
       .replace(" ", "_") as AgencySystems;
-    const defaultMetricSearchParam = Object.values(result)[0]?.find(
-      (metric) => metric.enabled
-    )?.key;
+    const defaultMetricSearchParam = firstEnabledMetric?.key;
 
     // same logic as in metric config page, the only difference is
     // there should always be metric search param
@@ -211,25 +211,12 @@ export const MetricsView: React.FC = observer(() => {
               return (
                 <React.Fragment key={system}>
                   {enabledMetrics.length > 0 ? (
-                    <SystemNameContainer
-                      isSystemActive={system === systemSearchParam}
-                      onClick={() => {
-                        setSettingsSearchParams({
-                          system: system as AgencySystems,
-                          metric: metricsBySystem[system].filter(
-                            (metric) => metric.enabled
-                          )[0].key,
-                        });
-                      }}
-                    >
+                    <SystemNameContainer isSystemActive>
                       <SystemName>
                         {formatSystemName(metrics[0].system.key, {
                           allUserSystems: currentAgency?.systems,
                         })}
                       </SystemName>
-                      <SystemNamePlusSign
-                        isSystemActive={system === systemSearchParam}
-                      />
                     </SystemNameContainer>
                   ) : (
                     <SystemNameContainer isSystemActive={false}>

--- a/publisher/src/components/MetricConfiguration/MetricsView.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricsView.tsx
@@ -205,43 +205,46 @@ export const MetricsView: React.FC = observer(() => {
         {/* List Of Metrics */}
         <PanelContainerLeft>
           <SystemsContainer>
-            {Object.entries(metricsBySystem).map(([system, metrics]) => (
-              <React.Fragment key={system}>
-                {metrics.filter((metric) => metric.enabled).length > 0 ? (
-                  <SystemNameContainer
-                    isSystemActive={system === systemSearchParam}
-                    onClick={() => {
-                      setSettingsSearchParams({
-                        system: system as AgencySystems,
-                        metric: metricsBySystem[system].filter(
-                          (metric) => metric.enabled
-                        )[0].key,
-                      });
-                    }}
-                  >
-                    <SystemName>
-                      {formatSystemName(metrics[0].system.key, {
-                        allUserSystems: currentAgency?.systems,
-                      })}
-                    </SystemName>
-                    <SystemNamePlusSign
-                      isSystemActive={system === systemSearchParam}
-                    />
-                  </SystemNameContainer>
-                ) : (
-                  <SystemNameContainer isSystemActive={false}>
-                    <SystemName>
-                      {metrics[0].system.display_name} (No enabled metrics)
-                    </SystemName>
-                  </SystemNameContainer>
-                )}
+            {Object.entries(metricsBySystem).map(([system, metrics]) => {
+              const enabledMetrics = metrics.filter((metric) => metric.enabled);
 
-                <MetricsItemsContainer
-                  isSystemActive={system === systemSearchParam}
-                >
-                  {metrics
-                    .filter((metric) => metric.enabled)
-                    .map((metric) => (
+              return (
+                <React.Fragment key={system}>
+                  {enabledMetrics.length > 0 ? (
+                    <SystemNameContainer
+                      isSystemActive={system === systemSearchParam}
+                      onClick={() => {
+                        setSettingsSearchParams({
+                          system: system as AgencySystems,
+                          metric: metricsBySystem[system].filter(
+                            (metric) => metric.enabled
+                          )[0].key,
+                        });
+                      }}
+                    >
+                      <SystemName>
+                        {formatSystemName(metrics[0].system.key, {
+                          allUserSystems: currentAgency?.systems,
+                        })}
+                      </SystemName>
+                      <SystemNamePlusSign
+                        isSystemActive={system === systemSearchParam}
+                      />
+                    </SystemNameContainer>
+                  ) : (
+                    <SystemNameContainer isSystemActive={false}>
+                      <SystemName>
+                        {metrics[0].system.display_name} (No enabled metrics)
+                      </SystemName>
+                    </SystemNameContainer>
+                  )}
+
+                  <MetricsItemsContainer
+                    isSystemActive={
+                      system === systemSearchParam || enabledMetrics.length > 0
+                    }
+                  >
+                    {enabledMetrics.map((metric) => (
                       <MetricItem
                         key={metric.key}
                         selected={metricSearchParam === metric.key}
@@ -255,9 +258,10 @@ export const MetricsView: React.FC = observer(() => {
                         {metric.display_name}
                       </MetricItem>
                     ))}
-                </MetricsItemsContainer>
-              </React.Fragment>
-            ))}
+                  </MetricsItemsContainer>
+                </React.Fragment>
+              );
+            })}
           </SystemsContainer>
           <DisclaimerContainer>
             <DisclaimerTitle>Note</DisclaimerTitle>

--- a/publisher/src/components/MetricConfiguration/MetricsView.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricsView.tsx
@@ -55,6 +55,7 @@ import {
   MetricsViewControlPanelOverflowHidden,
   MobileDatapointsControls,
   MobileDisclaimerContainer,
+  NoEnabledMetricsMessage,
   PanelContainerLeft,
   PanelContainerRight,
   PanelRightTopButton,
@@ -84,6 +85,8 @@ export const MetricsView: React.FC = observer(() => {
   const { system: systemSearchParam, metric: metricSearchParam } =
     settingsSearchParams;
 
+  console.log(settingsSearchParams);
+
   const initDataPageMetrics = async () => {
     const result = await reportStore.initializeReportSettings(agencyId);
     if (result instanceof Error) {
@@ -94,7 +97,9 @@ export const MetricsView: React.FC = observer(() => {
     const defaultSystemSearchParam = Object.keys(result)[0]
       .toLowerCase()
       .replace(" ", "_") as AgencySystems;
-    const defaultMetricSearchParam = Object.values(result)[0][0].key;
+    const defaultMetricSearchParam = Object.values(result)[0]?.find(
+      (metric) => metric.enabled
+    )?.key;
 
     // same logic as in metric config page, the only difference is
     // there should always be metric search param
@@ -166,6 +171,21 @@ export const MetricsView: React.FC = observer(() => {
     }
   }, [windowWidth]);
 
+  if (!metricSearchParam) {
+    return (
+      <NoEnabledMetricsMessage>
+        There are no enabled metrics to view. Please go to{" "}
+        <DisclaimerLink
+          onClick={() => {
+            navigate("../settings/metric-config");
+          }}
+        >
+          Metric Configuration
+        </DisclaimerLink>{" "}
+        to enable a metric.
+      </NoEnabledMetricsMessage>
+    );
+  }
   if (isLoading || !systemSearchParam || !metricSearchParam) {
     return <Loading />;
   }

--- a/publisher/src/components/MetricConfiguration/MetricsView.tsx
+++ b/publisher/src/components/MetricConfiguration/MetricsView.tsx
@@ -85,8 +85,6 @@ export const MetricsView: React.FC = observer(() => {
   const { system: systemSearchParam, metric: metricSearchParam } =
     settingsSearchParams;
 
-  console.log(settingsSearchParams);
-
   const initDataPageMetrics = async () => {
     const result = await reportStore.initializeReportSettings(agencyId);
     if (result instanceof Error) {
@@ -171,7 +169,7 @@ export const MetricsView: React.FC = observer(() => {
     }
   }, [windowWidth]);
 
-  if (!metricSearchParam) {
+  if (!metricSearchParam && !isLoading) {
     return (
       <NoEnabledMetricsMessage>
         There are no enabled metrics to view. Please go to{" "}
@@ -186,6 +184,7 @@ export const MetricsView: React.FC = observer(() => {
       </NoEnabledMetricsMessage>
     );
   }
+
   if (isLoading || !systemSearchParam || !metricSearchParam) {
     return <Loading />;
   }


### PR DESCRIPTION
## Description of the change

The Data page currently shows a chart for the first metric (regardless of whether or not it is enabled/disabled) when a user loads the page. It also does not currently handle a case where no metrics are enabled. This PR allows a user to see the first _enabled_ metric on load, and when no metrics are enabled, the user sees a message with a link to the Metric Configuration page. 

Currently, when there are no metrics enabled, the user just sees a loader that never resolves. Does this new message screen feel jarring or does it feel like it works within this context? Open to all thoughts!

Before:

https://user-images.githubusercontent.com/59492998/231017800-92ea5000-bcad-44ca-a51c-09e0bc247c62.mov

After:

https://user-images.githubusercontent.com/59492998/231018789-fbcb4410-919d-4b7c-9db7-b4031a078868.mov



## Related issues

Closes #523 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
