### PR TITLE
Adjustment to UploadReview logic to allow a super agency to publish for their child agencies

### DIFF
--- a/common/components/DataViz/DatapointsTableView.styles.tsx
+++ b/common/components/DataViz/DatapointsTableView.styles.tsx
@@ -79,11 +79,22 @@ export const DatapointsTableNamesCell = styled.td<{
     color: ${palette.solid.darkgrey};
   }
 `;
-export const DatapointsMetricNameCell = styled(DatapointsTableNamesCell)`
-  ${typography.sizeCSS.title};
-  color: ${palette.solid.darkgrey};
+export const DatapointsMetricNameCell = styled(DatapointsTableNamesCell)<{
+  useMultiAgencyStyles?: boolean;
+}>`
+  ${({ useMultiAgencyStyles }) =>
+    useMultiAgencyStyles
+      ? typography.sizeCSS.medium
+      : typography.sizeCSS.title};
+  color: ${({ useMultiAgencyStyles }) =>
+    useMultiAgencyStyles ? palette.solid.blue : palette.solid.darkgrey};
   line-height: 38px;
   padding: 0 0 31px 0;
+
+  &:hover {
+    color: ${({ useMultiAgencyStyles }) =>
+      useMultiAgencyStyles ? palette.solid.blue : palette.solid.darkgrey};
+  }
 `;
 export const DatapointsMetricNameCellTooltip = styled.div`
   ${typography.sizeCSS.normal};

--- a/common/components/DataViz/DatapointsTableView.tsx
+++ b/common/components/DataViz/DatapointsTableView.tsx
@@ -73,9 +73,16 @@ type DatapointValueCellProps = {
 export const DatapointsTableView: React.FC<{
   datapoints: RawDatapoint[];
   useDataPageStyles?: boolean;
+  useMultiAgencyStyles?: boolean;
   metricName: string;
   metricFrequency?: ReportFrequency;
-}> = ({ datapoints, useDataPageStyles, metricName, metricFrequency }) => {
+}> = ({
+  datapoints,
+  useDataPageStyles,
+  metricName,
+  metricFrequency,
+  useMultiAgencyStyles,
+}) => {
   const [hoveredRowKey, setHoveredRowKey] = useState<string | null>(null);
   const [hoveredColKey, setHoveredColKey] = useState<number | null>(null);
 
@@ -150,7 +157,10 @@ export const DatapointsTableView: React.FC<{
             <DatapointsTableNamesTableBody>
               {!useDataPageStyles && (
                 <DatapointsTableNamesRow>
-                  <DatapointsMetricNameCell title={metricName}>
+                  <DatapointsMetricNameCell
+                    title={metricName}
+                    useMultiAgencyStyles={useMultiAgencyStyles}
+                  >
                     {metricName}
                     <DatapointsMetricNameCellTooltip>
                       {metricName}

--- a/common/components/Modal/Modal.styled.tsx
+++ b/common/components/Modal/Modal.styled.tsx
@@ -40,7 +40,10 @@ export const OuterWrapper = styled.div<{
   }};
 `;
 
-export const InnerWrapper = styled.div<{ modalType?: ModalType }>`
+export const InnerWrapper = styled.div<{
+  modalType?: ModalType;
+  centerText?: boolean;
+}>`
   background-color: ${palette.solid.white};
   width: 100%;
   max-width: 582px;
