### PR TITLE
Context values within includes/excludes should "count" as configuring

### DIFF
--- a/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
+++ b/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
@@ -384,7 +384,7 @@ function DefinitionModalForm({
               {Object.entries(currentSettings).map(
                 ([includesExcludesKey, value]) => {
                   return (
-                    <>
+                    <Fragment key={includesExcludesKey}>
                       {includesExcludesKey !== "NO_DESCRIPTION" &&
                         includesExcludesKey}
                       {Object.entries(value.settings).map(
@@ -412,7 +412,7 @@ function DefinitionModalForm({
                           );
                         }
                       )}
-                    </>
+                    </Fragment>
                   );
                 }
               )}

--- a/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
@@ -59,6 +59,7 @@ function MetricDefinitions() {
     ).reduce((acc, metricSetting) => {
       return { ...acc, ...metricSetting.settings };
     }, {} as { [settingKey: string]: Partial<MetricConfigurationSettings> });
+    /** Top-level metric context key will always be "INCLUDES_EXCLUDES_DESCRIPTION" */
     const hasContextValue = Boolean(
       contexts[systemMetricKey].INCLUDES_EXCLUDES_DESCRIPTION.value
     );
@@ -152,8 +153,15 @@ function MetricDefinitions() {
                   const dimensionContext =
                     dimensionContexts[systemMetricKey][disaggregationKey][key];
                   const hasContext = Boolean(dimensionContext);
+                  /**
+                   * Dimension-level context key will be either "INCLUDES_EXCLUDES_DESCRIPTION"
+                   * for general context descriptions or "ADDITIONAL_CONTEXT" for the "Other" dimensions' context
+                   */
                   const hasContextValue = hasContext
-                    ? Boolean(Object.values(dimensionContext)[0].value)
+                    ? Boolean(
+                        dimensionContext.INCLUDES_EXCLUDES_DESCRIPTION?.value ||
+                          dimensionContext.ADDITIONAL_CONTEXT?.value
+                      )
                     : false;
 
                   if (

--- a/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
@@ -50,6 +50,7 @@ function MetricDefinitions() {
   const activeDisaggregationKeys =
     disaggregations[systemMetricKey] &&
     Object.keys(disaggregations[systemMetricKey]);
+
   const metricHasDefinitionSelected = () => {
     if (!metricDefinitionSettings[systemMetricKey]) return true;
     const metricSettings = Object.values(

--- a/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
@@ -136,7 +136,7 @@ function MetricDefinitions() {
                   {currentDisaggregation.display_name}
                 </Styled.SectionTitle>
                 {currentEnabledDimensions.map(([key, dimension]) => {
-                  let hasEnabledDefinition: boolean;
+                  let hasEnabledDefinition = false;
                   const currentDimensionDefinitionSettings =
                     dimensionDefinitionSettings[systemMetricKey][
                       disaggregationKey
@@ -156,19 +156,19 @@ function MetricDefinitions() {
                     (!hasSettings && hasContext && hasContextValue)
                   ) {
                     hasEnabledDefinition = true;
-                  } else {
-                    const dimensionSettings =
-                      hasSettings &&
-                      Object.values(currentDimensionDefinitionSettings).reduce(
-                        (acc, dimensionSetting) => {
-                          return { ...acc, ...dimensionSetting.settings };
-                        },
-                        {} as {
-                          [
-                            settingKey: string
-                          ]: Partial<MetricConfigurationSettings>;
-                        }
-                      );
+                  } else if (hasSettings) {
+                    const dimensionSettings = Object.values(
+                      currentDimensionDefinitionSettings
+                    ).reduce(
+                      (acc, dimensionSetting) => {
+                        return { ...acc, ...dimensionSetting.settings };
+                      },
+                      {} as {
+                        [
+                          settingKey: string
+                        ]: Partial<MetricConfigurationSettings>;
+                      }
+                    );
                     hasEnabledDefinition = !!Object.values(
                       dimensionSettings
                     ).find(

--- a/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
@@ -52,6 +52,7 @@ function MetricDefinitions() {
     Object.keys(disaggregations[systemMetricKey]);
 
   const metricHasDefinitionSelected = () => {
+    /** Top-level Metric Definitions */
     if (!metricDefinitionSettings[systemMetricKey]) return true;
     const metricSettings = Object.values(
       metricDefinitionSettings[systemMetricKey]
@@ -61,8 +62,11 @@ function MetricDefinitions() {
     const hasContextValue = Boolean(
       contexts[systemMetricKey].INCLUDES_EXCLUDES_DESCRIPTION.value
     );
-    return !!Object.values(metricSettings).find(
-      (setting) => setting.included === "Yes" || hasContextValue
+    return (
+      hasContextValue ||
+      !!Object.values(metricSettings).find(
+        (setting) => setting.included === "Yes"
+      )
     );
   };
 
@@ -135,6 +139,7 @@ function MetricDefinitions() {
                 <Styled.SectionTitle>
                   {currentDisaggregation.display_name}
                 </Styled.SectionTitle>
+                {/* Dimension-level Definitions */}
                 {currentEnabledDimensions.map(([key, dimension]) => {
                   let hasEnabledDefinition = false;
                   const currentDimensionDefinitionSettings =
@@ -169,11 +174,11 @@ function MetricDefinitions() {
                         ]: Partial<MetricConfigurationSettings>;
                       }
                     );
-                    hasEnabledDefinition = !!Object.values(
-                      dimensionSettings
-                    ).find(
-                      (setting) => setting.included === "Yes" || hasContextValue
-                    );
+                    hasEnabledDefinition =
+                      hasContextValue ||
+                      !!Object.values(dimensionSettings).find(
+                        (setting) => setting.included === "Yes"
+                      );
                   }
 
                   return (

--- a/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
@@ -166,7 +166,7 @@ function MetricDefinitions() {
 
                   if (
                     (!hasSettings && !hasContext) ||
-                    (!hasSettings && hasContext && hasContextValue)
+                    (!hasSettings && hasContextValue)
                   ) {
                     hasEnabledDefinition = true;
                   } else if (hasSettings) {


### PR DESCRIPTION
## Description of the change

Allows context values to count towards includes/excludes configuration. Basically, if you have no includes/excludes selected, entering any value in the context text box will give you an includes/excludes-has-been-configured checkmark.

https://github.com/Recidiviz/justice-counts/assets/59492998/bb789bfe-2a2b-44b0-83eb-c5b7cad3b184

## Related issues

Closes #631 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
