### PR TITLE
Refactor bulk upload review page to handle and properly display multiple agency uploads

### DIFF
--- a/common/components/DataViz/DatapointsTableView.styles.tsx
+++ b/common/components/DataViz/DatapointsTableView.styles.tsx
@@ -79,11 +79,22 @@ export const DatapointsTableNamesCell = styled.td<{
     color: ${palette.solid.darkgrey};
   }
 `;
-export const DatapointsMetricNameCell = styled(DatapointsTableNamesCell)`
-  ${typography.sizeCSS.title};
-  color: ${palette.solid.darkgrey};
+export const DatapointsMetricNameCell = styled(DatapointsTableNamesCell)<{
+  useMultiAgencyStyles?: boolean;
+}>`
+  ${({ useMultiAgencyStyles }) =>
+    useMultiAgencyStyles
+      ? typography.sizeCSS.medium
+      : typography.sizeCSS.title};
+  color: ${({ useMultiAgencyStyles }) =>
+    useMultiAgencyStyles ? palette.solid.blue : palette.solid.darkgrey};
   line-height: 38px;
   padding: 0 0 31px 0;
+
+  &:hover {
+    color: ${({ useMultiAgencyStyles }) =>
+      useMultiAgencyStyles ? palette.solid.blue : palette.solid.darkgrey};
+  }
 `;
 export const DatapointsMetricNameCellTooltip = styled.div`
   ${typography.sizeCSS.normal};

--- a/common/components/DataViz/DatapointsTableView.tsx
+++ b/common/components/DataViz/DatapointsTableView.tsx
@@ -73,9 +73,16 @@ type DatapointValueCellProps = {
 export const DatapointsTableView: React.FC<{
   datapoints: RawDatapoint[];
   useDataPageStyles?: boolean;
+  useMultiAgencyStyles?: boolean;
   metricName: string;
   metricFrequency?: ReportFrequency;
-}> = ({ datapoints, useDataPageStyles, metricName, metricFrequency }) => {
+}> = ({
+  datapoints,
+  useDataPageStyles,
+  metricName,
+  metricFrequency,
+  useMultiAgencyStyles,
+}) => {
   const [hoveredRowKey, setHoveredRowKey] = useState<string | null>(null);
   const [hoveredColKey, setHoveredColKey] = useState<number | null>(null);
 
@@ -150,7 +157,10 @@ export const DatapointsTableView: React.FC<{
             <DatapointsTableNamesTableBody>
               {!useDataPageStyles && (
                 <DatapointsTableNamesRow>
-                  <DatapointsMetricNameCell title={metricName}>
+                  <DatapointsMetricNameCell
+                    title={metricName}
+                    useMultiAgencyStyles={useMultiAgencyStyles}
+                  >
                     {metricName}
                     <DatapointsMetricNameCellTooltip>
                       {metricName}

--- a/publisher/src/components/DataUpload/UploadReview.tsx
+++ b/publisher/src/components/DataUpload/UploadReview.tsx
@@ -125,7 +125,6 @@ const UploadReview: React.FC = observer(() => {
 
   const { isSuperAgencyUpload, datapointsByAgencyName } =
     uploadedMetricsToDatapointsByAgencyName(uploadedMetrics);
-
   const metrics = uploadedMetrics
     .map((metric) => {
       return {

--- a/publisher/src/components/DataUpload/UploadReview.tsx
+++ b/publisher/src/components/DataUpload/UploadReview.tsx
@@ -159,6 +159,7 @@ const UploadReview: React.FC = observer(() => {
           key: dp.id,
           metricName: dp.metric_display_name || "",
           dimensionName: dp.dimension_display_name || "",
+          agencyName: dp.agency_name,
           startDate: dp.start_date,
         };
         overwrites.push(overwriteData);

--- a/publisher/src/components/DataUpload/UploadReview.tsx
+++ b/publisher/src/components/DataUpload/UploadReview.tsx
@@ -110,11 +110,14 @@ const UploadReview: React.FC = observer(() => {
       .flatMap((metric) => metric.datapoints)
       .filter((dp) => dp.value);
     const datapointsByAgencyName = allDatapoints.reduce((acc, dp) => {
-      if (!dp.agency_name) return acc;
+      if (!dp.agency_name || !dp.metric_display_name) return acc;
       if (!acc[dp.agency_name]) {
-        acc[dp.agency_name] = [];
+        acc[dp.agency_name] = {};
       }
-      acc[dp.agency_name].push(dp);
+      if (!acc[dp.agency_name][dp.metric_display_name]) {
+        acc[dp.agency_name][dp.metric_display_name] = [];
+      }
+      acc[dp.agency_name][dp.metric_display_name].push(dp);
       return acc;
     }, {} as { [key: string]: RawDatapoint[] });
     const isSuperAgencyUpload =

--- a/publisher/src/components/DataUpload/UploadReview.tsx
+++ b/publisher/src/components/DataUpload/UploadReview.tsx
@@ -104,9 +104,7 @@ const UploadReview: React.FC = observer(() => {
     setIsSuccessModalOpen(true);
   };
 
-  const uploadedMetricsToDatapointsByAgencyName = (
-    metrics: UploadedMetric[]
-  ) => {
+  const metricsToMetricDatapointsByAgencyName = (metrics: UploadedMetric[]) => {
     const allDatapoints = metrics
       .flatMap((metric) => metric.datapoints)
       .filter((dp) => dp.value);
@@ -121,23 +119,21 @@ const UploadReview: React.FC = observer(() => {
       acc[dp.agency_name][dp.metric_display_name].push(dp);
       return acc;
     }, {} as DatapointsByAgencyName);
-    const isSuperAgencyUpload =
+    const isMultiAgencyUpload =
       Object.values(datapointsByAgencyName).length > 1;
 
-    return { isSuperAgencyUpload, datapointsByAgencyName };
+    return { isMultiAgencyUpload, datapointsByAgencyName };
   };
 
-  const { isSuperAgencyUpload, datapointsByAgencyName } =
-    uploadedMetricsToDatapointsByAgencyName(uploadedMetrics);
+  const { isMultiAgencyUpload, datapointsByAgencyName } =
+    metricsToMetricDatapointsByAgencyName(uploadedMetrics);
   const metrics = uploadedMetrics
-    .map((metric) => {
-      return {
-        ...metric,
-        datapoints: metric.datapoints.filter((dp) => dp.value !== null),
-        metricHasError: false,
-        metricHasValidInput: true,
-      };
-    })
+    .map((metric) => ({
+      ...metric,
+      datapoints: metric.datapoints.filter((dp) => dp.value !== null),
+      metricHasError: false,
+      metricHasValidInput: true,
+    }))
     .filter((metric) => metric.datapoints.length > 0);
   const overwrites: ReviewMetricOverwrites[] = [];
   metrics.forEach((metric) => {
@@ -249,7 +245,7 @@ const UploadReview: React.FC = observer(() => {
         metrics={metrics}
         metricOverwrites={overwrites}
         records={existingAndNewRecords}
-        isSuperAgencyUpload={isSuperAgencyUpload}
+        isMultiAgencyUpload={isMultiAgencyUpload}
         datapointsByAgencyName={datapointsByAgencyName}
       />
     </>

--- a/publisher/src/components/DataUpload/UploadReview.tsx
+++ b/publisher/src/components/DataUpload/UploadReview.tsx
@@ -18,7 +18,7 @@
 import { palette } from "@justice-counts/common/components/GlobalStyles";
 import { Modal } from "@justice-counts/common/components/Modal";
 import { showToast } from "@justice-counts/common/components/Toast";
-import { RawDatapoint, ReportOverview } from "@justice-counts/common/types";
+import { ReportOverview } from "@justice-counts/common/types";
 import { printReportTitle } from "@justice-counts/common/utils";
 import { observer } from "mobx-react-lite";
 import React, { useState } from "react";
@@ -32,6 +32,7 @@ import {
 import { useStore } from "../../stores";
 import { REPORTS_CAPITALIZED, REPORTS_LOWERCASE } from "../Global/constants";
 import {
+  DatapointsByAgencyName,
   ReviewHeaderActionButton,
   ReviewMetricOverwrites,
   ReviewMetrics,
@@ -119,7 +120,7 @@ const UploadReview: React.FC = observer(() => {
       }
       acc[dp.agency_name][dp.metric_display_name].push(dp);
       return acc;
-    }, {} as { [key: string]: RawDatapoint[] });
+    }, {} as DatapointsByAgencyName);
     const isSuperAgencyUpload =
       Object.values(datapointsByAgencyName).length > 1;
 

--- a/publisher/src/components/DataUpload/UploadReview.tsx
+++ b/publisher/src/components/DataUpload/UploadReview.tsx
@@ -32,7 +32,7 @@ import {
 import { useStore } from "../../stores";
 import { REPORTS_CAPITALIZED, REPORTS_LOWERCASE } from "../Global/constants";
 import {
-  DatapointsByAgencyName,
+  DatapointsByMetricNameByAgencyName,
   ReviewHeaderActionButton,
   ReviewMetricOverwrites,
   ReviewMetrics,
@@ -104,29 +104,45 @@ const UploadReview: React.FC = observer(() => {
     setIsSuccessModalOpen(true);
   };
 
-  const metricsToMetricDatapointsByAgencyName = (metrics: UploadedMetric[]) => {
+  /**
+   * Groups uploaded metrics' datapoints by metric name by agency name
+   * @returns Object { isMultiAgencyUpload, datapointsByMetricNameByAgencyName }
+   *          - isMultiAgencyUpload { boolean } - whether or not this is a multiple agency upload
+   *          - datapointsByMetricNameByAgencyName { object } - grouped
+   * @example
+   *  {
+   *    "Agency 1": { "Staff": [...datapoints], "Arrests": [...datapoints], ... }
+   *    "Agency 2": { "Staff": [...datapoints], ... },
+   *  }
+   *   */
+  const metricsToDatapointsByMetricNameByAgencyName = (
+    metrics: UploadedMetric[]
+  ) => {
     const allDatapoints = metrics
       .flatMap((metric) => metric.datapoints)
       .filter((dp) => dp.value);
-    const datapointsByAgencyName = allDatapoints.reduce((acc, dp) => {
-      if (!dp.agency_name || !dp.metric_display_name) return acc;
-      if (!acc[dp.agency_name]) {
-        acc[dp.agency_name] = {};
-      }
-      if (!acc[dp.agency_name][dp.metric_display_name]) {
-        acc[dp.agency_name][dp.metric_display_name] = [];
-      }
-      acc[dp.agency_name][dp.metric_display_name].push(dp);
-      return acc;
-    }, {} as DatapointsByAgencyName);
+    const datapointsByMetricNameByAgencyName = allDatapoints.reduce(
+      (acc, dp) => {
+        if (!dp.agency_name || !dp.metric_display_name) return acc;
+        if (!acc[dp.agency_name]) {
+          acc[dp.agency_name] = {};
+        }
+        if (!acc[dp.agency_name][dp.metric_display_name]) {
+          acc[dp.agency_name][dp.metric_display_name] = [];
+        }
+        acc[dp.agency_name][dp.metric_display_name].push(dp);
+        return acc;
+      },
+      {} as DatapointsByMetricNameByAgencyName
+    );
     const isMultiAgencyUpload =
-      Object.values(datapointsByAgencyName).length > 1;
+      Object.values(datapointsByMetricNameByAgencyName).length > 1;
 
-    return { isMultiAgencyUpload, datapointsByAgencyName };
+    return { isMultiAgencyUpload, datapointsByMetricNameByAgencyName };
   };
 
-  const { isMultiAgencyUpload, datapointsByAgencyName } =
-    metricsToMetricDatapointsByAgencyName(uploadedMetrics);
+  const { isMultiAgencyUpload, datapointsByMetricNameByAgencyName } =
+    metricsToDatapointsByMetricNameByAgencyName(uploadedMetrics);
   const metrics = uploadedMetrics
     .map((metric) => ({
       ...metric,
@@ -246,7 +262,7 @@ const UploadReview: React.FC = observer(() => {
         metricOverwrites={overwrites}
         records={existingAndNewRecords}
         isMultiAgencyUpload={isMultiAgencyUpload}
-        datapointsByAgencyName={datapointsByAgencyName}
+        datapointsByMetricNameByAgencyName={datapointsByMetricNameByAgencyName}
       />
     </>
   );

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
@@ -249,15 +249,15 @@ export const NoDatapointsMessage = styled.div`
   margin: auto auto;
 `;
 
-export const AgencyTitle = styled.div`
-  ${typography.sizeCSS.normal}
+export const AgencyName = styled.div`
+  ${typography.sizeCSS.medium}
   width: 100%;
-  margin-bottom: 15px;
-  color: ${palette.highlight.grey8};
+  margin-bottom: 25px;
+  color: ${palette.solid.green};
 
   &:not(:first-child) {
-    margin-top: 30px;
-    padding-top: 20px;
-    border-top: 1px solid ${palette.highlight.grey3};
+    margin-top: 80px;
+    padding-top: 30px;
+    border-top: 1px dotted ${palette.highlight.grey8};
   }
 `;

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
@@ -225,9 +225,9 @@ export const MetricsPanel = styled.div`
   overflow-x: hidden;
 `;
 
