### PR TITLE
Nit #9: Change visual treatment for Agency Settings modal

### DIFF
--- a/publisher/src/components/Settings/AgencySettingsDescription.tsx
+++ b/publisher/src/components/Settings/AgencySettingsDescription.tsx
@@ -78,46 +78,49 @@ const AgencySettingsDescription: React.FC<{
     removeEditMode();
   };
 
-  if (isSettingInEditMode) {
-    return (
-      <AgencySettingsEditModeModal
-        openCancelModal={handleCancelClick}
-        isConfirmModalOpen={isConfirmModalOpen}
-        closeCancelModal={() => setIsConfirmModalOpen(false)}
-        handleCancelModalConfirm={handleModalConfirm}
-      >
-        <>
-          <AgencySettingsBlockTitle isEditModeActive>
-            Agency Information
-          </AgencySettingsBlockTitle>
-          <AgencyInfoTextAreaLabel>
-            Briefly describe your agency’s purpose and functions. This text will
-            be displayed in the About page of the public-facing dashboard.
-          </AgencyInfoTextAreaLabel>
-          <Input
-            name="basic-info-description"
-            label=""
-            onChange={(e) => setInfoText(e.target.value)}
-            placeholder="Enter agency description..."
-            isPlaceholderVisible
-            multiline
-            value={infoText}
-            maxLength={750}
-          />
-          <AgencyInfoTextAreaWordCounter isRed={infoText.length >= 750}>
-            {infoText.length}/{MAX_DESCRIPTION_CHARACTERS} characters
-          </AgencyInfoTextAreaWordCounter>
-          <EditModeButtonsContainer noMargin>
-            <Button label="Cancel" onClick={handleCancelClick} />
-            <Button label="Save" onClick={handleSaveClick} buttonColor="blue" />
-          </EditModeButtonsContainer>
-        </>
-      </AgencySettingsEditModeModal>
-    );
-  }
-
   return (
     <>
+      {isSettingInEditMode && (
+        <AgencySettingsEditModeModal
+          openCancelModal={handleCancelClick}
+          isConfirmModalOpen={isConfirmModalOpen}
+          closeCancelModal={() => setIsConfirmModalOpen(false)}
+          handleCancelModalConfirm={handleModalConfirm}
+        >
+          <>
+            <AgencySettingsBlockTitle isEditModeActive>
+              Agency Information
+            </AgencySettingsBlockTitle>
+            <AgencyInfoTextAreaLabel>
+              Briefly describe your agency’s purpose and functions. This text
+              will be displayed in the About page of the public-facing
+              dashboard.
+            </AgencyInfoTextAreaLabel>
+            <Input
+              name="basic-info-description"
+              label=""
+              onChange={(e) => setInfoText(e.target.value)}
+              placeholder="Enter agency description..."
+              isPlaceholderVisible
+              multiline
+              value={infoText}
+              maxLength={750}
+            />
+            <AgencyInfoTextAreaWordCounter isRed={infoText.length >= 750}>
+              {infoText.length}/{MAX_DESCRIPTION_CHARACTERS} characters
+            </AgencyInfoTextAreaWordCounter>
+            <EditModeButtonsContainer noMargin>
+              <Button label="Cancel" onClick={handleCancelClick} />
+              <Button
+                label="Save"
+                onClick={handleSaveClick}
+                buttonColor="blue"
+              />
+            </EditModeButtonsContainer>
+          </>
+        </AgencySettingsEditModeModal>
+      )}
+
       <AgencySettingsBlock id="description">
         <AgencySettingsBlockTitle>Agency Information</AgencySettingsBlockTitle>
         <AgencyInfoBlockDescription>

--- a/publisher/src/components/Settings/AgencySettingsEditModeModal.tsx
+++ b/publisher/src/components/Settings/AgencySettingsEditModeModal.tsx
@@ -17,7 +17,7 @@
 
 import { palette } from "@justice-counts/common/components/GlobalStyles";
 import { Modal } from "@justice-counts/common/components/Modal";
-import React from "react";
+import React, { useEffect } from "react";
 import { createPortal } from "react-dom";
 import styled from "styled-components/macro";
 
@@ -29,7 +29,7 @@ const EditModalOuterWrapper = styled.div`
   left: 0;
   width: 100vw;
   height: 100vh;
-  background-color: rgb(220, 221, 223);
+  background-color: ${palette.highlight.grey2};
   overflow-y: auto;
   display: flex;
   justify-content: center;
@@ -62,6 +62,13 @@ export const AgencySettingsEditModeModal: React.FC<{
   closeCancelModal,
   handleCancelModalConfirm,
 }) => {
+  useEffect(() => {
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = "auto";
+    };
+  }, []);
+
   const Portal = (
     <>
       <EditModalOuterWrapper onClick={openCancelModal}>

--- a/publisher/src/components/Settings/AgencySettingsJurisdictions.tsx
+++ b/publisher/src/components/Settings/AgencySettingsJurisdictions.tsx
@@ -233,211 +233,211 @@ export const AgencySettingsJurisdictions: React.FC<{
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [excludedJurisdictionsIds]);
 
-  if (isSettingInEditMode) {
-    return (
-      <AgencySettingsEditModeModal
-        openCancelModal={handleCancelClick}
-        isConfirmModalOpen={isConfirmModalOpen}
-        closeCancelModal={() => setIsConfirmModalOpen(false)}
-        handleCancelModalConfirm={handleModalConfirm}
-      >
-        <>
-          <AgencySettingsBlockTitle isEditModeActive>
-            {isExclusionsViewActive
-              ? "Which jurisdiction should be excluded?"
-              : "Jurisdictions"}
-          </AgencySettingsBlockTitle>
-          <AgencySettingsBlockDescription>
-            Add counties, states, or counties subdivisions that{" "}
-            {isExclusionsViewActive && "DO NOT"} correspond with your agency.
-          </AgencySettingsBlockDescription>
-          <JurisdictionsInputWrapper>
-            <JurisdictionsSearchBar
-              placeholder="Type in the name of your jurisdiction (for example, Thurston County)"
-              value={inputValue}
-              onChange={(e) => {
-                setInputValue(e.target.value);
-                getSearch(e.target.value);
-              }}
-            />
-            {!!inputValue &&
-              (searchResult.length === 0 ? (
-                <JurisdictionsSearchResultContainer>
-                  <JurisdictionsSearchResult>
-                    No matches
-                  </JurisdictionsSearchResult>
-                </JurisdictionsSearchResultContainer>
-              ) : (
-                <JurisdictionsSearchResultContainer>
-                  {searchResult
-                    .slice(0, totalSearchResultsShow)
-                    .map((result) => (
-                      <JurisdictionsSearchResult
-                        key={result.id}
-                        hasAction
-                        onClick={() => handleAddArea(result.id)}
-                      >
-                        {result.name}
-                        <JurisdictionAreaType>
-                          {removeUnderscore(result.type)}{" "}
-                          <AddIcon src={addIcon} alt="" />
-                        </JurisdictionAreaType>
-                      </JurisdictionsSearchResult>
-                    ))}
-                  {!!inputValue &&
-                    searchResult.length > totalSearchResultsShow && (
-                      <Button
-                        label="See More"
-                        onClick={() =>
-                          setTotalSearchResultsShow(totalSearchResultsShow + 10)
-                        }
-                        labelColor="blue"
-                        noHover
-                      />
-                    )}
-                </JurisdictionsSearchResultContainer>
-              ))}
-          </JurisdictionsInputWrapper>
-
-          {!isExclusionsViewActive && (
-            <>
-              <AgencySettingsBlockSubDescription>
-                Areas included
-              </AgencySettingsBlockSubDescription>
-              <JurisdictionsListArea>
-                {editedIncludedJurisdictionsIds.map((id) => (
-                  <JurisdictionsInfoRow
-                    key={id}
-                    hasHover
-                    onClick={() => handleCheckedJurisdictionsIds(id)}
-                  >
-                    {mappedJurisdictionsData[id].name}
-                    <JurisdictionCheckBlock>
-                      {removeUnderscore(mappedJurisdictionsData[id].type)}
-                      <CheckboxWrapper>
-                        <Checkbox
-                          type="checkbox"
-                          checked={checkedJurisdictionsIds.includes(id)}
-                          onChange={() => handleCheckedJurisdictionsIds(id)}
-                        />
-                        <BlueCheckIcon src={blackCheck} alt="" enabled />
-                      </CheckboxWrapper>
-                    </JurisdictionCheckBlock>
-                  </JurisdictionsInfoRow>
-                ))}
-              </JurisdictionsListArea>
-            </>
-          )}
-
-          {isExclusionsViewActive && (
-            <>
-              <AgencySettingsBlockSubDescription>
-                Areas excluded
-              </AgencySettingsBlockSubDescription>
-              <JurisdictionsListArea>
-                {editedExcludedJurisdictionsIds.map((id) => (
-                  <JurisdictionsInfoRow
-                    key={id}
-                    hasHover
-                    onClick={() => handleCheckedJurisdictionsIds(id)}
-                  >
-                    {mappedJurisdictionsData[id].name}
-                    <JurisdictionCheckBlock>
-                      {removeUnderscore(mappedJurisdictionsData[id].type)}
-                      <CheckboxWrapper>
-                        <Checkbox
-                          type="checkbox"
-                          checked={checkedJurisdictionsIds.includes(id)}
-                          onChange={() => handleCheckedJurisdictionsIds(id)}
-                        />
-                        <BlueCheckIcon src={blackCheck} alt="" enabled />
-                      </CheckboxWrapper>
-                    </JurisdictionCheckBlock>
-                  </JurisdictionsInfoRow>
-                ))}
-              </JurisdictionsListArea>
-            </>
-          )}
-
-          <JurisdictionsEditModeFooter>
-            {isExclusionsViewActive ? (
-              <JurisdictionsEditModeFooterLeftBlock>
-                {hasInclusions
-                  ? `${editedIncludedJurisdictionsIds.length} ${
-                      editedIncludedJurisdictionsIds.length > 1
-                        ? "areas"
-                        : "area"
-                    } included`
-                  : "Need to declare included areas?"}
-                <Button
-                  label={hasInclusions ? "View and Edit" : "Add them"}
-                  onClick={() =>
-                    setIsExclusionsViewActive(!isExclusionsViewActive)
-                  }
-                  labelColor="blue"
-                  noSidePadding
-                  noHover
-                />
-              </JurisdictionsEditModeFooterLeftBlock>
-            ) : (
-              <JurisdictionsEditModeFooterLeftBlock>
-                {hasExclusions
-                  ? `${editedExcludedJurisdictionsIds.length} ${
-                      editedExcludedJurisdictionsIds.length > 1
-                        ? "areas"
-                        : "area"
-                    } excluded`
-                  : "Need to declare excluded areas?"}
-                <Button
-                  label={hasExclusions ? "View and Edit" : "Add them"}
-                  onClick={() =>
-                    setIsExclusionsViewActive(!isExclusionsViewActive)
-                  }
-                  labelColor="blue"
-                  noSidePadding
-                  noHover
-                />
-              </JurisdictionsEditModeFooterLeftBlock>
-            )}
-            {checkedJurisdictionsIds.length === 0 ? (
-              <EditModeButtonsContainer>
-                <Button label="Cancel" onClick={handleCancelClick} />
-                <Button
-                  label="Save"
-                  onClick={handleSaveClick}
-                  buttonColor="blue"
-                />
-              </EditModeButtonsContainer>
-            ) : (
-              <EditModeButtonsContainer>
-                <Button
-                  label="Cancel"
-                  onClick={() => setCheckedJurisdictionsIds([])}
-                  labelColor="blue"
-                  noSidePadding
-                  noHover
-                />
-                <Button
-                  label={`Remove ${checkedAreasCount} ${
-                    checkedAreasCount > 1 ? "areas" : "area"
-                  }`}
-                  onClick={() =>
-                    handleRemoveJurisdictions(checkedJurisdictionsIds)
-                  }
-                  labelColor="red"
-                  noSidePadding
-                  noHover
-                />
-              </EditModeButtonsContainer>
-            )}
-          </JurisdictionsEditModeFooter>
-        </>
-      </AgencySettingsEditModeModal>
-    );
-  }
-
   return (
     <>
+      {isSettingInEditMode && (
+        <AgencySettingsEditModeModal
+          openCancelModal={handleCancelClick}
+          isConfirmModalOpen={isConfirmModalOpen}
+          closeCancelModal={() => setIsConfirmModalOpen(false)}
+          handleCancelModalConfirm={handleModalConfirm}
+        >
+          <>
+            <AgencySettingsBlockTitle isEditModeActive>
+              {isExclusionsViewActive
+                ? "Which jurisdiction should be excluded?"
+                : "Jurisdictions"}
+            </AgencySettingsBlockTitle>
+            <AgencySettingsBlockDescription>
+              Add counties, states, or counties subdivisions that{" "}
+              {isExclusionsViewActive && "DO NOT"} correspond with your agency.
+            </AgencySettingsBlockDescription>
+            <JurisdictionsInputWrapper>
+              <JurisdictionsSearchBar
+                placeholder="Type in the name of your jurisdiction (for example, Thurston County)"
+                value={inputValue}
+                onChange={(e) => {
+                  setInputValue(e.target.value);
+                  getSearch(e.target.value);
+                }}
+              />
+              {!!inputValue &&
+                (searchResult.length === 0 ? (
+                  <JurisdictionsSearchResultContainer>
+                    <JurisdictionsSearchResult>
+                      No matches
+                    </JurisdictionsSearchResult>
+                  </JurisdictionsSearchResultContainer>
+                ) : (
+                  <JurisdictionsSearchResultContainer>
+                    {searchResult
+                      .slice(0, totalSearchResultsShow)
+                      .map((result) => (
+                        <JurisdictionsSearchResult
+                          key={result.id}
+                          hasAction
+                          onClick={() => handleAddArea(result.id)}
+                        >
+                          {result.name}
+                          <JurisdictionAreaType>
+                            {removeUnderscore(result.type)}{" "}
+                            <AddIcon src={addIcon} alt="" />
+                          </JurisdictionAreaType>
+                        </JurisdictionsSearchResult>
+                      ))}
+                    {!!inputValue &&
+                      searchResult.length > totalSearchResultsShow && (
+                        <Button
+                          label="See More"
+                          onClick={() =>
+                            setTotalSearchResultsShow(
+                              totalSearchResultsShow + 10
+                            )
+                          }
+                          labelColor="blue"
+                          noHover
+                        />
+                      )}
+                  </JurisdictionsSearchResultContainer>
+                ))}
+            </JurisdictionsInputWrapper>
+
+            {!isExclusionsViewActive && (
+              <>
+                <AgencySettingsBlockSubDescription>
+                  Areas included
+                </AgencySettingsBlockSubDescription>
+                <JurisdictionsListArea>
+                  {editedIncludedJurisdictionsIds.map((id) => (
+                    <JurisdictionsInfoRow
+                      key={id}
+                      hasHover
+                      onClick={() => handleCheckedJurisdictionsIds(id)}
+                    >
+                      {mappedJurisdictionsData[id].name}
+                      <JurisdictionCheckBlock>
+                        {removeUnderscore(mappedJurisdictionsData[id].type)}
+                        <CheckboxWrapper>
+                          <Checkbox
+                            type="checkbox"
+                            checked={checkedJurisdictionsIds.includes(id)}
+                            onChange={() => handleCheckedJurisdictionsIds(id)}
+                          />
+                          <BlueCheckIcon src={blackCheck} alt="" enabled />
+                        </CheckboxWrapper>
+                      </JurisdictionCheckBlock>
+                    </JurisdictionsInfoRow>
+                  ))}
+                </JurisdictionsListArea>
+              </>
+            )}
+
+            {isExclusionsViewActive && (
+              <>
+                <AgencySettingsBlockSubDescription>
+                  Areas excluded
+                </AgencySettingsBlockSubDescription>
+                <JurisdictionsListArea>
+                  {editedExcludedJurisdictionsIds.map((id) => (
+                    <JurisdictionsInfoRow
+                      key={id}
+                      hasHover
+                      onClick={() => handleCheckedJurisdictionsIds(id)}
+                    >
+                      {mappedJurisdictionsData[id].name}
+                      <JurisdictionCheckBlock>
+                        {removeUnderscore(mappedJurisdictionsData[id].type)}
+                        <CheckboxWrapper>
+                          <Checkbox
+                            type="checkbox"
+                            checked={checkedJurisdictionsIds.includes(id)}
+                            onChange={() => handleCheckedJurisdictionsIds(id)}
+                          />
+                          <BlueCheckIcon src={blackCheck} alt="" enabled />
+                        </CheckboxWrapper>
+                      </JurisdictionCheckBlock>
+                    </JurisdictionsInfoRow>
+                  ))}
+                </JurisdictionsListArea>
+              </>
+            )}
+
+            <JurisdictionsEditModeFooter>
+              {isExclusionsViewActive ? (
+                <JurisdictionsEditModeFooterLeftBlock>
+                  {hasInclusions
+                    ? `${editedIncludedJurisdictionsIds.length} ${
+                        editedIncludedJurisdictionsIds.length > 1
+                          ? "areas"
+                          : "area"
+                      } included`
+                    : "Need to declare included areas?"}
+                  <Button
+                    label={hasInclusions ? "View and Edit" : "Add them"}
+                    onClick={() =>
+                      setIsExclusionsViewActive(!isExclusionsViewActive)
+                    }
+                    labelColor="blue"
+                    noSidePadding
+                    noHover
+                  />
+                </JurisdictionsEditModeFooterLeftBlock>
+              ) : (
+                <JurisdictionsEditModeFooterLeftBlock>
+                  {hasExclusions
+                    ? `${editedExcludedJurisdictionsIds.length} ${
+                        editedExcludedJurisdictionsIds.length > 1
+                          ? "areas"
+                          : "area"
+                      } excluded`
+                    : "Need to declare excluded areas?"}
+                  <Button
+                    label={hasExclusions ? "View and Edit" : "Add them"}
+                    onClick={() =>
+                      setIsExclusionsViewActive(!isExclusionsViewActive)
+                    }
+                    labelColor="blue"
+                    noSidePadding
+                    noHover
+                  />
+                </JurisdictionsEditModeFooterLeftBlock>
+              )}
+              {checkedJurisdictionsIds.length === 0 ? (
+                <EditModeButtonsContainer>
+                  <Button label="Cancel" onClick={handleCancelClick} />
+                  <Button
+                    label="Save"
+                    onClick={handleSaveClick}
+                    buttonColor="blue"
+                  />
+                </EditModeButtonsContainer>
+              ) : (
+                <EditModeButtonsContainer>
+                  <Button
+                    label="Cancel"
+                    onClick={() => setCheckedJurisdictionsIds([])}
+                    labelColor="blue"
+                    noSidePadding
+                    noHover
+                  />
+                  <Button
+                    label={`Remove ${checkedAreasCount} ${
+                      checkedAreasCount > 1 ? "areas" : "area"
+                    }`}
+                    onClick={() =>
+                      handleRemoveJurisdictions(checkedJurisdictionsIds)
+                    }
+                    labelColor="red"
+                    noSidePadding
+                    noHover
+                  />
+                </EditModeButtonsContainer>
+              )}
+            </JurisdictionsEditModeFooter>
+          </>
+        </AgencySettingsEditModeModal>
+      )}
+
       <AgencySettingsBlock id="jurisdictions">
         <AgencySettingsBlockTitle>Jurisdictions</AgencySettingsBlockTitle>
 

--- a/publisher/src/components/Settings/AgencySettingsSupervisions.tsx
+++ b/publisher/src/components/Settings/AgencySettingsSupervisions.tsx
@@ -125,54 +125,57 @@ export const AgencySettingsSupervisions: React.FC<{
     }
   };
 
-  if (isSettingInEditMode) {
-    return (
-      <AgencySettingsEditModeModal
-        openCancelModal={handleCancelClick}
-        isConfirmModalOpen={isConfirmModalOpen}
-        closeCancelModal={() => setIsConfirmModalOpen(false)}
-        handleCancelModalConfirm={handleModalConfirm}
-      >
-        <>
-          <AgencySettingsBlockTitle isEditModeActive>
-            Supervision Populations
-          </AgencySettingsBlockTitle>
-          <AgencySettingsBlockDescription>
-            Select the supervision populations that your agency is responsible
-            for. This enables disaggregating data by selected population types.
-          </AgencySettingsBlockDescription>
-          {supervisionAgencySystems.map(({ label, value }) => (
-            <SupervisionSystemRow
-              key={value}
-              hasHover={isSettingInEditMode}
-              onClick={() => handleSetSupervisionSystemsToSave(value)}
-            >
-              <CheckboxWrapper>
-                <Checkbox
-                  type="checkbox"
-                  checked={
-                    supervisionSystemsToSave?.includes(
-                      value as AgencySystems
-                    ) || false
-                  }
-                  onChange={() => handleSetSupervisionSystemsToSave(value)}
-                />
-                <BlueCheckIcon src={blueCheck} alt="" enabled />
-              </CheckboxWrapper>
-              {label}
-            </SupervisionSystemRow>
-          ))}
-          <EditModeButtonsContainer>
-            <Button label="Cancel" onClick={handleCancelClick} />
-            <Button label="Save" onClick={handleSaveClick} buttonColor="blue" />
-          </EditModeButtonsContainer>
-        </>
-      </AgencySettingsEditModeModal>
-    );
-  }
-
   return (
     <>
+      {isSettingInEditMode && (
+        <AgencySettingsEditModeModal
+          openCancelModal={handleCancelClick}
+          isConfirmModalOpen={isConfirmModalOpen}
+          closeCancelModal={() => setIsConfirmModalOpen(false)}
+          handleCancelModalConfirm={handleModalConfirm}
+        >
+          <>
+            <AgencySettingsBlockTitle isEditModeActive>
+              Supervision Populations
+            </AgencySettingsBlockTitle>
+            <AgencySettingsBlockDescription>
+              Select the supervision populations that your agency is responsible
+              for. This enables disaggregating data by selected population
+              types.
+            </AgencySettingsBlockDescription>
+            {supervisionAgencySystems.map(({ label, value }) => (
+              <SupervisionSystemRow
+                key={value}
+                hasHover={isSettingInEditMode}
+                onClick={() => handleSetSupervisionSystemsToSave(value)}
+              >
+                <CheckboxWrapper>
+                  <Checkbox
+                    type="checkbox"
+                    checked={
+                      supervisionSystemsToSave?.includes(
+                        value as AgencySystems
+                      ) || false
+                    }
+                    onChange={() => handleSetSupervisionSystemsToSave(value)}
+                  />
+                  <BlueCheckIcon src={blueCheck} alt="" enabled />
+                </CheckboxWrapper>
+                {label}
+              </SupervisionSystemRow>
+            ))}
+            <EditModeButtonsContainer>
+              <Button label="Cancel" onClick={handleCancelClick} />
+              <Button
+                label="Save"
+                onClick={handleSaveClick}
+                buttonColor="blue"
+              />
+            </EditModeButtonsContainer>
+          </>
+        </AgencySettingsEditModeModal>
+      )}
+
       <AgencySettingsBlock id="supervisions">
         <AgencySettingsBlockTitle>
           Supervision Populations

--- a/publisher/src/components/Settings/AgencySettingsURL.tsx
+++ b/publisher/src/components/Settings/AgencySettingsURL.tsx
@@ -89,40 +89,42 @@ const AgencySettingsUrl: React.FC<{
     }
   }, [urlText, isSettingInEditMode]);
 
-  if (isSettingInEditMode) {
-    return (
-      <AgencySettingsEditModeModal
-        openCancelModal={handleCancelClick}
-        isConfirmModalOpen={isConfirmModalOpen}
-        closeCancelModal={() => setIsConfirmModalOpen(false)}
-        handleCancelModalConfirm={handleModalConfirm}
-      >
-        <>
-          <AgencySettingsBlockTitle isEditModeActive>
-            Agency Homepage URL
-          </AgencySettingsBlockTitle>
-          <AgencyInfoTextAreaLabel>
-            Provide a link to your agency&apos;s website.
-          </AgencyInfoTextAreaLabel>
-          <Input
-            name="homepage-url"
-            label=""
-            placeholder="URL of agency (e.g., https://doc.iowa.gov/)"
-            isPlaceholderVisible
-            onChange={(e) => setUrlText(e.target.value)}
-            value={urlText}
-          />
-          <EditModeButtonsContainer noMargin>
-            <Button label="Cancel" onClick={handleCancelClick} />
-            <Button label="Save" onClick={handleSaveClick} buttonColor="blue" />
-          </EditModeButtonsContainer>
-        </>
-      </AgencySettingsEditModeModal>
-    );
-  }
-
   return (
     <>
+      {isSettingInEditMode && (
+        <AgencySettingsEditModeModal
+          openCancelModal={handleCancelClick}
+          isConfirmModalOpen={isConfirmModalOpen}
+          closeCancelModal={() => setIsConfirmModalOpen(false)}
+          handleCancelModalConfirm={handleModalConfirm}
+        >
+          <>
+            <AgencySettingsBlockTitle isEditModeActive>
+              Agency Homepage URL
+            </AgencySettingsBlockTitle>
+            <AgencyInfoTextAreaLabel>
+              Provide a link to your agency&apos;s website.
+            </AgencyInfoTextAreaLabel>
+            <Input
+              name="homepage-url"
+              label=""
+              placeholder="URL of agency (e.g., https://doc.iowa.gov/)"
+              isPlaceholderVisible
+              onChange={(e) => setUrlText(e.target.value)}
+              value={urlText}
+            />
+            <EditModeButtonsContainer noMargin>
+              <Button label="Cancel" onClick={handleCancelClick} />
+              <Button
+                label="Save"
+                onClick={handleSaveClick}
+                buttonColor="blue"
+              />
+            </EditModeButtonsContainer>
+          </>
+        </AgencySettingsEditModeModal>
+      )}
+
       <AgencySettingsBlock id="homepage_url">
         <AgencySettingsBlockTitle>Agency Homepage URL</AgencySettingsBlockTitle>
         <AgencyInfoBlockDescription>


### PR DESCRIPTION
## Description of the change

> Transparent background for agency settings edit mode modals

## Type of change
Type: Non-breaking refactor

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Closes #698 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