@@ -49,6 +52,7 @@ export const InnerWrapper = styled.div<{ modalType?: ModalType }>`
   flex-direction: column;
   align-items: center;
   border-radius: 3px;
+  ${({ centerText }) => centerText && `text-align: center;`}
 `;
 
 export const Icon = styled.img`

--- a/common/components/Modal/Modal.tsx
+++ b/common/components/Modal/Modal.tsx
@@ -32,6 +32,7 @@ type ModalProps = {
   secondaryButton: { label: string; onClick: () => void };
   modalType?: ModalType;
   modalBackground?: ModalBackground;
+  centerText?: boolean;
 };
 
 export function Modal({
@@ -41,6 +42,7 @@ export function Modal({
   secondaryButton,
   modalType,
   modalBackground,
+  centerText,
 }: ModalProps) {
   const primaryButtonColor = (): ButtonColor => {
     if (modalType === "alert") return "red";
@@ -58,7 +60,7 @@ export function Modal({
 
   const Portal = (
     <Styled.OuterWrapper modalBackground={modalBackground}>
-      <Styled.InnerWrapper modalType={modalType}>
+      <Styled.InnerWrapper modalType={modalType} centerText={centerText}>
         {modalType === "success" && <Styled.Icon src={successIcon} alt="" />}
         {modalType === "warning" && <Styled.Icon src={warningIcon} alt="" />}
         {modalType === "alert" && <Styled.Icon src={alertIcon} alt="" />}

--- a/common/types.ts
+++ b/common/types.ts
@@ -114,6 +114,7 @@ export interface ReportOverview {
   last_modified_at_timestamp: number | null;
   editors: ReportEditor[];
   status: ReportStatus;
+  agency_name?: string;
 }
 
 export interface Report extends ReportOverview {
@@ -318,6 +319,7 @@ export interface RawDatapoint {
   old_value: string | number | null;
   is_published: boolean;
   frequency: ReportFrequency;
+  agency_name?: string;
 }
 
 /**

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -113,12 +113,12 @@ export const DataUpload: React.FC = observer(() => {
   >();
   const [newAndUpdatedReports, setNewAndUpdatedReports] = useState<{
     newReports: ReportOverview[];
-    updatedReportIDs: number[];
-    unchangedReportIDs: number[];
+    updatedReports: ReportOverview[];
+    unchangedReports: ReportOverview[];
   }>({
     newReports: [],
-    updatedReportIDs: [],
-    unchangedReportIDs: [],
+    updatedReports: [],
+    unchangedReports: [],
   });
 
   const headerBackground = () => {
@@ -166,8 +166,8 @@ export const DataUpload: React.FC = observer(() => {
        */
       setNewAndUpdatedReports({
         newReports: data.new_reports || [],
-        updatedReportIDs: data.updated_report_ids || [],
-        unchangedReportIDs: data.unchanged_report_ids || [],
+        updatedReports: data.updated_reports || [],
+        unchangedReports: data.unchanged_reports || [],
       });
 
       /** Errors and/or Warnings Encountered During Upload -- Show Interstitial instead of Confirmation Page */
@@ -190,8 +190,8 @@ export const DataUpload: React.FC = observer(() => {
           uploadedMetrics: data.metrics,
           fileName: file.name,
           newReports: data.new_reports || [],
-          updatedReportIDs: data.updated_report_ids || [],
-          unchangedReportIDs: data.unchanged_report_ids || [],
+          updatedReports: data.updated_reports || [],
+          unchangedReports: data.unchanged_reports || [],
         },
         replace: true,
       });

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -60,8 +60,8 @@ type UploadErrorsWarningsProps = {
   fileName?: string;
   newAndUpdatedReports: {
     newReports: ReportOverview[];
-    updatedReportIDs: number[];
-    unchangedReportIDs: number[];
+    updatedReports: ReportOverview[];
+    unchangedReports: ReportOverview[];
   };
 };
 export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
@@ -403,8 +403,8 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
                   uploadedMetrics: metrics,
                   fileName,
                   newReports: newAndUpdatedReports.newReports,
-                  updatedReportIDs: newAndUpdatedReports.updatedReportIDs,
-                  unchangedReportIDs: newAndUpdatedReports.unchangedReportIDs,
+                  updatedReports: newAndUpdatedReports.updatedReports,
+                  unchangedReports: newAndUpdatedReports.unchangedReports,
                 },
                 replace: true,
               })

--- a/publisher/src/components/DataUpload/UploadReview.tsx
+++ b/publisher/src/components/DataUpload/UploadReview.tsx
@@ -50,14 +50,14 @@ const UploadReview: React.FC = observer(() => {
     uploadedMetrics,
     fileName,
     newReports,
-    updatedReportIDs,
-    unchangedReportIDs,
+    updatedReports,
+    unchangedReports,
   } = state as {
     uploadedMetrics: UploadedMetric[] | null;
     fileName: string;
     newReports: ReportOverview[];
-    updatedReportIDs: number[];
-    unchangedReportIDs: number[];
+    updatedReports: ReportOverview[];
+    unchangedReports: ReportOverview[];
   };
   const navigate = useNavigate();
   const [isSuccessModalOpen, setIsSuccessModalOpen] = useState(false);
@@ -69,9 +69,10 @@ const UploadReview: React.FC = observer(() => {
   }
 
   // review component props
-  const existingReports = [...updatedReportIDs, ...unchangedReportIDs]
-    .map((id) => reportStore.reportOverviews[id])
-    .filter((report) => report);
+  const existingReports = [
+    ...(updatedReports || []),
+    ...(unchangedReports || []),
+  ];
   const hasExistingAndNewRecords =
     existingReports.length > 0 && newReports.length > 0;
   const existingAndNewRecords = [...existingReports, ...newReports];
@@ -80,7 +81,7 @@ const UploadReview: React.FC = observer(() => {
   );
   const hasAllPublishedRecordsNoOverwrites =
     existingAndNewRecords.filter((record) => record.status !== "PUBLISHED")
-      .length === 0 && updatedReportIDs.length === 0;
+      .length === 0 && updatedReports?.length === 0;
 
   const publishMultipleRecords = async () => {
     if (agencyId && !hasAllPublishedRecordsNoOverwrites) {
@@ -194,6 +195,7 @@ const UploadReview: React.FC = observer(() => {
             onClick: () => setExistingReportWarningOpen(false),
           }}
           modalType="warning"
+          centerText
         />
       )}
       {isSuccessModalOpen && (
@@ -209,6 +211,7 @@ const UploadReview: React.FC = observer(() => {
             onClick: () => navigate(`/agency/${agencyId}/${REPORTS_LOWERCASE}`),
           }}
           modalType="success"
+          centerText
         />
       )}
       <ReviewMetrics

--- a/publisher/src/components/DataUpload/types.ts
+++ b/publisher/src/components/DataUpload/types.ts
@@ -21,8 +21,8 @@ export interface DataUploadResponseBody {
   metrics: UploadedMetric[];
   non_metric_errors?: ErrorWarningMessage[];
   new_reports: ReportOverview[];
-  updated_report_ids: number[];
-  unchanged_report_ids: number[];
+  updated_reports: ReportOverview[];
+  unchanged_reports: ReportOverview[];
 }
 
 export interface UploadedMetric {

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
@@ -225,9 +225,9 @@ export const MetricsPanel = styled.div`
   overflow-x: hidden;
 `;
 
-export const SectionContainer = styled.div`
+export const SectionContainer = styled.div<{ isMultiAgencyUpload?: boolean }>`
   margin-top: 32px;
-  padding-top: 24px;
+  padding-top: 22px;
   display: flex;
   align-items: center;
   justify-content: stretch;
@@ -236,7 +236,9 @@ export const SectionContainer = styled.div`
   overflow-x: auto;
 
   &:not(:first-child) {
-    border-top: 1px solid ${palette.highlight.grey3};
+    ${({ isMultiAgencyUpload }) =>
+      !isMultiAgencyUpload &&
+      `border-top: 1px solid ${palette.highlight.grey3}`};
   }
 
   &:first-child {
@@ -247,4 +249,28 @@ export const SectionContainer = styled.div`
 
 export const NoDatapointsMessage = styled.div`
   margin: auto auto;
+`;
+
+export const AgencyName = styled.div`
+  ${typography.sizeCSS.title}
+  width: 100%;
+  margin-bottom: 13px;
+  color: ${palette.solid.darkgrey};
+
+  &:not(:first-child) {
+    margin-top: 40px;
+    padding-top: 8px;
+    border-top: 1px solid ${palette.highlight.grey3};
+  }
+`;
+
+export const SummaryAgencyName = styled.div`
+  ${typography.sizeCSS.normal}
+  color: ${palette.solid.blue};
+`;
+
+export const SummaryWrapper = styled.div`
+  ${SummaryAgencyName}:not(:first-child) {
+    margin-top: 5px;
+  }
 `;

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
@@ -227,6 +227,7 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
       ) : (
         <MetricsPanel>
           {metrics.map((metric) => {
+            console.log("agency_name", metric);
             return renderSection(metric);
           })}
         </MetricsPanel>

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
@@ -227,7 +227,6 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
       ) : (
         <MetricsPanel>
           {metrics.map((metric) => {
-            console.log("agency_name", metric);
             return renderSection(metric);
           })}
         </MetricsPanel>

--- a/publisher/src/components/ReviewMetrics/types.ts
+++ b/publisher/src/components/ReviewMetrics/types.ts
@@ -51,6 +51,7 @@ export type ReviewMetricOverwrites = {
   metricName: string;
   dimensionName: string;
   startDate: string;
+  agencyName?: string;
 };
 
 export type ReviewMetricsProps = {
@@ -60,6 +61,8 @@ export type ReviewMetricsProps = {
   metrics: ReviewMetric[];
   metricOverwrites?: ReviewMetricOverwrites[];
   records?: ReportOverview[];
+  isMultiAgencyUpload?: boolean;
+  datapointsByMetricNameByAgencyName?: DatapointsByMetricNameByAgencyName;
 };
 
 export type PublishReviewMetricErrors = {
@@ -74,4 +77,8 @@ export type PublishReviewPropsFromDatapoints = {
     displayName: string;
   }[];
   metricErrors: PublishReviewMetricErrors;
+};
+
+export type DatapointsByMetricNameByAgencyName = {
+  [agencyName: string]: { [metricName: string]: RawDatapoint[] };
 };


### PR DESCRIPTION
## Description of the change

Now that the BE sends reports' metadata, this updates the `UploadReview` logic to utilize the metadata for rendering instead of the report IDs + querying the `reportStore`.

## Related issues

Closes #653 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
