### PR TITLE
Metric Config: Hide "Show All" button for metrics that only have one breakdown

### DIFF
--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -420,19 +420,21 @@ function MetricAvailability() {
                 disaggregations of {metrics[systemMetricKey]?.label}.
               </Styled.BreakdownsSectionDescription>
               <Styled.BreakdownsOptionsContainer>
-                <Styled.BreakdownsOption
-                  onClick={() => setActiveDisaggregationKey(undefined)}
-                  active={!activeDisaggregationKey}
-                >
-                  Show all
-                </Styled.BreakdownsOption>
+                {disaggregationsOptions.length > 1 && (
+                  <Styled.BreakdownsOption
+                    onClick={() => setActiveDisaggregationKey(undefined)}
+                    active={!activeDisaggregationKey}
+                  >
+                    Show all
+                  </Styled.BreakdownsOption>
+                )}
                 {disaggregationsOptions &&
                   disaggregationsOptions.map(
                     ({ key, label, onClick, active }) => (
                       <Styled.BreakdownsOption
                         key={key}
                         onClick={onClick}
-                        active={active}
+                        active={active || disaggregationsOptions.length === 1}
                       >
                         {label}
                       </Styled.BreakdownsOption>


### PR DESCRIPTION
## Description of the change

Hides "Show All" button for metrics that only have one breakdown

https://github.com/Recidiviz/justice-counts/assets/59492998/908175f4-0028-4088-9ec1-7a3dbb9bcea2

## Related issues

Closes #619 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
