### PR TITLE
Remove supported type `.csv` from the Bulk Upload home screen

### DIFF
--- a/publisher/src/components/DataUpload/UploadFile.tsx
+++ b/publisher/src/components/DataUpload/UploadFile.tsx
@@ -159,7 +159,7 @@ export const UploadFile: React.FC<UploadFileProps> = ({
               Browse
             </UploadButtonLabel>
           </span>
-          <span style={{ opacity: 0.5 }}>Files type: .csv, .xls, .xlsx</span>
+          <span style={{ opacity: 0.5 }}>Files type: .xls, .xlsx</span>
         </div>
       </DragDropContainer>
     </UploadFileContainer>


### PR DESCRIPTION
## Description of the change

Removes `.csv` from supported file types within the Bulk Upload page.

<img width="1728" alt="Screenshot 2023-04-24 at 4 32 26 PM" src="https://user-images.githubusercontent.com/59492998/234121541-2b0fa76e-715a-42ba-9b9d-b19368286cd0.png">

## Related issues

Closes #583 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
