### PR TITLE
Metric Config: Replace checkmarks with toggles

### DIFF
--- a/common/components/ToggleSwitch/ToggleSwitch.styles.tsx
+++ b/common/components/ToggleSwitch/ToggleSwitch.styles.tsx
@@ -1,0 +1,70 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2023 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import styled from "styled-components/macro";
+import { palette } from "../GlobalStyles/Palette";
+
+export const ToggleSwitchContainer = styled.div`
+  display: flex;
+  align-items: center;
+  padding: 8px 0;
+`;
+
+export const ToggleSwitchLabel = styled.label`
+  position: relative;
+  display: inline-block;
+  width: 38px;
+  height: 22px;
+`;
+
+export const ToggleSwitchInput = styled.input`
+  opacity: 0;
+  width: 0;
+  height: 0;
+
+  &:checked + span {
+    background-color: ${palette.solid.blue};
+  }
+
+  &:checked + span:before {
+    transform: translateX(15px);
+  }
+`;
+
+export const Slider = styled.span`
+  position: absolute;
+  cursor: pointer;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background-color: ${palette.highlight.grey3};
+  border-radius: 34px;
+  transition: 0.3s;
+
+  &:before {
+    content: "";
+    height: 15px;
+    width: 15px;
+    position: absolute;
+    left: 4px;
+    bottom: 3.5px;
+    background-color: ${palette.solid.white};
+    border-radius: 50%;
+    transition: 0.3s;
+  }
+`;

--- a/common/components/ToggleSwitch/ToggleSwitch.styles.tsx
+++ b/common/components/ToggleSwitch/ToggleSwitch.styles.tsx
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import styled from "styled-components/macro";
+
 import { palette } from "../GlobalStyles/Palette";
 
 export const ToggleSwitchContainer = styled.div`

--- a/common/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/common/components/ToggleSwitch/ToggleSwitch.tsx
@@ -15,12 +15,13 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React, { useState } from "react";
+import React from "react";
+
 import {
   Slider,
+  ToggleSwitchContainer,
   ToggleSwitchInput,
   ToggleSwitchLabel,
-  ToggleSwitchContainer,
   ToggleSwitchProps,
 } from ".";
 

--- a/common/components/ToggleSwitch/ToggleSwitch.tsx
+++ b/common/components/ToggleSwitch/ToggleSwitch.tsx
@@ -1,0 +1,40 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2023 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import React, { useState } from "react";
+import {
+  Slider,
+  ToggleSwitchInput,
+  ToggleSwitchLabel,
+  ToggleSwitchContainer,
+  ToggleSwitchProps,
+} from ".";
+
+export const ToggleSwitch = ({ checked, onChange }: ToggleSwitchProps) => {
+  return (
+    <ToggleSwitchContainer>
+      <ToggleSwitchLabel>
+        <ToggleSwitchInput
+          type="checkbox"
+          checked={checked}
+          onChange={onChange}
+        />
+        <Slider />
+      </ToggleSwitchLabel>
+    </ToggleSwitchContainer>
+  );
+};

--- a/common/components/ToggleSwitch/index.ts
+++ b/common/components/ToggleSwitch/index.ts
@@ -1,0 +1,20 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2023 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+export * from "./ToggleSwitch";
+export * from "./ToggleSwitch.styles";
+export * from "./types";

--- a/common/components/ToggleSwitch/types.ts
+++ b/common/components/ToggleSwitch/types.ts
@@ -1,0 +1,21 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2023 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+export type ToggleSwitchProps = {
+  checked: boolean;
+  onChange: () => void;
+};

--- a/publisher/src/components/MetricsConfiguration/DefinitionModalForm.styled.tsx
+++ b/publisher/src/components/MetricsConfiguration/DefinitionModalForm.styled.tsx
@@ -83,13 +83,14 @@ export const IncludesExcludesContainer = styled.div`
   margin-bottom: 32px;
 `;
 
-export const IncludeExclude = styled.div`
+export const IncludeExclude = styled.div<{ enabled?: boolean }>`
   display: flex;
   flex-direction: row;
   gap: 8px;
-  align-items: start;
+  align-items: center;
   ${typography.sizeCSS.normal};
   cursor: pointer;
+  ${({ enabled }) => !enabled && `color: ${palette.highlight.grey7};`}
 
   &:hover {
     color: ${palette.solid.darkblue};

--- a/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
+++ b/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
@@ -15,8 +15,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+import blueCheckIcon from "@justice-counts/common/assets/status-check-icon.png";
 import { Button } from "@justice-counts/common/components/Button";
-import { ToggleSwitch } from "@justice-counts/common/components/ToggleSwitch";
 import {
   MetricConfigurationSettings,
   MetricConfigurationSettingsOptions,
@@ -392,17 +392,21 @@ function DefinitionModalForm({
                           return (
                             <Styled.IncludeExclude
                               key={settingKey}
-                              enabled={setting.included === "Yes"}
+                              onClick={() =>
+                                handleChangeDefinitionIncluded(
+                                  includesExcludesKey,
+                                  settingKey
+                                )
+                              }
                             >
-                              <ToggleSwitch
-                                checked={setting.included === "Yes"}
-                                onChange={() =>
-                                  handleChangeDefinitionIncluded(
-                                    includesExcludesKey,
-                                    settingKey
-                                  )
-                                }
-                              />
+                              {setting.included === "Yes" ? (
+                                <Styled.EnabledIcon
+                                  src={blueCheckIcon}
+                                  alt=""
+                                />
+                              ) : (
+                                <Styled.DisabledIcon />
+                              )}
                               {setting.label}
                             </Styled.IncludeExclude>
                           );
@@ -414,6 +418,7 @@ function DefinitionModalForm({
               )}
             </Styled.IncludesExcludesContainer>
           )}
+
           <Styled.ContextContainer>
             {currentContexts &&
               Object.entries(currentContexts).map(([key, { label, value }]) => {

--- a/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
+++ b/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
@@ -15,8 +15,8 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import blueCheckIcon from "@justice-counts/common/assets/status-check-icon.png";
 import { Button } from "@justice-counts/common/components/Button";
+import { ToggleSwitch } from "@justice-counts/common/components/ToggleSwitch";
 import {
   MetricConfigurationSettings,
   MetricConfigurationSettingsOptions,
@@ -392,21 +392,17 @@ function DefinitionModalForm({
                           return (
                             <Styled.IncludeExclude
                               key={settingKey}
-                              onClick={() =>
-                                handleChangeDefinitionIncluded(
-                                  includesExcludesKey,
-                                  settingKey
-                                )
-                              }
+                              enabled={setting.included === "Yes"}
                             >
-                              {setting.included === "Yes" ? (
-                                <Styled.EnabledIcon
-                                  src={blueCheckIcon}
-                                  alt=""
-                                />
-                              ) : (
-                                <Styled.DisabledIcon />
-                              )}
+                              <ToggleSwitch
+                                checked={setting.included === "Yes"}
+                                onChange={() =>
+                                  handleChangeDefinitionIncluded(
+                                    includesExcludesKey,
+                                    settingKey
+                                  )
+                                }
+                              />
                               {setting.label}
                             </Styled.IncludeExclude>
                           );

--- a/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
+++ b/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
@@ -398,6 +398,7 @@ function DefinitionModalForm({
                                   settingKey
                                 )
                               }
+                              enabled={setting.included === "Yes"}
                             >
                               {setting.included === "Yes" ? (
                                 <Styled.EnabledIcon

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.styled.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.styled.tsx
@@ -264,10 +264,6 @@ export const DimensionsListItem = styled.div<{ enabled?: boolean }>`
     width: 20px;
     height: 20px;
   }
