### PR TITLE
Bulk Publishing: Follow Ups - Match order of metrics list in Data Entry and Publish Review pages

### DIFF
--- a/publisher/src/components/Reports/DataEntryForm.tsx
+++ b/publisher/src/components/Reports/DataEntryForm.tsx
@@ -256,6 +256,10 @@ const DataEntryForm: React.FC<{
   const reportOverview = reportStore.reportOverviews[reportID] as Report;
   const reportMetrics = reportStore.reportMetrics[reportID];
   const metricsBySystem = reportStore.reportMetricsBySystem[reportID];
+  // We'll use metricDisplayNames as a reference to sort the publish review page's list of metrics so they both match
+  const metricDisplayNames = Object.values(metricsBySystem)
+    .flat()
+    .map((metric) => metric.display_name);
   const showMetricSectionTitles = Object.keys(metricsBySystem).length > 1;
 
   if (!reportOverview || !reportMetrics) {
@@ -310,7 +314,13 @@ const DataEntryForm: React.FC<{
               )}
               <Button
                 label="Review"
-                onClick={() => navigate("review")}
+                onClick={() =>
+                  navigate("review", {
+                    state: {
+                      metricDisplayNames,
+                    },
+                  })
+                }
                 buttonColor="blue"
                 disabled={isSaveInProgress}
               />

--- a/publisher/src/components/Reports/DataEntryReview.tsx
+++ b/publisher/src/components/Reports/DataEntryReview.tsx
@@ -154,6 +154,7 @@ const DataEntryReview = () => {
           };
           return [...acc, reviewMetric];
         }, [] as ReviewMetric[])
+        // Sort this list of metrics so it matches the order of the metrics list on the data entry page
         .sort(
           (a, b) =>
             metricDisplayNames.indexOf(a.display_name) -

--- a/publisher/src/stores/ReportStore.ts
+++ b/publisher/src/stores/ReportStore.ts
@@ -210,15 +210,12 @@ class ReportStore {
         );
       }
 
-      const combinedFilteredSortedDatapointsFromAllReports =
-        reportsWithDatapoints
-          ?.map((report) => report.datapoints)
-          .flat()
-          // sorting by `id` allows the list of metrics rendered in the data entry page to match the review page
-          .sort((a, b) => a.id - b.id)
-          .filter((dp) => dp.value !== null);
+      const combinedFilteredDatapointsFromAllReports = reportsWithDatapoints
+        ?.map((report) => report.datapoints)
+        .flat()
+        .filter((dp) => dp.value !== null);
       const datapointsByMetric = DatapointsStore.keyRawDatapointsByMetric(
-        combinedFilteredSortedDatapointsFromAllReports
+        combinedFilteredDatapointsFromAllReports
       );
       const datapointsEntries = Object.entries(datapointsByMetric);
       const metricsToDisplay = datapointsEntries.map(

--- a/publisher/src/stores/ReportStore.ts
+++ b/publisher/src/stores/ReportStore.ts
@@ -210,13 +210,15 @@ class ReportStore {
         );
       }
 
-      const combinedFilteredDatapointsFromAllReports = reportsWithDatapoints
-        ?.map((report) => report.datapoints)
-        .flat()
-        .sort((a, b) => a.id - b.id)
-        .filter((dp) => dp.value !== null);
+      const combinedFilteredSortedDatapointsFromAllReports =
+        reportsWithDatapoints
+          ?.map((report) => report.datapoints)
+          .flat()
+          // sorting by `id` allows the list of metrics rendered in the data entry page to match the review page
+          .sort((a, b) => a.id - b.id)
+          .filter((dp) => dp.value !== null);
       const datapointsByMetric = DatapointsStore.keyRawDatapointsByMetric(
-        combinedFilteredDatapointsFromAllReports
+        combinedFilteredSortedDatapointsFromAllReports
       );
       const datapointsEntries = Object.entries(datapointsByMetric);
       const metricsToDisplay = datapointsEntries.map(

--- a/publisher/src/stores/ReportStore.ts
+++ b/publisher/src/stores/ReportStore.ts
@@ -213,6 +213,7 @@ class ReportStore {
       const combinedFilteredDatapointsFromAllReports = reportsWithDatapoints
         ?.map((report) => report.datapoints)
         .flat()
+        .sort((a, b) => a.id - b.id)
         .filter((dp) => dp.value !== null);
       const datapointsByMetric = DatapointsStore.keyRawDatapointsByMetric(
         combinedFilteredDatapointsFromAllReports


### PR DESCRIPTION
## Description of the change

Sorts the list of metrics on the publish review page to match the order of the metrics list in the data entry page. 
[Thank you Michelle & Lili for unblocking me w/ your great suggestions!]

https://user-images.githubusercontent.com/59492998/234736512-7533099b-e1dd-4cbe-bd64-944377b3fbc7.mov

## Related issues

Closes #590

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