-export const SectionContainer = styled.div`
+export const SectionContainer = styled.div<{ isMultiAgencyUpload?: boolean }>`
   margin-top: 32px;
-  padding-top: 24px;
+  padding-top: 22px;
   display: flex;
   align-items: center;
   justify-content: stretch;
@@ -236,7 +236,9 @@ export const SectionContainer = styled.div`
   overflow-x: auto;
 
   &:not(:first-child) {
-    border-top: 1px solid ${palette.highlight.grey3};
+    ${({ isMultiAgencyUpload }) =>
+      !isMultiAgencyUpload &&
+      `border-top: 1px solid ${palette.highlight.grey3}`};
   }
 
   &:first-child {
@@ -250,14 +252,14 @@ export const NoDatapointsMessage = styled.div`
 `;
 
 export const AgencyName = styled.div`
-  ${typography.sizeCSS.medium}
+  ${typography.sizeCSS.title}
   width: 100%;
-  margin-bottom: 25px;
-  color: ${palette.solid.green};
+  margin-bottom: 13px;
+  color: ${palette.solid.darkgrey};
 
   &:not(:first-child) {
-    margin-top: 80px;
-    padding-top: 30px;
-    border-top: 1px dotted ${palette.highlight.grey8};
+    margin-top: 40px;
+    padding-top: 8px;
+    border-top: 1px solid ${palette.highlight.grey3};
   }
 `;

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
@@ -248,3 +248,16 @@ export const SectionContainer = styled.div`
 export const NoDatapointsMessage = styled.div`
   margin: auto auto;
 `;
