### PR TITLE
[Bug] Clicking on Data link while in the Data page does not reload the page

### DIFF
--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -276,7 +276,7 @@ const Menu: React.FC = () => {
         {/* Data (Visualizations) */}
         <MenuItem
           onClick={() => {
-            navigate("data");
+            if (pathWithoutAgency !== "data") navigate("data");
             handleCloseMobileMenu();
           }}
           active={pathWithoutAgency === "data"}


### PR DESCRIPTION
## Description of the change

**Issue**: when you are on the `Data` page and you click on the `Data` link, you're redirected to the `Data` page with no query params, and will encounter the "There are no enabled metrics to view. Please go to Metric Configuration to enable a metric."

This is more/less a temporary fix - ~I need to dig deeper to figure out why things don't appear to be reinitializing~ (see below conversation). We're basically taking no action if a user is already on the page, and clicking on the link - which might be good to do anyway because doing a reinitialization seems excessive and not entirely necessary. Open to thoughts!


https://user-images.githubusercontent.com/59492998/235522899-898981cb-3773-434e-835a-4ead01e782ee.mov

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
