### PR TITLE
Gate the Delete functionality of Bulk Actions to JC Admins only

### DIFF
--- a/publisher/src/pages/Reports.tsx
+++ b/publisher/src/pages/Reports.tsx
@@ -242,6 +242,7 @@ const Reports: React.FC = () => {
       noHover: true,
     },
   ].filter((option) => {
+    // Gates `Delete` action to Justice Counts Admins only
     if (option.key === "deleteAction" && !isJCAdmin) {
       return false;
     }

--- a/publisher/src/pages/Reports.tsx
+++ b/publisher/src/pages/Reports.tsx
@@ -119,6 +119,11 @@ const Reports: React.FC = () => {
   const [isRemoveRecordsModalOpen, setIsRemoveRecordsModalOpen] =
     useState(false);
 
+  const isAdmin =
+    userStore.isJusticeCountsAdmin(agencyId) ||
+    userStore.isAgencyAdmin(agencyId);
+  const isJCAdmin = userStore.isJusticeCountsAdmin(agencyId);
+
   const selectBulkAction = (action: RecordsBulkAction) => setBulkAction(action);
   const clearBulkAction = () => setBulkAction(undefined);
   const clearAllSelectedRecords = () => setSelectedRecords([]);
@@ -234,6 +239,7 @@ const Reports: React.FC = () => {
       label: "Delete...",
       onClick: () => selectBulkAction("delete"),
       color: "red",
+      disabled: !isJCAdmin,
       noHover: true,
     },
   ];
@@ -253,10 +259,6 @@ const Reports: React.FC = () => {
     onClick: () => setReportsFilter(normalizeString(key)),
     highlight: ReportStatusFilterOptionObject[reportsFilter] === value,
   }));
-
-  const isAdmin =
-    userStore.isJusticeCountsAdmin(agencyId) ||
-    userStore.isAgencyAdmin(agencyId);
 
   const renderReports = () => {
     if (reportStore.loadingOverview) {

--- a/publisher/src/pages/Reports.tsx
+++ b/publisher/src/pages/Reports.tsx
@@ -218,7 +218,7 @@ const Reports: React.FC = () => {
     reportsFilter === "not_started" ||
     filteredReportsMemoized.filter((record) => record.status === "PUBLISHED")
       .length === 0;
-  const bulkActionsDropdownOptions: DropdownOption[] = [
+  const bulkActionsDropdownOptions = [
     {
       key: "publishAction",
       label: "Publish...",
@@ -239,10 +239,14 @@ const Reports: React.FC = () => {
       label: "Delete...",
       onClick: () => selectBulkAction("delete"),
       color: "red",
-      disabled: !isJCAdmin,
       noHover: true,
     },
-  ];
+  ].filter((option) => {
+    if (option.key === "deleteAction" && !isJCAdmin) {
+      return false;
+    }
+    return true;
+  }) as DropdownOption[];
   const tabbedBarOptions: TabOption[] = Object.entries(
     ReportStatusFilterOptionObject
   ).map(([key, value]) => ({


### PR DESCRIPTION
## Description of the change


The BE currently throws a JusticeCountsServerError when a user tries to delete records but is not a JC admin. The FE currently allows agency admins and JC admins to access the Bulk Actions > Delete button. This effectively gates the Delete action button to JC admins only in-line with the BE.


<img width="1728" alt="Screenshot 2023-06-20 at 1 57 01 PM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/86b5f34e-f4b1-40ba-ae25-e6c1a2474609">

Let me know if there's a preference in not rendering it at all - for now I kept it in a disabled state for non-JC admins.

## Related issues

Closes #710
*Resolves the `JusticeCountsServerError - api.delete_reports` error

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
