### PR TITLE
Bulk Publishing: Follow Ups - Small Styling Adjustments

### DIFF
--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
@@ -44,7 +44,7 @@ export const Container = styled(DataUploadContainer)`
 export const ReviewMetricsWrapper = styled.div<{ hasNoDatapoints: boolean }>`
   ${({ hasNoDatapoints }) => hasNoDatapoints && `height: 100%;`}
   max-width: 100%;
-  padding: 40px 0 128px 520px;
+  padding: 40px 0 128px 500px;
   display: flex;
   flex-direction: row;
   gap: 88px;
@@ -70,7 +70,7 @@ export const Summary = styled.div<{ isFooterVisible?: boolean }>`
   transition: max-height 0.5s ease-in-out;
 
   padding-left: 24px;
-  width: 400px;
+  width: 380px;
   display: flex;
   flex-direction: column;
   background-color: ${palette.solid.white};

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
@@ -267,6 +267,7 @@ export const ReviewPublishModalIcon = styled.img`
   margin-bottom: 24px;
 `;
 export const ReviewPublishModalTitle = styled(RemoveRecordsModalTitle)`
+  text-align: center;
   span {
     color: ${palette.solid.blue};
   }

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
@@ -44,7 +44,7 @@ export const Container = styled(DataUploadContainer)`
 export const ReviewMetricsWrapper = styled.div<{ hasNoDatapoints: boolean }>`
   ${({ hasNoDatapoints }) => hasNoDatapoints && `height: 100%;`}
   max-width: 100%;
-  padding: 40px 0 128px 612px;
+  padding: 40px 0 128px 520px;
   display: flex;
   flex-direction: row;
   gap: 88px;
@@ -70,7 +70,7 @@ export const Summary = styled.div<{ isFooterVisible?: boolean }>`
   transition: max-height 0.5s ease-in-out;
 
   padding-left: 24px;
-  width: 500px;
+  width: 400px;
   display: flex;
   flex-direction: column;
   background-color: ${palette.solid.white};

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
@@ -190,7 +190,7 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
           {records && records.length > 0 && (
             <SummarySection>
               <SummarySectionTitle
-                color="grey"
+                color="orange"
                 onClick={() =>
                   setIsRecordsSectionExpanded(!isRecordsSectionExpanded)
                 }


### PR DESCRIPTION
## Description of the change

Makes the following styling adjustments:
* Centers text in the success modal after publishing an uploaded spreadsheet
  * Before:
  * <img width="528" alt="Screenshot 2023-04-25 at 5 42 05 PM" src="https://user-images.githubusercontent.com/59492998/234424097-4e447061-4f1e-4349-b037-a2a74bc3e839.png">
  * After:
  * <img width="528" alt="Screenshot 2023-04-25 at 5 41 53 PM" src="https://user-images.githubusercontent.com/59492998/234424100-4177cc93-c9fa-4dd9-a92c-3d7e95e9fd33.png">

---

* Reduces left panel width within the review page (where the list of metrics and reports live)
  * Before:
  * <img width="528" alt="Screenshot 2023-04-25 at 5 51 46 PM" src="https://user-images.githubusercontent.com/59492998/234424626-34672b8b-122a-4e66-89b0-b9fed3b7f0a7.png">
  * After:
  * <img width="528" alt="Screenshot 2023-04-25 at 5 54 20 PM" src="https://user-images.githubusercontent.com/59492998/234424624-e2aaaf47-b8e9-45d0-a7df-37263b8affe1.png">
</div>

---

* Update # Record header with orange text color
  * Before:
  * <img width="328" alt="Screenshot 2023-04-25 at 5 34 43 PM" src="https://user-images.githubusercontent.com/59492998/234424856-583e3c74-9192-4985-a8c5-c2a24778c282.png">
  * After:
  * <img width="328" alt="Screenshot 2023-04-25 at 5 39 36 PM" src="https://user-images.githubusercontent.com/59492998/234424896-b6d2af8f-22a4-4b60-a447-5d7bd762a66c.png">

## Related issues

Closes #586 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
