### PR TITLE
[Justice Counts] get reports for child agencies before publish

### DIFF
--- a/publisher/src/components/DataUpload/UploadReview.tsx
+++ b/publisher/src/components/DataUpload/UploadReview.tsx
@@ -19,7 +19,7 @@ import { ButtonColor } from "@justice-counts/common/components/Button";
 import { showToast } from "@justice-counts/common/components/Toast";
 import { ReportOverview } from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import {
   Navigate,
   useLocation,
@@ -54,6 +54,19 @@ const UploadReview: React.FC = observer(() => {
     updatedReportIDs: number[];
     unchangedReportIDs: number[];
   };
+  useEffect(() => {
+    const getAllRelevantReports = async () => {
+      reportStore.resetState();
+      if (agencyId !== undefined) {
+        await reportStore.getReportOverviews(
+          /* agencyId */ agencyId?.toString(),
+          /* includeChildAgencies */ true
+        );
+      }
+    };
+    getAllRelevantReports();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
   const navigate = useNavigate();
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
   const [isExistingReportWarningModalOpen, setExistingReportWarningOpen] =

--- a/publisher/src/stores/ReportStore.ts
+++ b/publisher/src/stores/ReportStore.ts
@@ -110,10 +110,17 @@ class ReportStore {
     });
   }
 
-  async getReportOverviews(agencyId: string): Promise<void | Error> {
+  async getReportOverviews(
+    agencyId: string,
+    includeChildAgencies?: boolean
+  ): Promise<void | Error> {
+    let path = `/api/agencies/${agencyId}/reports`;
+    if (includeChildAgencies === true) {
+      path += "?includeChildAgencies=true";
+    }
     try {
       const response = (await this.api.request({
-        path: `/api/agencies/${agencyId}/reports`,
+        path,
         method: "GET",
       })) as Response;
       if (response.status === 200) {


### PR DESCRIPTION
## Description of the change

I was debugging why I wasn't able to publish the child agency reports from the super agency bulk upload metric review page and it turns out that they were not in the `ReportStore` because we only fetch the reports by the id of the current agency. I made a change here where we request the reports again at the data review page. This is another call to the BE, and another transaction with the DB. 

I tried to return them all at once when we populate the report store initially, but then the records overview page had 5x the original records because it included the records of the super agency  _and_ the child agencies.  

We could reduce the number of calls to the BE if the BE sends all records for the child agencies + super agencies whenever we went to fetch the records for a super agency. The response would key reports by the agency id / name. On the records overview page, the records could be sorted by super agency with some simple labels or we could only show the records created for the super agency. This refactor will probably break other parts of the FE as well. Alternatively, the FE can do this grouping.


## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Closes #XXXX

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
