### PR TITLE
Bulk Upload: Render warnings (if any) for metrics that will not be uploaded

### DIFF
--- a/publisher/src/components/DataUpload/DataUpload.styles.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.styles.tsx
@@ -137,7 +137,7 @@ export const ErrorWarningButtonWrapper = styled(ButtonWrapper)`
   width: 100%;
   justify-content: space-between;
 
-  div:not(:last-child) {
+  div:not(:last-child) > div {
     background: transparent;
     border: 1px solid ${palette.highlight.grey4};
     border-radius: 4px;
@@ -147,7 +147,7 @@ export const ErrorWarningButtonWrapper = styled(ButtonWrapper)`
     }
   }
 
-  div:last-child {
+  div:last-child > div {
     background: ${palette.solid.blue};
     color: ${palette.solid.white};
 

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -260,6 +260,26 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
               (metric) => (
                 <Message key={metric.key} enabled={metric.enabled}>
                   <MetricTitle>{metric.display_name}</MetricTitle>
+                  {metric.metric_errors.map((sheet) => (
+                    <Fragment key={sheet.display_name + sheet.sheet_name}>
+                      {sheet.messages.map((message) => (
+                        <Fragment key={message.title + message.description}>
+                          <IconWrapper>
+                            <WarningIcon />
+                            <MessageBody>
+                              <MessageTitle>{message.title}</MessageTitle>
+                              <MessageSubtitle>
+                                {message.subtitle}
+                              </MessageSubtitle>
+                            </MessageBody>
+                          </IconWrapper>
+                          <MessageDescription>
+                            {message.description}
+                          </MessageDescription>
+                        </Fragment>
+                      ))}
+                    </Fragment>
+                  ))}
                 </Message>
               )
             )}


### PR DESCRIPTION
## Description of the change

Renders any captured warnings for metrics in the `notUploadedMetrics` category (these are any metrics that have no errors and no datapoints).

https://github.com/Recidiviz/justice-counts/assets/59492998/d73a2db6-a866-4fb1-ab81-16cad3b9f5f6

Side mission: fix the button styling (both were showing up blue, with the "New Upload" having a grey border)

## Related issues

Closes [#20733](https://github.com/Recidiviz/recidiviz-data/issues/20733)

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
