### PR TITLE
Disable Guidance flow for all users

### DIFF
--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -182,7 +182,7 @@ const Menu: React.FC = () => {
   useEffect(() => {
     const initOnboardingTopicStatuses = async () => {
       // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      await guidanceStore.getOnboardingTopicsStatuses(agencyId);
+      await guidanceStore.getOnboardingTopicsStatuses();
     };
 
     initOnboardingTopicStatuses();

--- a/publisher/src/stores/GuidanceStore.ts
+++ b/publisher/src/stores/GuidanceStore.ts
@@ -90,51 +90,23 @@ class GuidanceStore {
     return topicID;
   }
 
-  getOnboardingTopicsStatuses = async (
-    agencyId: string
-  ): Promise<OnboardingTopicsStatuses[]> => {
-    if (!this.userStore.isJusticeCountsAdmin(agencyId)) {
-      /**
-       * NOTE:
-       * This gates the guidance flow for users who are not JC Admins.
-       * If you are not a JC Admin, your guidance progress is marked as completed for all topics.
-       * If you are a JC Admin, your guidance progress is based on your actual guidance progress from the DB.
-       *
-       * TODO(#496) ungate guidance flow for all users
-       */
-
-      runInAction(() => {
-        this.onboardingTopicsStatuses = {
-          WELCOME: true,
-        };
-      });
-      return [];
-    }
-
-    const response = (await this.api.request({
-      path: `/api/users/agencies/${agencyId}/guidance`,
-      method: "GET",
-    })) as Response;
-
-    if (response.status !== 200) {
-      throw new Error(
-        "There was an issue retrieving the onboarding topics statuses."
-      );
-    }
-
-    const onboardingTopicsStatuses: {
-      guidance_progress: OnboardingTopicsStatuses[];
-    } = await response.json();
+  getOnboardingTopicsStatuses = async (): Promise<
+    OnboardingTopicsStatuses[]
+  > => {
+    /**
+     * NOTE:
+     * This gates the guidance flow for all users.
+     * We will eventually remove this entire iteration of guidance.
+     *
+     * TODO(#621) deprecate current guidance flow
+     */
 
     runInAction(() => {
-      this.onboardingTopicsStatuses =
-        onboardingTopicsStatuses.guidance_progress.reduce((acc, topic) => {
-          acc[topic.topicID] = topic.topicCompleted;
-          return acc;
-        }, {} as { [topicID: string]: boolean });
-      this.isInitialized = true;
+      this.onboardingTopicsStatuses = {
+        WELCOME: true,
+      };
     });
-    return onboardingTopicsStatuses.guidance_progress;
+    return [];
   };
 
   saveOnboardingTopicsStatuses = async (


### PR DESCRIPTION
## Description of the change

Disabling the current guidance flow for all users as it's not currently being used/referenced. A task has been made to fully deprecate this (#621) - but I wasn't sure if that was necessary just yet.

## Related issues

Closes #XXXX

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
