### PR TITLE
Bulk Publishing: Refactor for UX, code reusability and performance

### DIFF
--- a/common/components/DataViz/DatapointsTableView.styles.tsx
+++ b/common/components/DataViz/DatapointsTableView.styles.tsx
@@ -85,6 +85,23 @@ export const DatapointsMetricNameCell = styled(DatapointsTableNamesCell)`
   line-height: 38px;
   padding: 0 0 31px 0;
 `;
+export const DatapointsMetricNameCellTooltip = styled.div`
+  ${typography.sizeCSS.normal};
+  display: none;
+  position: absolute;
+  z-index: 100;
+  transition: opacity 0s ease-out;
+  background: ${palette.solid.darkgrey};
+  box-shadow: 0px 4px 10px rgba(23, 28, 43, 0.2);
+  border-radius: 5px;
+  opacity: 1;
+  padding: 10px 12px;
+  color: ${palette.solid.white};
+
+  ${DatapointsMetricNameCell}:hover & {
+    display: block;
+  }
+`;
 export const DatapointsTableNamesDivider = styled.td`
   ${typography.sizeCSS.small}
   padding-top: 8px;

--- a/common/components/DataViz/DatapointsTableView.tsx
+++ b/common/components/DataViz/DatapointsTableView.tsx
@@ -24,6 +24,7 @@ import {
 } from "../../types";
 import {
   DatapointsMetricNameCell,
+  DatapointsMetricNameCellTooltip,
   DatapointsTableBottomBorder,
   DatapointsTableContainer,
   DatapointsTableDetailsCell,
@@ -151,6 +152,9 @@ export const DatapointsTableView: React.FC<{
                 <DatapointsTableNamesRow>
                   <DatapointsMetricNameCell title={metricName}>
                     {metricName}
+                    <DatapointsMetricNameCellTooltip>
+                      {metricName}
+                    </DatapointsMetricNameCellTooltip>
                   </DatapointsMetricNameCell>
                 </DatapointsTableNamesRow>
               )}

--- a/publisher/src/components/Reports/BulkActionReview.tsx
+++ b/publisher/src/components/Reports/BulkActionReview.tsx
@@ -51,10 +51,12 @@ const BulkActionReview = () => {
   );
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
   const [publishReviewProps, setPublishReviewProps] =
-    useState<PublishReviewPropsFromDatapoints>(
-      {} as PublishReviewPropsFromDatapoints
-    );
-  const { records, datapointsByMetric, metricsToDisplay } = publishReviewProps;
+    useState<PublishReviewPropsFromDatapoints>();
+  const records = publishReviewProps?.records;
+  const datapointsByMetric = publishReviewProps?.datapointsByMetric;
+  const metricsToDisplay = publishReviewProps?.metricsToDisplay;
+  const hasPublishReviewProps =
+    records && metricsToDisplay && datapointsByMetric;
 
   const publishMultipleRecords = async () => {
     const response = (await reportStore.updateMultipleReportStatuses(
@@ -128,7 +130,7 @@ const BulkActionReview = () => {
 
   // review component props
   const metrics =
-    metricsToDisplay.length > 0
+    hasPublishReviewProps && metricsToDisplay.length > 0
       ? metricsToDisplay.reduce((acc, metric) => {
           const reviewMetric = {
             datapoints: datapointsByMetric[metric.key],
@@ -155,7 +157,7 @@ const BulkActionReview = () => {
     </>
   );
   const unpublishActionDescription = `Here’s a breakdown of data you’ve selected to unpublish. All data in ${
-    records?.length > 1
+    records && records?.length > 1
       ? `these ${REPORTS_LOWERCASE}`
       : `this ${REPORT_LOWERCASE}`
   } will be saved, and you can re-publish at any time.`;

--- a/publisher/src/components/Reports/BulkActionReview.tsx
+++ b/publisher/src/components/Reports/BulkActionReview.tsx
@@ -54,13 +54,7 @@ const BulkActionReview = () => {
     useState<PublishReviewPropsFromDatapoints>(
       {} as PublishReviewPropsFromDatapoints
     );
-  const {
-    records,
-    datapointsByMetric,
-    metricsToDisplay,
-    firstSystemKey,
-    firstMetricKey,
-  } = publishReviewProps;
+  const { records, datapointsByMetric, metricsToDisplay } = publishReviewProps;
 
   const publishMultipleRecords = async () => {
     const response = (await reportStore.updateMultipleReportStatuses(
@@ -184,19 +178,10 @@ const BulkActionReview = () => {
     },
   ];
 
-  // modal props
-  const systemSearchParam = firstSystemKey;
-  const metricSearchParam = firstMetricKey;
-
   return (
     <ReviewWrapper>
       {isSuccessModalOpen && (
-        <ReviewMetricsModal
-          systemSearchParam={systemSearchParam}
-          metricSearchParam={metricSearchParam}
-          recordsCount={recordsIds.length}
-          action={action}
-        />
+        <ReviewMetricsModal recordsCount={recordsIds.length} action={action} />
       )}
       <ReviewMetrics
         title={action === "publish" ? publishActionTitle : unpublishActionTitle}

--- a/publisher/src/components/Reports/BulkActionReview.tsx
+++ b/publisher/src/components/Reports/BulkActionReview.tsx
@@ -109,7 +109,8 @@ const BulkActionReview = () => {
       }
       const combinedDatapointsFromAllReports = reportsWithDatapoints
         ?.map((report) => report.datapoints)
-        .flat();
+        .flat()
+        .filter((dp) => dp.value !== null);
 
       if (combinedDatapointsFromAllReports) {
         setDatapoints(
@@ -144,12 +145,14 @@ const BulkActionReview = () => {
   // review component props
   const datapointsEntries = Object.entries(datapoints);
   const currentSystemKey = datapointsEntries[0][0].split("_")[0]; // get system key via splitting a datapoint's metric key
-  const metricsToDisplay = datapointsEntries.map(([metricKey, datapoint]) => {
-    return {
-      key: metricKey,
-      displayName: datapoint[0].metric_display_name as string,
-    };
-  });
+  const metricsToDisplay = datapointsEntries.map(
+    ([metricKey, metricDatapoints]) => {
+      return {
+        key: metricKey,
+        displayName: metricDatapoints[0].metric_display_name as string,
+      };
+    }
+  );
   const metrics =
     metricsToDisplay.length > 0
       ? metricsToDisplay.reduce((acc, metric) => {

--- a/publisher/src/components/Reports/BulkActionReview.tsx
+++ b/publisher/src/components/Reports/BulkActionReview.tsx
@@ -55,7 +55,7 @@ const BulkActionReview = () => {
       {} as PublishReviewPropsFromDatapoints
     );
   const {
-    reports,
+    records,
     datapointsByMetric,
     metricsToDisplay,
     firstSystemKey,
@@ -161,7 +161,7 @@ const BulkActionReview = () => {
     </>
   );
   const unpublishActionDescription = `Here’s a breakdown of data you’ve selected to unpublish. All data in ${
-    reports?.length > 1
+    records?.length > 1
       ? `these ${REPORTS_LOWERCASE}`
       : `this ${REPORT_LOWERCASE}`
   } will be saved, and you can re-publish at any time.`;
@@ -207,7 +207,7 @@ const BulkActionReview = () => {
         }
         buttons={buttons}
         metrics={metrics}
-        records={reports}
+        records={records}
       />
     </ReviewWrapper>
   );

--- a/publisher/src/components/Reports/BulkActionReview.tsx
+++ b/publisher/src/components/Reports/BulkActionReview.tsx
@@ -16,12 +16,6 @@
 // =============================================================================
 
 import { showToast } from "@justice-counts/common/components/Toast";
-import DatapointsStore from "@justice-counts/common/stores/BaseDatapointsStore";
-import {
-  RawDatapointsByMetric,
-  Report,
-  ReportOverview,
-} from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
@@ -50,20 +44,16 @@ const BulkActionReview = () => {
   const agencyId = Number(params.agencyId);
   const agencyIdString = String(agencyId);
   const navigate = useNavigate();
+  const { reportStore } = useStore();
   const [isLoading, setIsLoading] = useState<boolean>(true);
   const [loadingError, setLoadingError] = useState<string | undefined>(
     undefined
   );
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
-  const { reportStore } = useStore();
-
-  // const [datapoints, setDatapoints] = useState<RawDatapointsByMetric>({});
   const [publishReviewProps, setPublishReviewProps] =
     useState<PublishReviewPropsFromDatapoints>(
       {} as PublishReviewPropsFromDatapoints
     );
-  // const [records, setRecords] = useState<ReportOverview[]>([]);
-
   const {
     reports,
     datapointsByMetric,
@@ -111,11 +101,6 @@ const BulkActionReview = () => {
 
   useEffect(() => {
     const initialize = async () => {
-      // const reportsWithDatapoints =
-      //   (await reportStore.getMultipleReportsWithDatapoints(
-      //     recordsIds,
-      //     agencyIdString
-      //   )) as Report[] | Error;
       const reviewProps = await reportStore.getPublishReviewPropsFromDatapoints(
         recordsIds,
         agencyIdString
@@ -124,20 +109,7 @@ const BulkActionReview = () => {
         setIsLoading(false);
         return setLoadingError(reviewProps.message);
       }
-      // const combinedDatapointsFromAllReports = reportsWithDatapoints
-      //   ?.map((report) => report.datapoints)
-      //   .flat()
-      //   .filter((dp) => dp.value !== null);
-
-      // if (combinedDatapointsFromAllReports) {
-      //   setDatapoints(
-      //     DatapointsStore.keyRawDatapointsByMetric(
-      //       combinedDatapointsFromAllReports
-      //     )
-      //   );
-      // }
       if (reviewProps) setPublishReviewProps(reviewProps);
-      // setRecords(reviewProps.reports);
       setIsLoading(false);
     };
 
@@ -161,16 +133,6 @@ const BulkActionReview = () => {
   }
 
   // review component props
-  // const datapointsEntries = Object.entries(datapoints);
-  // const currentSystemKey = datapointsEntries[0][0].split("_")[0]; // get system key via splitting a datapoint's metric key
-  // const metricsToDisplay = datapointsEntries.map(
-  //   ([metricKey, metricDatapoints]) => {
-  //     return {
-  //       key: metricKey,
-  //       displayName: metricDatapoints[0].metric_display_name as string,
-  //     };
-  //   }
-  // );
   const metrics =
     metricsToDisplay.length > 0
       ? metricsToDisplay.reduce((acc, metric) => {

--- a/publisher/src/components/Reports/DataEntryReview.tsx
+++ b/publisher/src/components/Reports/DataEntryReview.tsx
@@ -49,34 +49,39 @@ const DataEntryReview = () => {
   const checkMetricForErrors = useCheckMetricForErrors(reportID);
 
   const publishReport = async () => {
-    const finalMetricsToPublish =
-      formStore.reportUpdatedValuesForBackend(reportID);
+    if (isPublishable) {
+      setIsPublishable(false);
 
-    const response = (await reportStore.updateReport(
-      reportID,
-      finalMetricsToPublish,
-      "PUBLISHED"
-    )) as Response;
+      const finalMetricsToPublish =
+        formStore.reportUpdatedValuesForBackend(reportID);
 
-    if (response.status === 200) {
-      // For users who have not completed the onboarding flow and are publishing for the first time.
-      if (
-        guidanceStore.currentTopicID === "PUBLISH_DATA" &&
-        !guidanceStore.hasCompletedOnboarding
-      )
-        guidanceStore.updateTopicStatus("PUBLISH_DATA", true);
-      setIsSuccessModalOpen(true);
-      const agencyID = reportStore.reportOverviews[reportID]?.agency_id;
-      const agency = userStore.userAgenciesById[agencyID];
-      trackReportPublished(reportID, finalMetricsToPublish, agency);
-    } else {
-      showToast({
-        message: `Something went wrong publishing the ${printReportTitle(
-          reportStore.reportOverviews[reportID].month,
-          reportStore.reportOverviews[reportID].year,
-          reportStore.reportOverviews[reportID].frequency
-        )} ${REPORT_LOWERCASE}!`,
-      });
+      const response = (await reportStore.updateReport(
+        reportID,
+        finalMetricsToPublish,
+        "PUBLISHED"
+      )) as Response;
+
+      if (response.status === 200) {
+        // For users who have not completed the onboarding flow and are publishing for the first time.
+        if (
+          guidanceStore.currentTopicID === "PUBLISH_DATA" &&
+          !guidanceStore.hasCompletedOnboarding
+        )
+          guidanceStore.updateTopicStatus("PUBLISH_DATA", true);
+        setIsSuccessModalOpen(true);
+        const agencyID = reportStore.reportOverviews[reportID]?.agency_id;
+        const agency = userStore.userAgenciesById[agencyID];
+        trackReportPublished(reportID, finalMetricsToPublish, agency);
+      } else {
+        showToast({
+          message: `Something went wrong publishing the ${printReportTitle(
+            reportStore.reportOverviews[reportID].month,
+            reportStore.reportOverviews[reportID].year,
+            reportStore.reportOverviews[reportID].frequency
+          )} ${REPORT_LOWERCASE}!`,
+        });
+        setIsPublishable(true);
+      }
     }
   };
 

--- a/publisher/src/components/Reports/DataEntryReview.tsx
+++ b/publisher/src/components/Reports/DataEntryReview.tsx
@@ -48,10 +48,10 @@ const DataEntryReview = () => {
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
   const [loadingDatapoints, setLoadingDatapoints] = useState(true);
   const [publishReviewProps, setPublishReviewProps] =
-    useState<PublishReviewPropsFromDatapoints>(
-      {} as PublishReviewPropsFromDatapoints
-    );
-  const { datapointsByMetric, metricsToDisplay } = publishReviewProps;
+    useState<PublishReviewPropsFromDatapoints>();
+  const datapointsByMetric = publishReviewProps?.datapointsByMetric;
+  const metricsToDisplay = publishReviewProps?.metricsToDisplay;
+  const hasPublishReviewProps = metricsToDisplay && datapointsByMetric;
 
   const publishReport = async () => {
     if (isPublishable) {
@@ -138,20 +138,21 @@ const DataEntryReview = () => {
     );
 
   // review component props
-  const metrics = metricsToDisplay
-    ? metricsToDisplay.reduce((acc, metric) => {
-        const reviewMetric = {
-          datapoints: datapointsByMetric[metric.key],
-          display_name: metric.displayName,
-          key: metric.key,
-          metricHasError: checkMetricForErrors(metric.key),
-          metricHasValidInput: Boolean(
-            formStore.metricsValues?.[reportID]?.[metric.key]?.value
-          ),
-        };
-        return [...acc, reviewMetric];
-      }, [] as ReviewMetric[])
-    : [];
+  const metrics =
+    hasPublishReviewProps && metricsToDisplay
+      ? metricsToDisplay.reduce((acc, metric) => {
+          const reviewMetric = {
+            datapoints: datapointsByMetric[metric.key],
+            display_name: metric.displayName,
+            key: metric.key,
+            metricHasError: checkMetricForErrors(metric.key),
+            metricHasValidInput: Boolean(
+              formStore.metricsValues?.[reportID]?.[metric.key]?.value
+            ),
+          };
+          return [...acc, reviewMetric];
+        }, [] as ReviewMetric[])
+      : [];
   const record = reportStore.reportOverviews[reportID];
   const title = "Review & Publish";
   const description = (

--- a/publisher/src/components/Reports/DataEntryReview.tsx
+++ b/publisher/src/components/Reports/DataEntryReview.tsx
@@ -138,21 +138,20 @@ const DataEntryReview = () => {
     );
 
   // review component props
-  const metrics =
-    hasPublishReviewProps && metricsToDisplay
-      ? metricsToDisplay.reduce((acc, metric) => {
-          const reviewMetric = {
-            datapoints: datapointsByMetric[metric.key],
-            display_name: metric.displayName,
-            key: metric.key,
-            metricHasError: checkMetricForErrors(metric.key),
-            metricHasValidInput: Boolean(
-              formStore.metricsValues?.[reportID]?.[metric.key]?.value
-            ),
-          };
-          return [...acc, reviewMetric];
-        }, [] as ReviewMetric[])
-      : [];
+  const metrics = hasPublishReviewProps
+    ? metricsToDisplay.reduce((acc, metric) => {
+        const reviewMetric = {
+          datapoints: datapointsByMetric[metric.key],
+          display_name: metric.displayName,
+          key: metric.key,
+          metricHasError: checkMetricForErrors(metric.key),
+          metricHasValidInput: Boolean(
+            formStore.metricsValues?.[reportID]?.[metric.key]?.value
+          ),
+        };
+        return [...acc, reviewMetric];
+      }, [] as ReviewMetric[])
+    : [];
   const record = reportStore.reportOverviews[reportID];
   const title = "Review & Publish";
   const description = (

--- a/publisher/src/components/Reports/DataEntryReview.tsx
+++ b/publisher/src/components/Reports/DataEntryReview.tsx
@@ -51,12 +51,7 @@ const DataEntryReview = () => {
     useState<PublishReviewPropsFromDatapoints>(
       {} as PublishReviewPropsFromDatapoints
     );
-  const {
-    datapointsByMetric,
-    metricsToDisplay,
-    firstSystemKey,
-    firstMetricKey,
-  } = publishReviewProps;
+  const { datapointsByMetric, metricsToDisplay } = publishReviewProps;
 
   const publishReport = async () => {
     if (isPublishable) {
@@ -189,18 +184,9 @@ const DataEntryReview = () => {
     },
   ];
 
-  // modal props
-  const systemSearchParam = firstSystemKey;
-  const metricSearchParam = firstMetricKey;
-
   return (
     <ReviewWrapper>
-      {isSuccessModalOpen && (
-        <ReviewMetricsModal
-          systemSearchParam={systemSearchParam}
-          metricSearchParam={metricSearchParam}
-        />
-      )}
+      {isSuccessModalOpen && <ReviewMetricsModal />}
       <ReviewMetrics
         title={title}
         description={description}

--- a/publisher/src/components/ReviewMetrics/ReviewMetricsModal.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetricsModal.tsx
@@ -37,8 +37,6 @@ import {
 } from "./ReviewMetrics.styles";
 
 export const ReviewMetricsModal: React.FC<{
-  systemSearchParam?: string;
-  metricSearchParam?: string;
   recordsCount?: number;
   fileName?: string;
   action?: RecordsBulkAction;
@@ -50,8 +48,6 @@ export const ReviewMetricsModal: React.FC<{
     onClick: () => void;
   }[];
 }> = ({
-  systemSearchParam,
-  metricSearchParam,
   recordsCount,
   fileName,
   action,
@@ -62,15 +58,7 @@ export const ReviewMetricsModal: React.FC<{
   const { agencyId } = useParams();
   const navigate = useNavigate();
 
-  const goToDataPage = () => {
-    if (systemSearchParam && metricSearchParam) {
-      navigate(
-        `/agency/${agencyId}/data?system=${systemSearchParam.toLowerCase()}&metric=${metricSearchParam.toLowerCase()}`
-      );
-    } else {
-      navigate(`/agency/${agencyId}/data`);
-    }
-  };
+  const goToDataPage = () => navigate(`/agency/${agencyId}/data`);
 
   return (
     <ReviewPublishModalWrapper>

--- a/publisher/src/components/ReviewMetrics/types.ts
+++ b/publisher/src/components/ReviewMetrics/types.ts
@@ -68,6 +68,6 @@ export type PublishReviewPropsFromDatapoints = {
     key: string;
     displayName: string;
   }[];
-  firstSystemKey: string;
+  firstSystemKey: string | undefined;
   firstMetricKey: string;
 };

--- a/publisher/src/components/ReviewMetrics/types.ts
+++ b/publisher/src/components/ReviewMetrics/types.ts
@@ -20,7 +20,12 @@ import {
   ButtonColor,
   ButtonLabelColor,
 } from "@justice-counts/common/components/Button";
-import { RawDatapoint, ReportOverview } from "@justice-counts/common/types";
+import {
+  RawDatapoint,
+  RawDatapointsByMetric,
+  Report,
+  ReportOverview,
+} from "@justice-counts/common/types";
 import React from "react";
 
 export type ReviewHeaderActionButton = {
@@ -54,4 +59,15 @@ export type ReviewMetricsProps = {
   metrics: ReviewMetric[];
   metricOverwrites?: ReviewMetricOverwrites[];
   records?: ReportOverview[];
+};
+
+export type PublishReviewPropsFromDatapoints = {
+  reports: Report[];
+  datapointsByMetric: RawDatapointsByMetric;
+  metricsToDisplay: {
+    key: string;
+    displayName: string;
+  }[];
+  firstSystemKey: string;
+  firstMetricKey: string;
 };

--- a/publisher/src/components/ReviewMetrics/types.ts
+++ b/publisher/src/components/ReviewMetrics/types.ts
@@ -62,7 +62,7 @@ export type ReviewMetricsProps = {
 };
 
 export type PublishReviewPropsFromDatapoints = {
-  reports: Report[];
+  records: Report[];
   datapointsByMetric: RawDatapointsByMetric;
   metricsToDisplay: {
     key: string;

--- a/publisher/src/components/ReviewMetrics/types.ts
+++ b/publisher/src/components/ReviewMetrics/types.ts
@@ -68,6 +68,4 @@ export type PublishReviewPropsFromDatapoints = {
     key: string;
     displayName: string;
   }[];
-  firstSystemKey: string | undefined;
-  firstMetricKey: string;
 };

--- a/publisher/src/stores/ReportStore.ts
+++ b/publisher/src/stores/ReportStore.ts
@@ -202,6 +202,7 @@ class ReportStore {
           reportIDs,
           currentAgencyId
         )) as Report[] | Error;
+
       if (reportsWithDatapoints instanceof Error) {
         throw new Error(
           `There was an issue retrieving these ${REPORTS_LOWERCASE}.`
@@ -215,7 +216,6 @@ class ReportStore {
       const datapointsByMetric = DatapointsStore.keyRawDatapointsByMetric(
         combinedFilteredDatapointsFromAllReports
       );
-
       const datapointsEntries = Object.entries(datapointsByMetric);
       const metricsToDisplay = datapointsEntries.map(
         ([metricKey, metricDatapoints]) => {

--- a/publisher/src/stores/ReportStore.ts
+++ b/publisher/src/stores/ReportStore.ts
@@ -226,17 +226,19 @@ class ReportStore {
           };
         }
       );
-      const firstSystemKey = this.userStore.userAgencies?.find(
-        (agency) => String(agency.id) === currentAgencyId
-      )?.systems?.[0];
-      const firstMetricKey = metricsToDisplay[0].key;
+      // const firstSystemKey = undefined;
+      // const firstMetricKey = undefined;
+      // const firstSystemKey = this.userStore.userAgencies?.find(
+      //   (agency) => String(agency.id) === currentAgencyId
+      // )?.systems?.[0];
+      // const firstMetricKey = metricsToDisplay[0].key;
 
       return {
         records: reportsWithDatapoints,
         datapointsByMetric,
         metricsToDisplay,
-        firstSystemKey,
-        firstMetricKey,
+        // firstSystemKey,
+        // firstMetricKey,
       };
     } catch (error) {
       if (error instanceof Error) return new Error(error.message);

--- a/publisher/src/stores/ReportStore.ts
+++ b/publisher/src/stores/ReportStore.ts
@@ -226,19 +226,11 @@ class ReportStore {
           };
         }
       );
-      // const firstSystemKey = undefined;
-      // const firstMetricKey = undefined;
-      // const firstSystemKey = this.userStore.userAgencies?.find(
-      //   (agency) => String(agency.id) === currentAgencyId
-      // )?.systems?.[0];
-      // const firstMetricKey = metricsToDisplay[0].key;
 
       return {
         records: reportsWithDatapoints,
         datapointsByMetric,
         metricsToDisplay,
-        // firstSystemKey,
-        // firstMetricKey,
       };
     } catch (error) {
       if (error instanceof Error) return new Error(error.message);

--- a/publisher/src/stores/ReportStore.ts
+++ b/publisher/src/stores/ReportStore.ts
@@ -192,6 +192,7 @@ class ReportStore {
     }
   }
 
+  /** Fetches Reports w/ datapoints and returns necessary props to render the Publish Review pages */
   async getPublishReviewPropsFromDatapoints(
     reportIDs: number[],
     currentAgencyId: string
@@ -225,7 +226,9 @@ class ReportStore {
           };
         }
       );
-      const firstSystemKey = datapointsEntries[0][0].split("_")[0]; // get first system key via splitting a datapoint's metric key
+      const firstSystemKey = this.userStore.userAgencies?.find(
+        (agency) => String(agency.id) === currentAgencyId
+      )?.systems?.[0];
       const firstMetricKey = metricsToDisplay[0].key;
 
       return {

--- a/publisher/src/stores/ReportStore.ts
+++ b/publisher/src/stores/ReportStore.ts
@@ -229,7 +229,7 @@ class ReportStore {
       const firstMetricKey = metricsToDisplay[0].key;
 
       return {
-        reports: reportsWithDatapoints,
+        records: reportsWithDatapoints,
         datapointsByMetric,
         metricsToDisplay,
         firstSystemKey,


### PR DESCRIPTION
## Description of the change

Refactoring the `BulkActionReview` & `DataEntryReview` components to:
* show all metrics that have datapoints in the review page instead of only enabled metrics
* use the datapoints as the source of truth for the list of metrics and everything else needed by the review components
  * this helps efforts to improve performance by minimizing excess calls to the backend
* consolidate similar logic
* render a consistent review page across all review components
* handle no datapoints consistently

Still left to figure out:
* handling Supervision agency with subsystems that have datapoints and the overall Supervision system is combined (it shows the subsystems' data in the review page - maybe this is the right behavior!)

Demo:

https://user-images.githubusercontent.com/59492998/233157121-0e7f5e0f-02ae-443d-a81c-6e0e17275d77.mov



## Related issues

Closes #578
Closes #510

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