+
+export const AgencyTitle = styled.div`
+  ${typography.sizeCSS.normal}
+  width: 100%;
+  margin-bottom: 15px;
+  color: ${palette.highlight.grey8};
+
+  &:not(:first-child) {
+    margin-top: 30px;
+    padding-top: 20px;
+    border-top: 1px solid ${palette.highlight.grey3};
+  }
+`;

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
@@ -264,13 +264,13 @@ export const AgencyName = styled.div`
   }
 `;
 
-export const OverwritesAgencyName = styled.div`
+export const SummaryAgencyName = styled.div`
   ${typography.sizeCSS.normal}
   color: ${palette.solid.blue};
 `;
 
-export const OverwritesWrapper = styled.div`
-  ${OverwritesAgencyName}:not(:first-child) {
+export const SummaryWrapper = styled.div`
+  ${SummaryAgencyName}:not(:first-child) {
     margin-top: 5px;
   }
 `;

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.styles.tsx
@@ -263,3 +263,14 @@ export const AgencyName = styled.div`
     border-top: 1px solid ${palette.highlight.grey3};
   }
 `;
+
+export const OverwritesAgencyName = styled.div`
+  ${typography.sizeCSS.normal}
+  color: ${palette.solid.blue};
+`;
+
+export const OverwritesWrapper = styled.div`
+  ${OverwritesAgencyName}:not(:first-child) {
+    margin-top: 5px;
+  }
+`;

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
@@ -34,6 +34,7 @@ import {
   REPORTS_LOWERCASE,
 } from "../Global/constants";
 import {
+  AgencyTitle,
   EmptyIcon,
   Heading,
   HeadingGradient,
@@ -80,10 +81,22 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
   const renderSection = (metric: ReviewMetric) => {
     return (
       <SectionContainer key={metric.key}>
-        <DatapointsTableView
-          datapoints={metric.datapoints}
-          metricName={metric.display_name}
-        />
+        {isSuperAgencyUpload && datapointsByAgencyName ? (
+          Object.entries(datapointsByAgencyName).map(([key, datapoints]) => (
+            <>
+              <AgencyTitle>{key}</AgencyTitle>
+              <DatapointsTableView
+                datapoints={datapoints}
+                metricName={metric.display_name}
+              />
+            </>
+          ))
+        ) : (
+          <DatapointsTableView
+            datapoints={metric.datapoints}
+            metricName={metric.display_name}
+          />
+        )}
       </SectionContainer>
     );
   };

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
@@ -97,6 +97,8 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
     );
   };
 
