### PR TITLE
[21327] Add Segment tracking functions based on design doc

### DIFF
--- a/publisher/src/analytics.ts
+++ b/publisher/src/analytics.ts
@@ -194,3 +194,21 @@ export const trackLoadTime = (
     loadTime,
   });
 };
+
+type TrackingInput = {
+  agencyId: string;
+  key: string;
+  enabled: boolean;
+};
+
+export const trackMetricConfiguration = ({
+  agencyId,
+  key,
+  enabled,
+}: Partial<TrackingInput>): void => {
+  track("metric_configured", {
+    agencyId,
+    key,
+    enabled,
+  });
+};

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -33,6 +33,7 @@ import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
+import { trackMetricConfiguration } from "../../analytics";
 import { useStore } from "../../stores";
 import { monthsByName, removeSnakeCase } from "../../utils";
 import { ReactComponent as CalendarIconDark } from "../assets/calendar-icon-dark.svg";
@@ -79,7 +80,7 @@ function MetricAvailability() {
     startingMonth,
     disaggregatedBySupervisionSubsystems,
   } = metrics[systemMetricKey];
-  const metricEnabled = metrics[systemMetricKey]?.enabled;
+  const metricEnabled = metrics[systemMetricKey]?.enabled ?? false;
   const customOrDefaultFrequency = customFrequency || defaultFrequency;
   const startingMonthNotJanuaryJuly =
     startingMonth !== null && startingMonth !== 1 && startingMonth !== 7;
@@ -98,6 +99,11 @@ function MetricAvailability() {
         metricSearchParam,
         enabledStatus
       );
+      trackMetricConfiguration({
+        agencyId,
+        key: metricSearchParam,
+        enabled: enabledStatus,
+      });
       saveMetricSettings(updatedSetting, agencyId);
     }
   };
@@ -111,6 +117,11 @@ function MetricAvailability() {
         metricSearchParam,
         frequencyUpdate
       );
+      trackMetricConfiguration({
+        agencyId,
+        key: metricSearchParam,
+        enabled: metricEnabled,
+      });
       saveMetricSettings(updatedSetting, agencyId);
     }
   };


### PR DESCRIPTION
## Description of the change

Adds Segment tracking for metric configuration. This will help us track in real-time when an agency enables or disables a metric.

## How to Test

- Log in as an Agency
- Create/Enable or disable metric
- Check Segment dashboard for `metric_configured` event

## Type of change

Feature

## Related issues

Closes #21327

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [x] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
