### PR TITLE
Bulk Upload: sanitize uploaded file name

### DIFF
--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -129,8 +129,9 @@ export const DataUpload: React.FC = observer(() => {
   ): Promise<void> => {
     if (file && system && agencyId) {
       setSelectedFile(file);
-      // Replaces () parentheses - opening parenthesis '(' becomes '_' and closing parenthesis is removed
+      // Removes extra spacing and replaces () parentheses - opening parenthesis '(' becomes '_' and closing parenthesis is removed
       const sanitizedFileName = file.name
+        .replaceAll(" ", "")
         .replaceAll("(", "_")
         .replaceAll(")", "");
 

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -129,9 +129,14 @@ export const DataUpload: React.FC = observer(() => {
   ): Promise<void> => {
     if (file && system && agencyId) {
       setSelectedFile(file);
+      // Replaces () parentheses - opening parenthesis '(' becomes '_' and closing parenthesis is removed
+      const sanitizedFileName = file.name
+        .replaceAll("(", "_")
+        .replaceAll(")", "");
+
       const formData = new FormData();
       formData.append("file", file);
-      formData.append("name", file.name);
+      formData.append("name", sanitizedFileName);
       formData.append("system", system);
       formData.append("ingest_on_upload", "True");
       formData.append("agency_id", agencyId);


### PR DESCRIPTION
## Description of the change

Removes parenthesis from uploaded file name and replaces opening parenthesis with an `_` underscore and removes the closing parenthesis entirely. This takes care of the PHP WAF rule that kept triggering for file names with more than one set of parentheses.

Open to suggestions if you have other formatting ideas! I originally had a regex match and replace all parenthesis with a `_` but that made a file like `HELLO (1)(2).xlsx` become `HELLO _1__2_.xlsx` - which felt too strange. With these changes, the `HELLO (1)(2).xlsx` file name becomes `HELLO_1_2.xlsx`

## Related issues

Closes #594 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