+  /** Multi-Agency Uploads */
+
   const renderDatapointsByMetricNameByAgencyName = (
     groupedDatapoints: DatapointsByMetricNameByAgencyName
   ) => {
@@ -178,6 +180,12 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
                   <SummaryAgencyName>{agencyName}</SummaryAgencyName>
                   {Object.keys(agencyMetrics).map((metric) => (
                     <SummarySectionLine key={metric}>
+                      {/**
+                       * Since multiagency uploads currenly only take place via the bulk upload flow
+                       * and that has its own errors/warnings page, we can safely assume that metrics that
+                       * make it to the review page are successfully saved metrics with inputs and
+                       * without errors - thus, earning a check icon.
+                       */}
                       <MetricStatusIcon src={checkIcon} alt="" />
                       {metric}
                     </SummarySectionLine>

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
@@ -34,7 +34,7 @@ import {
   REPORTS_LOWERCASE,
 } from "../Global/constants";
 import {
-  AgencyTitle,
+  AgencyName,
   EmptyIcon,
   Heading,
   HeadingGradient,
@@ -84,7 +84,7 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
         {/* {isSuperAgencyUpload && datapointsByAgencyName ? (
           Object.entries(datapointsByAgencyName).map(([key, dpByMetrics]) => (
             <>
-              <AgencyTitle>{key}</AgencyTitle>
+              <AgencyName>{key}</AgencyName>
               {Object.entries(dpByMetrics).map(([metricName, dps]) => (
                 <DatapointsTableView datapoints={dps} metricName={metricName} />
               ))}
@@ -244,15 +244,17 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
             ? Object.entries(datapointsByAgencyName).map(
                 ([key, dpByMetrics]) => (
                   <Fragment key={key}>
-                    <AgencyTitle>{key}</AgencyTitle>
-                    {Object.entries(dpByMetrics).map(([metricName, dps]) => (
-                      <SectionContainer key={metricName}>
-                        <DatapointsTableView
-                          datapoints={dps}
-                          metricName={metricName}
-                        />
-                      </SectionContainer>
-                    ))}
+                    <AgencyName>{key}</AgencyName>
+                    <div>
+                      {Object.entries(dpByMetrics).map(([metricName, dps]) => (
+                        <SectionContainer key={metricName}>
+                          <DatapointsTableView
+                            datapoints={dps}
+                            metricName={metricName}
+                          />
+                        </SectionContainer>
+                      ))}
+                    </div>
                   </Fragment>
                 )
               )

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
@@ -99,25 +99,27 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
   const renderDatapointsByMetricNameByAgencyName = (
     groupedDatapoints: DatapointsByMetricNameByAgencyName
   ) => {
-    return Object.entries(groupedDatapoints).map(([key, dpByMetrics]) => (
-      <Fragment key={key}>
-        <AgencyName>{key}</AgencyName>
-        <div>
-          {Object.entries(dpByMetrics).map(([metricName, dps]) => (
-            <SectionContainer
-              key={metricName}
-              isMultiAgencyUpload={isMultiAgencyUpload}
-            >
-              <DatapointsTableView
-                datapoints={dps}
-                metricName={metricName}
-                useMultiAgencyStyles={isMultiAgencyUpload}
-              />
-            </SectionContainer>
-          ))}
-        </div>
-      </Fragment>
-    ));
+    return Object.entries(groupedDatapoints).map(
+      ([agencyName, dpByMetrics]) => (
+        <Fragment key={agencyName}>
+          <AgencyName>{agencyName}</AgencyName>
+          <div>
+            {Object.entries(dpByMetrics).map(([metricName, dps]) => (
+              <SectionContainer
+                key={metricName}
+                isMultiAgencyUpload={isMultiAgencyUpload}
+              >
+                <DatapointsTableView
+                  datapoints={dps}
+                  metricName={metricName}
+                  useMultiAgencyStyles={isMultiAgencyUpload}
+                />
+              </SectionContainer>
+            ))}
+          </div>
+        </Fragment>
+      )
+    );
   };
 
   const renderOverwritesByAgencyName = (

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
@@ -123,7 +123,11 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
   const renderOverwritesByAgencyName = (
     reviewMetricOverwrites: ReviewMetricOverwrites[]
   ) => {
-    const groupedMetricOverwrites = reviewMetricOverwrites.reduce(
+    /**
+     * Groups metric overwrites by agency name
+     * @example { "Agency 1": { key, metricName, dimensionName, startDate, agencyName }, "Agency 2": { ... } }
+     */
+    const groupedMetricOverwritesByAgencyName = reviewMetricOverwrites.reduce(
       (acc, overwrite) => {
         if (!overwrite.agencyName) return acc;
         if (!acc[overwrite.agencyName]) {
@@ -137,7 +141,7 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
 
     return (
       <OverwritesWrapper>
-        {Object.entries(groupedMetricOverwrites).map(
+        {Object.entries(groupedMetricOverwritesByAgencyName).map(
           ([agencyName, overwrites]) => (
             <Fragment key={agencyName}>
               <OverwritesAgencyName>{agencyName}</OverwritesAgencyName>

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
@@ -22,7 +22,7 @@ import { DatapointsTableView } from "@justice-counts/common/components/DataViz/D
 import { formatDateShortMonthYear } from "@justice-counts/common/components/DataViz/utils";
 import { HeaderBar } from "@justice-counts/common/components/HeaderBar";
 import { useIsFooterVisible } from "@justice-counts/common/hooks";
-import React, { useState } from "react";
+import React, { Fragment, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
 import { printReportTitle } from "../../utils";
@@ -81,22 +81,21 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
   const renderSection = (metric: ReviewMetric) => {
     return (
       <SectionContainer key={metric.key}>
-        {isSuperAgencyUpload && datapointsByAgencyName ? (
-          Object.entries(datapointsByAgencyName).map(([key, datapoints]) => (
+        {/* {isSuperAgencyUpload && datapointsByAgencyName ? (
+          Object.entries(datapointsByAgencyName).map(([key, dpByMetrics]) => (
             <>
               <AgencyTitle>{key}</AgencyTitle>
-              <DatapointsTableView
-                datapoints={datapoints}
-                metricName={metric.display_name}
-              />
+              {Object.entries(dpByMetrics).map(([metricName, dps]) => (
+                <DatapointsTableView datapoints={dps} metricName={metricName} />
+              ))}
             </>
           ))
-        ) : (
-          <DatapointsTableView
-            datapoints={metric.datapoints}
-            metricName={metric.display_name}
-          />
-        )}
+        ) : ( */}
+        <DatapointsTableView
+          datapoints={metric.datapoints}
+          metricName={metric.display_name}
+        />
+        {/* )} */}
       </SectionContainer>
     );
   };
@@ -241,9 +240,25 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
         </NoDatapointsMessage>
       ) : (
         <MetricsPanel>
-          {metrics.map((metric) => {
-            return renderSection(metric);
-          })}
+          {isSuperAgencyUpload && datapointsByAgencyName
+            ? Object.entries(datapointsByAgencyName).map(
+                ([key, dpByMetrics]) => (
+                  <Fragment key={key}>
+                    <AgencyTitle>{key}</AgencyTitle>
+                    {Object.entries(dpByMetrics).map(([metricName, dps]) => (
+                      <SectionContainer key={metricName}>
+                        <DatapointsTableView
+                          datapoints={dps}
+                          metricName={metricName}
+                        />
+                      </SectionContainer>
+                    ))}
+                  </Fragment>
+                )
+              )
+            : metrics.map((metric) => {
+                return renderSection(metric);
+              })}
         </MetricsPanel>
       )}
     </ReviewMetricsWrapper>

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
@@ -178,6 +178,7 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
                   <SummaryAgencyName>{agencyName}</SummaryAgencyName>
                   {Object.keys(agencyMetrics).map((metric) => (
                     <SummarySectionLine key={metric}>
+                      <MetricStatusIcon src={checkIcon} alt="" />
                       {metric}
                     </SummarySectionLine>
                   ))}

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
@@ -60,7 +60,7 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
   metrics,
   metricOverwrites,
   records,
-  isSuperAgencyUpload,
+  isMultiAgencyUpload,
   datapointsByAgencyName,
 }) => {
   const { agencyId } = useParams();
@@ -81,21 +81,10 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
   const renderSection = (metric: ReviewMetric) => {
     return (
       <SectionContainer key={metric.key}>
-        {/* {isSuperAgencyUpload && datapointsByAgencyName ? (
-          Object.entries(datapointsByAgencyName).map(([key, dpByMetrics]) => (
-            <>
-              <AgencyName>{key}</AgencyName>
-              {Object.entries(dpByMetrics).map(([metricName, dps]) => (
-                <DatapointsTableView datapoints={dps} metricName={metricName} />
-              ))}
-            </>
-          ))
-        ) : ( */}
         <DatapointsTableView
           datapoints={metric.datapoints}
           metricName={metric.display_name}
         />
-        {/* )} */}
       </SectionContainer>
     );
   };
@@ -240,7 +229,7 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
         </NoDatapointsMessage>
       ) : (
         <MetricsPanel>
-          {isSuperAgencyUpload && datapointsByAgencyName
+          {isMultiAgencyUpload && datapointsByAgencyName
             ? Object.entries(datapointsByAgencyName).map(
                 ([key, dpByMetrics]) => (
                   <Fragment key={key}>

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
@@ -59,6 +59,8 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
   metrics,
   metricOverwrites,
   records,
+  isSuperAgencyUpload,
+  datapointsByAgencyName,
 }) => {
   const { agencyId } = useParams();
   const navigate = useNavigate();

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
@@ -41,6 +41,8 @@ import {
   MetricsPanel,
   MetricStatusIcon,
   NoDatapointsMessage,
+  OverwritesAgencyName,
+  OverwritesWrapper,
   ReviewMetricsButtonsContainer,
   ReviewMetricsWrapper,
   SectionContainer,
@@ -54,6 +56,7 @@ import {
 import {
   DatapointsByMetricNameByAgencyName,
   ReviewMetric,
+  ReviewMetricOverwrites,
   ReviewMetricsProps,
 } from "./types";
 
@@ -115,6 +118,42 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
         </div>
       </Fragment>
     ));
+  };
+
+  const renderOverwritesByAgencyName = (
+    reviewMetricOverwrites: ReviewMetricOverwrites[]
+  ) => {
+    const groupedMetricOverwrites = reviewMetricOverwrites.reduce(
+      (acc, overwrite) => {
+        if (!overwrite.agencyName) return acc;
+        if (!acc[overwrite.agencyName]) {
+          acc[overwrite.agencyName] = [];
+        }
+        acc[overwrite.agencyName].push(overwrite);
+        return acc;
+      },
+      {} as { [key: string]: ReviewMetricOverwrites[] }
+    );
+
+    return (
+      <OverwritesWrapper>
+        {Object.entries(groupedMetricOverwrites).map(
+          ([agencyName, overwrites]) => (
+            <Fragment key={agencyName}>
+              <OverwritesAgencyName>{agencyName}</OverwritesAgencyName>
+              {overwrites.map(
+                ({ key, metricName, dimensionName, startDate }) => (
+                  <SummarySectionLine key={key}>
+                    {metricName}: {dimensionName}
+                    <span>({formatDateShortMonthYear(startDate)})</span>
+                  </SummarySectionLine>
+                )
+              )}
+            </Fragment>
+          )
+        )}
+      </OverwritesWrapper>
+    );
   };
 
   return (
@@ -210,15 +249,20 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
                   {isOverwritesSectionExpanded ? "-" : "+"}
                 </SectionExpandStatusSign>
               </SummarySectionTitle>
-              {isOverwritesSectionExpanded &&
-                metricOverwrites.map(
-                  ({ key, metricName, dimensionName, startDate }) => (
-                    <SummarySectionLine key={key}>
-                      {metricName}: {dimensionName}
-                      <span>({formatDateShortMonthYear(startDate)})</span>
-                    </SummarySectionLine>
-                  )
-                )}
+              {isOverwritesSectionExpanded && (
+                <>
+                  {isMultiAgencyUpload
+                    ? renderOverwritesByAgencyName(metricOverwrites)
+                    : metricOverwrites.map(
+                        ({ key, metricName, dimensionName, startDate }) => (
+                          <SummarySectionLine key={key}>
+                            {metricName}: {dimensionName}
+                            <span>({formatDateShortMonthYear(startDate)})</span>
+                          </SummarySectionLine>
+                        )
+                      )}
+                </>
+              )}
             </SummarySection>
           )}
           {records && records.length > 0 && (

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
@@ -101,8 +101,15 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
         <AgencyName>{key}</AgencyName>
         <div>
           {Object.entries(dpByMetrics).map(([metricName, dps]) => (
-            <SectionContainer key={metricName}>
-              <DatapointsTableView datapoints={dps} metricName={metricName} />
+            <SectionContainer
+              key={metricName}
+              isMultiAgencyUpload={isMultiAgencyUpload}
+            >
+              <DatapointsTableView
+                datapoints={dps}
+                metricName={metricName}
+                useMultiAgencyStyles={isMultiAgencyUpload}
+              />
             </SectionContainer>
           ))}
         </div>

--- a/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
+++ b/publisher/src/components/ReviewMetrics/ReviewMetrics.tsx
@@ -51,7 +51,11 @@ import {
   SummarySectionsContainer,
   SummarySectionTitle,
 } from "./ReviewMetrics.styles";
-import { ReviewMetric, ReviewMetricsProps } from "./types";
+import {
+  DatapointsByMetricNameByAgencyName,
+  ReviewMetric,
+  ReviewMetricsProps,
+} from "./types";
 
 export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
   title,
@@ -61,7 +65,7 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
   metricOverwrites,
   records,
   isMultiAgencyUpload,
-  datapointsByAgencyName,
+  datapointsByMetricNameByAgencyName,
 }) => {
   const { agencyId } = useParams();
   const navigate = useNavigate();
@@ -87,6 +91,23 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
         />
       </SectionContainer>
     );
+  };
+
+  const renderDatapointsByMetricNameByAgencyName = (
+    groupedDatapoints: DatapointsByMetricNameByAgencyName
+  ) => {
+    return Object.entries(groupedDatapoints).map(([key, dpByMetrics]) => (
+      <Fragment key={key}>
+        <AgencyName>{key}</AgencyName>
+        <div>
+          {Object.entries(dpByMetrics).map(([metricName, dps]) => (
+            <SectionContainer key={metricName}>
+              <DatapointsTableView datapoints={dps} metricName={metricName} />
+            </SectionContainer>
+          ))}
+        </div>
+      </Fragment>
+    ));
   };
 
   return (
@@ -229,23 +250,9 @@ export const ReviewMetrics: React.FC<ReviewMetricsProps> = ({
         </NoDatapointsMessage>
       ) : (
         <MetricsPanel>
-          {isMultiAgencyUpload && datapointsByAgencyName
-            ? Object.entries(datapointsByAgencyName).map(
-                ([key, dpByMetrics]) => (
-                  <Fragment key={key}>
-                    <AgencyName>{key}</AgencyName>
-                    <div>
-                      {Object.entries(dpByMetrics).map(([metricName, dps]) => (
-                        <SectionContainer key={metricName}>
-                          <DatapointsTableView
-                            datapoints={dps}
-                            metricName={metricName}
-                          />
-                        </SectionContainer>
-                      ))}
-                    </div>
-                  </Fragment>
-                )
+          {isMultiAgencyUpload && datapointsByMetricNameByAgencyName
+            ? renderDatapointsByMetricNameByAgencyName(
+                datapointsByMetricNameByAgencyName
               )
             : metrics.map((metric) => {
                 return renderSection(metric);

--- a/publisher/src/components/ReviewMetrics/types.ts
+++ b/publisher/src/components/ReviewMetrics/types.ts
@@ -60,6 +60,8 @@ export type ReviewMetricsProps = {
   metrics: ReviewMetric[];
   metricOverwrites?: ReviewMetricOverwrites[];
   records?: ReportOverview[];
+  isSuperAgencyUpload?: boolean;
+  datapointsByAgencyName?: DatapointsByAgencyName;
 };
 
 export type PublishReviewMetricErrors = {
@@ -74,4 +76,8 @@ export type PublishReviewPropsFromDatapoints = {
     displayName: string;
   }[];
   metricErrors: PublishReviewMetricErrors;
+};
+
+export type DatapointsByAgencyName = {
+  [key: string]: RawDatapoint[];
 };

--- a/publisher/src/components/ReviewMetrics/types.ts
+++ b/publisher/src/components/ReviewMetrics/types.ts
@@ -60,7 +60,7 @@ export type ReviewMetricsProps = {
   metrics: ReviewMetric[];
   metricOverwrites?: ReviewMetricOverwrites[];
   records?: ReportOverview[];
-  isSuperAgencyUpload?: boolean;
+  isMultiAgencyUpload?: boolean;
   datapointsByAgencyName?: DatapointsByAgencyName;
 };
 

--- a/publisher/src/components/ReviewMetrics/types.ts
+++ b/publisher/src/components/ReviewMetrics/types.ts
@@ -51,6 +51,7 @@ export type ReviewMetricOverwrites = {
   metricName: string;
   dimensionName: string;
   startDate: string;
+  agencyName?: string;
 };
 
 export type ReviewMetricsProps = {

--- a/publisher/src/components/ReviewMetrics/types.ts
+++ b/publisher/src/components/ReviewMetrics/types.ts
@@ -61,7 +61,7 @@ export type ReviewMetricsProps = {
   metricOverwrites?: ReviewMetricOverwrites[];
   records?: ReportOverview[];
   isMultiAgencyUpload?: boolean;
-  datapointsByAgencyName?: DatapointsByAgencyName;
+  datapointsByMetricNameByAgencyName?: DatapointsByMetricNameByAgencyName;
 };
 
 export type PublishReviewMetricErrors = {
@@ -78,6 +78,6 @@ export type PublishReviewPropsFromDatapoints = {
   metricErrors: PublishReviewMetricErrors;
 };
 
-export type DatapointsByAgencyName = {
+export type DatapointsByMetricNameByAgencyName = {
   [agencyName: string]: { [metricName: string]: RawDatapoint[] };
 };

--- a/publisher/src/components/ReviewMetrics/types.ts
+++ b/publisher/src/components/ReviewMetrics/types.ts
@@ -79,5 +79,5 @@ export type PublishReviewPropsFromDatapoints = {
 };
 
 export type DatapointsByAgencyName = {
-  [key: string]: RawDatapoint[];
+  [agencyName: string]: { [metricName: string]: RawDatapoint[] };
 };


### PR DESCRIPTION
## Description of the change

Refactors the bulk upload review page to handle and properly display multiple agency uploads. The review page treatment remains the same for single agency uploads.

Screenshot of multiple agency upload treatment w/ overwrites:
<img width="1728" alt="Screenshot 2023-05-25 at 2 04 37 PM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/1a4efc4f-6e9b-48f9-91bf-cb748cd13faa">
Question: does this look right for uploading overwrites? It doesn't show the Staff metrics in the review page, which I thought were included in the spreadsheet (albeit there were no changes there - I only changed the arrest metrics to trigger the overwrite)

Video comparing single agency vs multiple agency upload:

https://github.com/Recidiviz/justice-counts/assets/59492998/fc2221a0-c227-4a8d-b311-d5f1477b713c

Spreadsheet I've been using: 
[sample-super-agency-sheet-two-metrics.xlsx](https://github.com/Recidiviz/justice-counts/files/11568161/sample-super-agency-sheet-two-metrics.xlsx)

NOTE: If running locally, you'll need to setup your account to have a super agency + child agencies. In the example above, my super agency is Law Enforcement w/ two Law Enforcement child agencies. Instructions can be found here: https://github.com/Recidiviz/justice-counts/pull/608#issuecomment-1534087462

## Related issues

Closes #658 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
