### PR TITLE
Home Page: Scroll to metric in Data Entry Form after clicking on "Manual Entry" action link in task card [3/n]

### DIFF
--- a/publisher/src/components/Home/TaskCard.tsx
+++ b/publisher/src/components/Home/TaskCard.tsx
@@ -36,7 +36,8 @@ export const TaskCard: React.FC<{
   reportID?: number;
 }> = ({ metadata, reportID }) => {
   const navigate = useNavigate();
-  const { title, description, actionLinks, metricSettingsParams } = metadata;
+  const { title, description, actionLinks, metricSettingsParams, metricKey } =
+    metadata;
 
   return (
     <Styled.TaskCardContainer key={title}>
@@ -62,7 +63,12 @@ export const TaskCard: React.FC<{
                 if (isSetMetricAvailabilityAction) {
                   return navigate(`./${action.path + metricSettingsParams}`);
                 }
-                if (isManualEntryAction || isPublishAction) {
+                if (isManualEntryAction) {
+                  return navigate(`./${action.path + reportID}`, {
+                    state: { scrollToMetricKey: metricKey },
+                  });
+                }
+                if (isPublishAction) {
                   return navigate(
                     `./${action.path + reportID + reviewPagePath}`
                   );

--- a/publisher/src/components/Home/helpers.ts
+++ b/publisher/src/components/Home/helpers.ts
@@ -126,6 +126,7 @@ export const createDataEntryTaskCardMetadata = (
     ],
     metricFrequency,
     hasMetricValue,
+    metricKey: currentMetric.key,
   };
 };
 

--- a/publisher/src/components/Home/types.ts
+++ b/publisher/src/components/Home/types.ts
@@ -36,6 +36,7 @@ export type TaskCardMetadata = {
   metricFrequency?: ReportFrequency;
   metricSettingsParams?: string;
   hasMetricValue?: boolean;
+  metricKey?: string;
 };
 
 export type TaskCardActionLinksMetadata = { label: string; path: string };

--- a/publisher/src/components/Reports/DataEntryForm.tsx
+++ b/publisher/src/components/Reports/DataEntryForm.tsx
@@ -27,7 +27,7 @@ import { AgencySystems, Report } from "@justice-counts/common/types";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react-lite";
 import React, { Fragment, useEffect, useRef, useState } from "react";
-import { useNavigate, useParams } from "react-router-dom";
+import { useLocation, useNavigate, useParams } from "react-router-dom";
 import styled from "styled-components/macro";
 
 import {
@@ -124,6 +124,7 @@ const DataEntryForm: React.FC<{
 }) => {
   const { agencyId } = useParams() as { agencyId: string };
   const navigate = useNavigate();
+  const { state } = useLocation();
   const headerBadge = useHeaderBadge();
   const { formStore, reportStore, userStore } = useStore();
   const [showOnboarding, setShowOnboarding] = useState(true);
@@ -133,9 +134,17 @@ const DataEntryForm: React.FC<{
   const metricsRef = useRef<HTMLDivElement[]>([]);
 
   const currentAgency = userStore.getAgency(agencyId);
-
   const isPublished =
     reportStore.reportOverviews[reportID].status === "PUBLISHED";
+
+  /** Scroll to metric (currently used by new Home page task cards) */
+  useEffect(() => {
+    if (state?.scrollToMetricKey) {
+      document
+        .getElementById(state.scrollToMetricKey)
+        ?.scrollIntoView({ behavior: "smooth" });
+    }
+  }, [state]);
 
   useEffect(
     () => {


### PR DESCRIPTION
## Description of the change

When a user clicks on the "Manual Entry" action link of a metric's task card and they are redirected to the latest record form - and the form loads as usual with the scroll position at the top of the page. This updates that transition and automatically scrolls a user to the metric on the form when they click on the "Manual Entry" action link.


https://github.com/Recidiviz/justice-counts/assets/59492998/7db87f51-4303-48ef-9850-98f1faab336a



## Related issues

Closes #705

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