-
-  &:hover {
-    background-color: ${palette.highlight.grey1};
-  }
 `;
 
 export const DisabledDimensionIcon = styled.div`

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.styled.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.styled.tsx
@@ -244,7 +244,7 @@ export const DimensionsList = styled.div`
   flex-direction: column;
 `;
 
-export const DimensionsListItem = styled.div`
+export const DimensionsListItem = styled.div<{ enabled?: boolean }>`
   display: flex;
   flex-direction: row;
   gap: 12px;
@@ -253,6 +253,8 @@ export const DimensionsListItem = styled.div`
   border-bottom: 1px solid ${palette.highlight.grey4};
   ${typography.sizeCSS.medium};
   cursor: pointer;
+
+  ${({ enabled }) => !enabled && `color: ${palette.highlight.grey7};`}
 
   &:last-child {
     border-bottom: none;

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.styled.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.styled.tsx
@@ -252,7 +252,6 @@ export const DimensionsListItem = styled.div<{ enabled?: boolean }>`
   padding: 16px 0 16px 10px;
   border-bottom: 1px solid ${palette.highlight.grey4};
   ${typography.sizeCSS.medium};
-  cursor: pointer;
 
   ${({ enabled }) => !enabled && `color: ${palette.highlight.grey7};`}
 

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -16,7 +16,6 @@
 // =============================================================================
 
 import infoIcon from "@justice-counts/common/assets/info-icon.svg";
