### PR TITLE
New Homepage: Support agencies with multiple systems [2/n]

### DIFF
--- a/publisher/src/components/Home/Home.styled.tsx
+++ b/publisher/src/components/Home/Home.styled.tsx
@@ -45,7 +45,7 @@ export const WelcomeUser = styled.div`
 export const WelcomeDescription = styled.div`
   ${typography.sizeCSS.medium};
   color: ${palette.highlight.grey8};
-  margin-bottom: 64px;
+  margin-bottom: 48px;
 `;
 
 export const ContentContainer = styled.div`
@@ -166,6 +166,22 @@ export const SubmenuItem = styled.a`
   }
 `;
 
+export const SystemSelectorContainer = styled.div`
+  ${typography.sizeCSS.normal};
+  display: flex;
+  gap: 32px;
+
+  & > div:nth-child(1) {
+    flex: 1 4 280px;
+  }
+  & > div:nth-child(2) {
+    width: 500px;
+  }
+  & > div:nth-child(3) {
+    flex: 1 1 280px;
+  }
+`;
+
 export const SystemSelectorTabWrapper = styled.div`
   display: flex;
   justify-content: flex-start;
@@ -174,6 +190,7 @@ export const SystemSelectorTabWrapper = styled.div`
 `;
 
 export const SystemSelectorTab = styled.div<{ selected?: boolean }>`
+  text-transform: capitalize;
   color: ${({ selected }) =>
     selected ? palette.solid.blue : palette.solid.darkgrey};
   border-bottom: 1.5px solid

