### PR TITLE
[Fix] Restrict editing Supervision Populations to admins

### DIFF
--- a/publisher/src/components/Settings/AgencySettingsSupervisions.tsx
+++ b/publisher/src/components/Settings/AgencySettingsSupervisions.tsx
@@ -55,13 +55,15 @@ export const AgencySettingsSupervisions: React.FC<{
   const { isSettingInEditMode, openSetting, removeEditMode } = settingProps;
 
   const { agencyId } = useParams() as { agencyId: string };
-  const { agencyStore } = useStore();
+  const { agencyStore, userStore } = useStore();
   const { currentAgencySystems, updateAgencySystems, saveAgencySystems } =
     agencyStore;
   const [supervisionSystemsToSave, setSupervisionSystemsToSave] =
     useState(currentAgencySystems);
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
-
+  const isAdmin =
+    userStore.isAgencyAdmin(agencyId) ||
+    userStore.isJusticeCountsAdmin(agencyId);
   const systemsToDisplayInReadMode = supervisionAgencySystems.filter((system) =>
     currentAgencySystems?.includes(system.value)
   );
@@ -188,19 +190,21 @@ export const AgencySettingsSupervisions: React.FC<{
             No supervision populations selected.
           </AgencyInfoBlockDescription>
         )}
-        <EditButtonContainer hasTopMargin>
-          <Button
-            label={
-              <>
-                Edit populations <EditArrowImage src={rightArrow} alt="" />
-              </>
-            }
-            onClick={openSetting}
-            labelColor="blue"
-            noSidePadding
-            noHover
-          />
-        </EditButtonContainer>
+        {isAdmin && (
+          <EditButtonContainer hasTopMargin>
+            <Button
+              label={
+                <>
+                  Edit populations <EditArrowImage src={rightArrow} alt="" />
+                </>
+              }
+              onClick={openSetting}
+              labelColor="blue"
+              noSidePadding
+              noHover
+            />
+          </EditButtonContainer>
+        )}
       </AgencySettingsBlock>
     </>
   );


### PR DESCRIPTION
## Description of the change

Gates the `Edit populations` button to users who are not admins (AGENCY_ADMIN or JUSTICE_COUNTS_ADMIN).

While we wait to do a more thorough audit - I figured we could at the very last gate this to resolve the error that was brought up.

Demo: https://mahmoudtest---justice-counts-web-qqec6jbn6a-uc.a.run.app/ (feel free to use a non admin account/adjust your role in staging admin panel)

## Related issues

Contributes to #628 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
