### PR TITLE
Agency Settings & Metric Config: Action Required treatment

### DIFF
--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.styled.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.styled.tsx
@@ -90,10 +90,11 @@ export const MetricsSection = styled.div`
   flex-direction: column;
 `;
 
-export const MetricsSectionTitle = styled.div`
+export const MetricsSectionTitle = styled.div<{ textColor?: string }>`
   ${typography.sizeCSS.medium};
   margin-bottom: 12px;
-  color: ${palette.highlight.grey9};
+  color: ${({ textColor }) =>
+    textColor === "red" ? palette.solid.red : palette.highlight.grey9};
 `;
 
 export const MetricItem = styled.div`

--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
@@ -97,7 +97,7 @@ export function MetricsOverview() {
       <Styled.MetricsWrapper>
         {hasActionRequiredMetrics && (
           <Styled.MetricsSection>
-            <Styled.MetricsSectionTitle>
+            <Styled.MetricsSectionTitle textColor="red">
               Action required
             </Styled.MetricsSectionTitle>
             {actionRequiredMetrics?.map(({ key, metric }) => (

--- a/publisher/src/components/Settings/AgencySettings.styles.tsx
+++ b/publisher/src/components/Settings/AgencySettings.styles.tsx
@@ -119,10 +119,24 @@ export const AgencySettingsBlock = styled.div<{
 
 export const AgencySettingsBlockTitle = styled.div<{
   isEditModeActive?: boolean;
+  configured?: boolean;
 }>`
   ${typography.sizeCSS.large};
   margin-bottom: ${({ isEditModeActive }) =>
     isEditModeActive ? "8px" : "16px"};
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  ${({ configured }) =>
+    configured === false &&
+    `
+    &::after {
+      ${typography.sizeCSS.small}
+      content: "Action Required";
+      color: ${palette.solid.red};
+    } 
+  `}
 `;
 
 export const AgencySettingsBlockDescription = styled.div`

--- a/publisher/src/components/Settings/AgencySettingsDescription.tsx
+++ b/publisher/src/components/Settings/AgencySettingsDescription.tsx
@@ -119,7 +119,11 @@ const AgencySettingsDescription: React.FC<{
   return (
     <>
       <AgencySettingsBlock id="description">
-        <AgencySettingsBlockTitle>Agency Information</AgencySettingsBlockTitle>
+        <AgencySettingsBlockTitle
+          configured={Boolean(currentAgencySettings?.[0]?.value)}
+        >
+          Agency Information
+        </AgencySettingsBlockTitle>
         <AgencyInfoBlockDescription>
           {purposeAndFunctionsSetting || "No description added."}
         </AgencyInfoBlockDescription>

--- a/publisher/src/components/Settings/AgencySettingsDescription.tsx
+++ b/publisher/src/components/Settings/AgencySettingsDescription.tsx
@@ -55,11 +55,7 @@ const AgencySettingsDescription: React.FC<{
     currentAgencySettings?.find(
       (setting) => setting.setting_type === "PURPOSE_AND_FUNCTIONS"
     )?.value || "";
-  const isAgencySettingConfigured = Boolean(
-    currentAgencySettings?.find(
-      (setting) => setting.setting_type === "PURPOSE_AND_FUNCTIONS"
-    )?.value
-  );
+  const isAgencySettingConfigured = Boolean(purposeAndFunctionsSetting);
 
   const handleSaveClick = () => {
     const updatedSettings = updateAgencySettings(

--- a/publisher/src/components/Settings/AgencySettingsDescription.tsx
+++ b/publisher/src/components/Settings/AgencySettingsDescription.tsx
@@ -55,6 +55,11 @@ const AgencySettingsDescription: React.FC<{
     currentAgencySettings?.find(
       (setting) => setting.setting_type === "PURPOSE_AND_FUNCTIONS"
     )?.value || "";
+  const isAgencySettingConfigured = Boolean(
+    currentAgencySettings?.find(
+      (setting) => setting.setting_type === "PURPOSE_AND_FUNCTIONS"
+    )?.value
+  );
 
   const handleSaveClick = () => {
     const updatedSettings = updateAgencySettings(
@@ -119,9 +124,7 @@ const AgencySettingsDescription: React.FC<{
   return (
     <>
       <AgencySettingsBlock id="description">
-        <AgencySettingsBlockTitle
-          configured={Boolean(currentAgencySettings?.[0]?.value)}
-        >
+        <AgencySettingsBlockTitle configured={isAgencySettingConfigured}>
           Agency Information
         </AgencySettingsBlockTitle>
         <AgencyInfoBlockDescription>

--- a/publisher/src/components/Settings/AgencySettingsJurisdictions.tsx
+++ b/publisher/src/components/Settings/AgencySettingsJurisdictions.tsx
@@ -66,6 +66,7 @@ export const AgencySettingsJurisdictions: React.FC<{
     settingProps;
   const { agencyStore } = useStore();
   const {
+    currentAgencySettings,
     includedJurisdictionsIds,
     excludedJurisdictionsIds,
     updateAgencyJurisdictions,
@@ -439,7 +440,11 @@ export const AgencySettingsJurisdictions: React.FC<{
   return (
     <>
       <AgencySettingsBlock id="jurisdictions">
-        <AgencySettingsBlockTitle>Jurisdictions</AgencySettingsBlockTitle>
+        <AgencySettingsBlockTitle
+          configured={Boolean(currentAgencySettings?.[2]?.value)}
+        >
+          Jurisdictions
+        </AgencySettingsBlockTitle>
 
         <AgencySettingsBlockDescription>
           The following are within the agency’s jurisdiction.

--- a/publisher/src/components/Settings/AgencySettingsJurisdictions.tsx
+++ b/publisher/src/components/Settings/AgencySettingsJurisdictions.tsx
@@ -66,7 +66,6 @@ export const AgencySettingsJurisdictions: React.FC<{
     settingProps;
   const { agencyStore } = useStore();
   const {
-    currentAgencySettings,
     includedJurisdictionsIds,
     excludedJurisdictionsIds,
     updateAgencyJurisdictions,
@@ -89,6 +88,7 @@ export const AgencySettingsJurisdictions: React.FC<{
   const checkedAreasCount = checkedJurisdictionsIds.length;
   const hasInclusions = includedJurisdictionsIds.length > 0;
   const hasExclusions = excludedJurisdictionsIds.length > 0;
+  const isAgencySettingConfigured = hasInclusions || hasExclusions;
 
   const handleSaveClick = () => {
     const updatedJurisdictions = updateAgencyJurisdictions({
@@ -440,9 +440,7 @@ export const AgencySettingsJurisdictions: React.FC<{
   return (
     <>
       <AgencySettingsBlock id="jurisdictions">
-        <AgencySettingsBlockTitle
-          configured={Boolean(currentAgencySettings?.[2]?.value)}
-        >
+        <AgencySettingsBlockTitle configured={isAgencySettingConfigured}>
           Jurisdictions
         </AgencySettingsBlockTitle>
 

--- a/publisher/src/components/Settings/AgencySettingsURL.tsx
+++ b/publisher/src/components/Settings/AgencySettingsURL.tsx
@@ -124,7 +124,11 @@ const AgencySettingsUrl: React.FC<{
   return (
     <>
       <AgencySettingsBlock id="homepage_url">
-        <AgencySettingsBlockTitle>Agency Homepage URL</AgencySettingsBlockTitle>
+        <AgencySettingsBlockTitle
+          configured={Boolean(currentAgencySettings?.[1]?.value)}
+        >
+          Agency Homepage URL
+        </AgencySettingsBlockTitle>
         <AgencyInfoBlockDescription>
           {homepageUrlSetting ? (
             <AgencyInfoLink

--- a/publisher/src/components/Settings/AgencySettingsURL.tsx
+++ b/publisher/src/components/Settings/AgencySettingsURL.tsx
@@ -55,6 +55,11 @@ const AgencySettingsUrl: React.FC<{
     currentAgencySettings?.find(
       (setting) => setting.setting_type === "HOMEPAGE_URL"
     )?.value || "";
+  const isAgencySettingConfigured = Boolean(
+    currentAgencySettings?.find(
+      (setting) => setting.setting_type === "HOMEPAGE_URL"
+    )?.value
+  );
 
   const handleSaveClick = () => {
     const updatedSettings = updateAgencySettings(
@@ -124,9 +129,7 @@ const AgencySettingsUrl: React.FC<{
   return (
     <>
       <AgencySettingsBlock id="homepage_url">
-        <AgencySettingsBlockTitle
-          configured={Boolean(currentAgencySettings?.[1]?.value)}
-        >
+        <AgencySettingsBlockTitle configured={isAgencySettingConfigured}>
           Agency Homepage URL
         </AgencySettingsBlockTitle>
         <AgencyInfoBlockDescription>

--- a/publisher/src/components/Settings/AgencySettingsURL.tsx
+++ b/publisher/src/components/Settings/AgencySettingsURL.tsx
@@ -55,11 +55,7 @@ const AgencySettingsUrl: React.FC<{
     currentAgencySettings?.find(
       (setting) => setting.setting_type === "HOMEPAGE_URL"
     )?.value || "";
-  const isAgencySettingConfigured = Boolean(
-    currentAgencySettings?.find(
-      (setting) => setting.setting_type === "HOMEPAGE_URL"
-    )?.value
-  );
+  const isAgencySettingConfigured = Boolean(homepageUrlSetting);
 
   const handleSaveClick = () => {
     const updatedSettings = updateAgencySettings(


### PR DESCRIPTION
## Description of the change

Adds red text color treatment to Metric Configuration "Action Required" title and adds red "Action Required" text to agency settings with no values entered.

https://github.com/Recidiviz/justice-counts/assets/59492998/2c85f288-c467-4989-8dcf-ec3e01169776


## Related issues

Closes #672 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
