### PR TITLE
[Bug] Data Entry Page: Filter out metrics that do not match the reporting frequency of the report

### DIFF
--- a/publisher/src/components/Reports/DataEntryForm.tsx
+++ b/publisher/src/components/Reports/DataEntryForm.tsx
@@ -359,7 +359,10 @@ const DataEntryForm: React.FC<{
             {Object.entries(metricsBySystem).map(
               ([system, metrics], systemIndex) => {
                 const enabledMetrics = metrics.filter(
-                  (metric) => metric.enabled
+                  (metric) =>
+                    metric.enabled &&
+                    (metric.custom_frequency || metric.frequency) ===
+                      reportOverview.frequency
                 );
 
                 const disabledMetrics = metrics.filter(

--- a/publisher/src/components/Reports/ReportSummaryPanel.tsx
+++ b/publisher/src/components/Reports/ReportSummaryPanel.tsx
@@ -265,7 +265,11 @@ const ReportSummaryPanel: React.FC<{
 
       <ReportSummaryProgressIndicatorWrapper>
         {Object.entries(metricsBySystem).map(([system, metrics]) => {
-          const enabledMetrics = metrics.filter((metric) => metric.enabled);
+          const enabledMetrics = metrics.filter(
+            (metric) =>
+              metric.enabled &&
+              (metric.custom_frequency || metric.frequency) === frequency
+          );
 
           return (
             <React.Fragment key={system}>


### PR DESCRIPTION
## Description of the change

Filters out metrics in the Data Entry Page that do not match the current report's reporting frequency. 

Companion to this [BE PR](https://github.com/Recidiviz/recidiviz-data/pull/21381)

## Related issues

Contributes to [#21380](https://github.com/Recidiviz/recidiviz-data/issues/21380)

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
