### PR TITLE
Metric Config: Render multiple includes-excludes descriptions

### DIFF
--- a/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
+++ b/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
@@ -382,27 +382,36 @@ function DefinitionModalForm({
             <Styled.IncludesExcludesContainer>
               {Object.entries(currentSettings).map(
                 ([includesExcludesKey, value]) => {
-                  return Object.entries(value.settings).map(
-                    ([settingKey, setting]) => {
-                      return (
-                        <Styled.IncludeExclude
-                          key={settingKey}
-                          onClick={() =>
-                            handleChangeDefinitionIncluded(
-                              includesExcludesKey,
-                              settingKey
-                            )
-                          }
-                        >
-                          {setting.included === "Yes" ? (
-                            <Styled.EnabledIcon src={blueCheckIcon} alt="" />
-                          ) : (
-                            <Styled.DisabledIcon />
-                          )}
-                          {setting.label}
-                        </Styled.IncludeExclude>
-                      );
-                    }
+                  return (
+                    <>
+                      {includesExcludesKey !== "NO_DESCRIPTION" &&
+                        includesExcludesKey}
+                      {Object.entries(value.settings).map(
+                        ([settingKey, setting]) => {
+                          return (
+                            <Styled.IncludeExclude
+                              key={settingKey}
+                              onClick={() =>
+                                handleChangeDefinitionIncluded(
+                                  includesExcludesKey,
+                                  settingKey
+                                )
+                              }
+                            >
+                              {setting.included === "Yes" ? (
+                                <Styled.EnabledIcon
+                                  src={blueCheckIcon}
+                                  alt=""
+                                />
+                              ) : (
+                                <Styled.DisabledIcon />
+                              )}
+                              {setting.label}
+                            </Styled.IncludeExclude>
+                          );
+                        }
+                      )}
+                    </>
                   );
                 }
               )}

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -375,11 +375,7 @@ class MetricConfigStore {
       system,
       metricKey
     );
-    // console.log("WTF", includesExcludesKey);
-    // console.log(
-    //   "WTF",
-    //   JSON.stringify(this.metricDefinitionSettings[systemMetricKey], null, 2)
-    // );
+
     /** Initialize nested objects for quick lookup and update and reduce re-renders */
     if (!this.metricDefinitionSettings[systemMetricKey]) {
       this.metricDefinitionSettings[systemMetricKey] = {};

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -264,7 +264,7 @@ class MetricConfigStore {
             this.initializeMetricDefinitionSetting(
               metric.system.key,
               metric.key,
-              includesExcludes.description,
+              includesExcludes.description || "NO_DESCRIPTION",
               includesExcludes.settings
             );
           });
@@ -328,7 +328,7 @@ class MetricConfigStore {
                   metric.key,
                   disaggregation.key,
                   dimension.key,
-                  includesExcludes.description,
+                  includesExcludes.description || "NO_DESCRIPTION",
                   includesExcludes.settings
                 );
               });
@@ -375,7 +375,11 @@ class MetricConfigStore {
       system,
       metricKey
     );
-
+    // console.log("WTF", includesExcludesKey);
+    // console.log(
+    //   "WTF",
+    //   JSON.stringify(this.metricDefinitionSettings[systemMetricKey], null, 2)
+    // );
     /** Initialize nested objects for quick lookup and update and reduce re-renders */
     if (!this.metricDefinitionSettings[systemMetricKey]) {
       this.metricDefinitionSettings[systemMetricKey] = {};


### PR DESCRIPTION
## Description of the change

Adds back the rendering of the descriptions for multiple includes/excludes and updates the key for the includes/excludes that have no descriptions from "null" to "NO_DESCRIPTION".

Before:
<img width="728" alt="Screenshot 2023-05-09 at 12 17 30 PM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/a80ba840-3cc3-4ee2-925c-7649d2a6014e">

After:

https://github.com/Recidiviz/justice-counts/assets/59492998/900e5b87-0bfa-46c6-9ebe-fce9eecea2cb




## Related issues

Closes #624, [#20517](https://github.com/Recidiviz/recidiviz-data/issues/20517)

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
