### PR TITLE
Guidance: Gate entire backend call to non-JC admins

### DIFF
--- a/publisher/src/stores/GuidanceStore.ts
+++ b/publisher/src/stores/GuidanceStore.ts
@@ -93,7 +93,7 @@ class GuidanceStore {
   getOnboardingTopicsStatuses = async (
     agencyId: string
   ): Promise<OnboardingTopicsStatuses[]> => {
-    if (this.userStore.isJusticeCountsAdmin(agencyId)) {
+    if (!this.userStore.isJusticeCountsAdmin(agencyId)) {
       /**
        * NOTE:
        * This gates the guidance flow for users who are not JC Admins.

--- a/publisher/src/stores/GuidanceStore.ts
+++ b/publisher/src/stores/GuidanceStore.ts
@@ -93,6 +93,24 @@ class GuidanceStore {
   getOnboardingTopicsStatuses = async (
     agencyId: string
   ): Promise<OnboardingTopicsStatuses[]> => {
+    if (this.userStore.isJusticeCountsAdmin(agencyId)) {
+      /**
+       * NOTE:
+       * This gates the guidance flow for users who are not JC Admins.
+       * If you are not a JC Admin, your guidance progress is marked as completed for all topics.
+       * If you are a JC Admin, your guidance progress is based on your actual guidance progress from the DB.
+       *
+       * TODO(#496) ungate guidance flow for all users
+       */
+
+      runInAction(() => {
+        this.onboardingTopicsStatuses = {
+          WELCOME: true,
+        };
+      });
+      return [];
+    }
+
     const response = (await this.api.request({
       path: `/api/users/agencies/${agencyId}/guidance`,
       method: "GET",
@@ -111,17 +129,7 @@ class GuidanceStore {
     runInAction(() => {
       this.onboardingTopicsStatuses =
         onboardingTopicsStatuses.guidance_progress.reduce((acc, topic) => {
-          /**
-           * NOTE:
-           * This gates the guidance flow for users who are not JC Admins.
-           * If you are not a JC Admin, your guidance progress is marked as completed for all topics.
-           * If you are a JC Admin, your guidance progress is based on your actual guidance progress from the DB.
-           *
-           * TODO(#496) ungate guidance flow for all users
-           */
-          acc[topic.topicID] = !this.userStore.isJusticeCountsAdmin(agencyId)
-            ? true
-            : topic.topicCompleted;
+          acc[topic.topicID] = topic.topicCompleted;
           return acc;
         }, {} as { [topicID: string]: boolean });
       this.isInitialized = true;


### PR DESCRIPTION
## Description of the change

Gates the entire backend call for non-JC admins as opposed to overwriting the completion boolean on each topic. 

* Non-JC-admins will not go through the guidance flow and the app will not make a call to the guidance endpoint
* JC-admins will go through the guidance flow based on their guidance status in the DB

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