-import blueCheckIcon from "@justice-counts/common/assets/status-check-icon.png";
 import {
   Dropdown,
   DropdownOption,
@@ -25,6 +24,7 @@ import {
   RadioButton,
   RadioButtonsWrapper,
 } from "@justice-counts/common/components/RadioButton";
+import { ToggleSwitch } from "@justice-counts/common/components/ToggleSwitch";
 import {
   SupervisionSubsystems,
   SupervisionSystem,
@@ -478,19 +478,18 @@ function MetricAvailability() {
                           ([dimensionKey, { label, enabled }]) => (
                             <Styled.DimensionsListItem
                               key={dimensionKey}
-                              onClick={() =>
-                                handleDimensionEnabledStatus(
-                                  !enabled,
-                                  dimensionKey,
-                                  disaggregationKey
-                                )
-                              }
+                              enabled={Boolean(enabled)}
                             >
-                              {enabled ? (
-                                <img src={blueCheckIcon} alt="" />
-                              ) : (
-                                <Styled.DisabledDimensionIcon />
-                              )}
+                              <ToggleSwitch
+                                checked={Boolean(enabled)}
+                                onChange={() =>
+                                  handleDimensionEnabledStatus(
+                                    !enabled,
+                                    dimensionKey,
+                                    disaggregationKey
+                                  )
+                                }
+                              />
                               {label}
                             </Styled.DimensionsListItem>
                           )

--- a/publisher/src/components/MetricsConfiguration/RaceEthnicitiesModalForm.styled.tsx
+++ b/publisher/src/components/MetricsConfiguration/RaceEthnicitiesModalForm.styled.tsx
@@ -81,13 +81,14 @@ export const RaceList = styled.div`
   margin-bottom: 40px;
 `;
 
-export const RaceListItem = styled.div`
+export const RaceListItem = styled.div<{ enabled?: boolean }>`
   display: flex;
   flex-direction: row;
   gap: 8px;
   align-items: center;
   ${typography.sizeCSS.normal};
   cursor: pointer;
+  ${({ enabled }) => !enabled && `color: ${palette.highlight.grey7};`}
 
   &:hover {
     color: ${palette.solid.darkblue};

--- a/publisher/src/components/MetricsConfiguration/RaceEthnicitiesModalForm.tsx
+++ b/publisher/src/components/MetricsConfiguration/RaceEthnicitiesModalForm.tsx
@@ -15,12 +15,12 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import blueCheckIcon from "@justice-counts/common/assets/status-check-icon.png";
 import { Button } from "@justice-counts/common/components/Button";
 import {
   RadioButton,
   RadioButtonsWrapper,
 } from "@justice-counts/common/components/RadioButton";
+import { ToggleSwitch } from "@justice-counts/common/components/ToggleSwitch";
 import { observer } from "mobx-react-lite";
 import React, { useState } from "react";
 import { useParams } from "react-router-dom";
@@ -164,40 +164,36 @@ function RaceEthnicitiesModalForm({
         </Styled.RaceListHeader>
         <Styled.RaceList>
           {!canSpecifyEthnicity && (
-            <Styled.RaceListItem
-              onClick={() => {
-                if (!specifiesHispanicAsRace) {
-                  setRacesStatusObject({ ...racesStatusObject, Unknown: true });
-                }
-                setSpecifiesHispanicAsRace(!specifiesHispanicAsRace);
-              }}
-            >
-              {specifiesHispanicAsRace ? (
-                <Styled.EnabledRaceIcon src={blueCheckIcon} alt="" />
-              ) : (
-                <Styled.DisabledRaceIcon />
-              )}
+            <Styled.RaceListItem enabled={specifiesHispanicAsRace}>
+              <ToggleSwitch
+                checked={specifiesHispanicAsRace}
+                onChange={() => {
+                  if (!specifiesHispanicAsRace) {
+                    setRacesStatusObject({
+                      ...racesStatusObject,
+                      Unknown: true,
+                    });
+                  }
+                  setSpecifiesHispanicAsRace(!specifiesHispanicAsRace);
+                }}
+              />
               {Ethnicity.HISPANIC_OR_LATINO}
             </Styled.RaceListItem>
           )}
           {Object.entries(racesStatusObject).map(([race, enabled]) => (
-            <Styled.RaceListItem
-              key={race}
-              onClick={() => {
-                if (race === "Unknown" && enabled && !canSpecifyEthnicity) {
-                  setSpecifiesHispanicAsRace(false);
-                }
-                setRacesStatusObject({
-                  ...racesStatusObject,
-                  [race]: !enabled,
-                });
-              }}
-            >
-              {enabled ? (
-                <Styled.EnabledRaceIcon src={blueCheckIcon} alt="" />
-              ) : (
-                <Styled.DisabledRaceIcon />
-              )}{" "}
+            <Styled.RaceListItem key={race} enabled={Boolean(enabled)}>
+              <ToggleSwitch
+                checked={Boolean(enabled)}
+                onChange={() => {
+                  if (race === "Unknown" && enabled && !canSpecifyEthnicity) {
+                    setSpecifiesHispanicAsRace(false);
+                  }
+                  setRacesStatusObject({
+                    ...racesStatusObject,
+                    [race]: !enabled,
+                  });
+                }}
+              />
               {race}
             </Styled.RaceListItem>
           ))}


### PR DESCRIPTION
## Description of the change

The return of the Toggle Switch!

Adds reusable ToggleSwitch component to `common` repo and replaces clickable checkmarks within the `MetricAvailability`, `DefinitionModalForm`, and `RaceEthnicitiesModalForm` components w/ toggle switches.

Demo (would love a sanity check):
https://mahmoudtest---justice-counts-web-qqec6jbn6a-uc.a.run.app

3 places to check:
* Metric Breakdowns in the Metric Availability screen
* Any definitions modal w/ includes/excludes
* Any Race & Ethnicities modal

## Related issues

Closes #635 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