--- a/publisher/src/components/Home/Home.tsx
+++ b/publisher/src/components/Home/Home.tsx
@@ -48,10 +48,10 @@ export const Home = observer(() => {
   const navigate = useNavigate();
   const { agencyId } = useParams() as { agencyId: string };
   const currentAgency = userStore.getAgency(agencyId);
-  const agencySystems =
-    currentAgency && currentAgency.systems.length > 1
-      ? ["ALL", ...Object.values(currentAgency.systems)]
-      : (currentAgency && Object.values(currentAgency.systems)) || [];
+  const hasMultipleSystems = currentAgency && currentAgency.systems.length > 1;
+  const agencySystems = hasMultipleSystems
+    ? ["ALL", ...Object.values(currentAgency.systems)]
+    : currentAgency?.systems || [];
 
   const [loading, setLoading] = useState(true);
   const [currentAgencyMetrics, setAgencyMetrics] = useState<Metric[]>([]);
@@ -137,7 +137,7 @@ export const Home = observer(() => {
   useEffect(() => {
     const fetchMetricsAndRecords = async () => {
       setLoading(true);
-      if (agencySystems) setCurrentSystem(agencySystems[0]);
+      if (agencySystems.length > 0) setCurrentSystem(agencySystems[0]);
       const {
         agency_metrics: agencyMetrics,
         annual_reports: annualRecords,
@@ -185,7 +185,26 @@ export const Home = observer(() => {
         {welcomeDescription}
       </Styled.WelcomeDescription>
 
-      {/* {agencySystems.length > 1 && renderSystemSelectorTabs()} */}
+      {/* System Selector */}
+      {agencySystems.length > 1 && (
+        <Styled.SystemSelectorContainer>
+          <div />
+          <Styled.SystemSelectorTabWrapper>
+            {agencySystems?.map((system) => (
+              <Styled.SystemSelectorTab
+                selected={system === currentSystem}
+                key={system}
+                onClick={() => setCurrentSystem(system)}
+              >
+                {system.toLocaleLowerCase()}
+              </Styled.SystemSelectorTab>
+            ))}
+          </Styled.SystemSelectorTabWrapper>
+          <div />
+        </Styled.SystemSelectorContainer>
+      )}
+
+      {/* Tasks & Submenu */}
       <Styled.ContentContainer>
         <Styled.LeftPanelWrapper />
         {/* All Open Tasks */}

--- a/publisher/src/components/Home/Home.tsx
+++ b/publisher/src/components/Home/Home.tsx
@@ -186,7 +186,7 @@ export const Home = observer(() => {
       </Styled.WelcomeDescription>
 
       {/* System Selector */}
-      {agencySystems.length > 1 && (
+      {hasMultipleSystems && (
         <Styled.SystemSelectorContainer>
           <div />
           <Styled.SystemSelectorTabWrapper>

--- a/publisher/src/components/Home/Home.tsx
+++ b/publisher/src/components/Home/Home.tsx
@@ -77,9 +77,26 @@ export const Home = observer(() => {
   const [currentSystem, setCurrentSystem] = useState(agencySystems[0]);
 
   const userFirstName = userStore.name?.split(" ")[0];
+  /** Does the given metric belong to the currently selected system? */
   const isCurrentSystemMetric = (metric: Metric) =>
     currentSystem === "ALL" ||
     (currentSystem !== "ALL" && metric.system.key === currentSystem);
+  const getSupervisionSubsystemStartingMonth = (metric: Metric) => {
+    if (
+      !latestMonthlyAnnualRecordsMetadata ||
+      !metric.disaggregated_by_supervision_subsystems
+    )
+      return null;
+    const annualRecordsEntries = Object.entries(
+      latestMonthlyAnnualRecordsMetadata.annual
+    );
+    const [startingMonth] =
+      annualRecordsEntries.find(([_, record]) =>
+        record.metrics.find((recordMetric) => recordMetric.key === metric.key)
+      ) || [];
+    return Number(startingMonth);
+  };
+
   /** Task Card Metadatas */
   const allTasksCompleteTaskCardMetadata: TaskCardMetadata = {
     title: "All tasks complete",

--- a/publisher/src/components/Home/Home.tsx
+++ b/publisher/src/components/Home/Home.tsx
@@ -46,7 +46,12 @@ import * as Styled from "./Home.styled";
 export const Home = observer(() => {
   const { userStore, reportStore } = useStore();
   const navigate = useNavigate();
-  const { agencyId } = useParams();
+  const { agencyId } = useParams() as { agencyId: string };
+  const currentAgency = userStore.getAgency(agencyId);
+  const agencySystems =
+    currentAgency && currentAgency.systems.length > 1
+      ? ["ALL", ...Object.values(currentAgency.systems)]
+      : (currentAgency && Object.values(currentAgency.systems)) || [];
 
   const [loading, setLoading] = useState(true);
   const [currentAgencyMetrics, setAgencyMetrics] = useState<Metric[]>([]);
@@ -69,6 +74,7 @@ export const Home = observer(() => {
       ? latestMonthlyRecordUnpublished
       : latestAnnualMetricUnpublished;
   };
+  const [currentSystem, setCurrentSystem] = useState(agencySystems[0]);
 
   const userFirstName = userStore.name?.split(" ")[0];
   /** Task Card Metadatas */
@@ -131,7 +137,7 @@ export const Home = observer(() => {
   useEffect(() => {
     const fetchMetricsAndRecords = async () => {
       setLoading(true);
-
+      if (agencySystems) setCurrentSystem(agencySystems[0]);
       const {
         agency_metrics: agencyMetrics,
         annual_reports: annualRecords,
@@ -165,6 +171,7 @@ export const Home = observer(() => {
     };
 
     fetchMetricsAndRecords();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agencyId, reportStore]);
 
   if (!currentAgencyMetrics || loading) {
@@ -178,6 +185,7 @@ export const Home = observer(() => {
         {welcomeDescription}
       </Styled.WelcomeDescription>
 
+      {/* {agencySystems.length > 1 && renderSystemSelectorTabs()} */}
       <Styled.ContentContainer>
         <Styled.LeftPanelWrapper />
         {/* All Open Tasks */}

--- a/publisher/src/components/Home/Home.tsx
+++ b/publisher/src/components/Home/Home.tsx
@@ -80,7 +80,6 @@ export const Home = observer(() => {
   const isCurrentSystemMetric = (metric: Metric) =>
     currentSystem === "ALL" ||
     (currentSystem !== "ALL" && metric.system.key === currentSystem);
-
   /** Task Card Metadatas */
   const allTasksCompleteTaskCardMetadata: TaskCardMetadata = {
     title: "All tasks complete",

--- a/publisher/src/components/Home/Home.tsx
+++ b/publisher/src/components/Home/Home.tsx
@@ -144,7 +144,7 @@ export const Home = observer(() => {
   useEffect(() => {
     const fetchMetricsAndRecords = async () => {
       setLoading(true);
-      if (agencySystems.length > 0) setCurrentSystem(agencySystems[0]);
+
       const {
         agency_metrics: agencyMetrics,
         annual_reports: annualRecords,

--- a/publisher/src/components/Home/Home.tsx
+++ b/publisher/src/components/Home/Home.tsx
@@ -77,6 +77,10 @@ export const Home = observer(() => {
   const [currentSystem, setCurrentSystem] = useState(agencySystems[0]);
 
   const userFirstName = userStore.name?.split(" ")[0];
+  const isCurrentSystemMetric = (metric: Metric) =>
+    currentSystem === "ALL" ||
+    (currentSystem !== "ALL" && metric.system.key === currentSystem);
+
   /** Task Card Metadatas */
   const allTasksCompleteTaskCardMetadata: TaskCardMetadata = {
     title: "All tasks complete",
@@ -192,8 +196,8 @@ export const Home = observer(() => {
           <Styled.SystemSelectorTabWrapper>
             {agencySystems?.map((system) => (
               <Styled.SystemSelectorTab
-                selected={system === currentSystem}
                 key={system}
+                selected={system === currentSystem}
                 onClick={() => setCurrentSystem(system)}
               >
                 {system.toLocaleLowerCase()}

--- a/publisher/src/components/Home/TaskCard.tsx
+++ b/publisher/src/components/Home/TaskCard.tsx
@@ -36,7 +36,8 @@ export const TaskCard: React.FC<{
   reportID?: number;
 }> = ({ metadata, reportID }) => {
   const navigate = useNavigate();
-  const { title, description, actionLinks, metricSettingsParams } = metadata;
+  const { title, description, actionLinks, metricSettingsParams, metricKey } =
+    metadata;
 
   return (
     <Styled.TaskCardContainer key={title}>
@@ -62,7 +63,12 @@ export const TaskCard: React.FC<{
                 if (isSetMetricAvailabilityAction) {
                   return navigate(`./${action.path + metricSettingsParams}`);
                 }
-                if (isManualEntryAction || isPublishAction) {
+                if (isManualEntryAction) {
+                  return navigate(`./${action.path + reportID}`, {
+                    state: { scrollToMetricKey: metricKey },
+                  });
+                }
+                if (isPublishAction) {
                   return navigate(
                     `./${action.path + reportID + reviewPagePath}`
                   );

--- a/publisher/src/components/Home/helpers.ts
+++ b/publisher/src/components/Home/helpers.ts
@@ -127,6 +127,7 @@ export const createDataEntryTaskCardMetadata = (
     ],
     metricFrequency,
     hasMetricValue,
+    metricKey: currentMetric.key,
   };
 };
 

--- a/publisher/src/components/Home/types.ts
+++ b/publisher/src/components/Home/types.ts
@@ -36,6 +36,7 @@ export type TaskCardMetadata = {
   metricFrequency?: ReportFrequency;
   metricSettingsParams?: string;
   hasMetricValue?: boolean;
+  metricKey?: string;
 };
 
 export type TaskCardActionLinksMetadata = { label: string; path: string };

--- a/publisher/src/components/Reports/DataEntryForm.tsx
+++ b/publisher/src/components/Reports/DataEntryForm.tsx
@@ -27,7 +27,7 @@ import { AgencySystems, Report } from "@justice-counts/common/types";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react-lite";
 import React, { Fragment, useEffect, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components/macro";
 
 import {
@@ -124,6 +124,7 @@ const DataEntryForm: React.FC<{
 }) => {
   const { agencyId } = useParams() as { agencyId: string };
   const navigate = useNavigate();
+  const { state } = useLocation();
   const headerBadge = useHeaderBadge();
   const { formStore, reportStore, userStore } = useStore();
   const [showOnboarding, setShowOnboarding] = useState(true);
@@ -133,9 +134,17 @@ const DataEntryForm: React.FC<{
   const metricsRef = useRef<HTMLDivElement[]>([]);
 
   const currentAgency = userStore.getAgency(agencyId);
-
   const isPublished =
     reportStore.reportOverviews[reportID].status === "PUBLISHED";
+
+  /** Scroll to metric (currently used by new Home page task cards) */
+  useEffect(() => {
+    if (state?.scrollToMetricKey) {
+      document
+        .getElementById(state.scrollToMetricKey)
+        ?.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [state]);
 
   useEffect(
     () => {


### PR DESCRIPTION
## Description of the change

Adds system selector buttons (for agencies with multiple systems) to toggle the home page task cards based on system.

Preview:

https://github.com/Recidiviz/justice-counts/assets/59492998/70c27a9b-f443-438c-a717-da67d39fb05b

[Would love a sanity check of the supervision with subsystems cases if folks have the bandwidth.]

## Related issues

Closes #716 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
