### PR TITLE
Home Page: Link “Manual Entry” action link to Create Report page for users who do not have a records [5/n]

### DIFF
--- a/publisher/src/components/Home/Home.tsx
+++ b/publisher/src/components/Home/Home.tsx
@@ -84,7 +84,7 @@ export const Home = observer(() => {
           { latestMonthlyRecord, latestAnnualRecord },
           createDataEntryTaskCardMetadata
         )
-      ) || [];
+      );
   const unconfiguredMetricsTaskCardMetadata: TaskCardMetadata[] =
     currentAgencyMetrics
       .filter(metricNotConfigured)
@@ -95,21 +95,7 @@ export const Home = observer(() => {
           { latestMonthlyRecord, latestAnnualRecord },
           createConfigurationTaskCardMetadata
         )
-      ) || [];
-
-  /**
-   * User has completed all tasks if:
-   *  1. User has configured all metrics and set them all to "Not Available"
-   *  2. User has entered values for all metrics in the latest annual and/or monthly
-   *     records and those records are published
-   */
-  const hasCompletedAllTasks =
-    enabledMetricsTaskCardMetadata.length === 0 &&
-    unconfiguredMetricsTaskCardMetadata.length === 0;
-  const welcomeDescription = !hasCompletedAllTasks
-    ? "See open tasks below"
-    : "Dashboards are updated with the latest published records";
-  const userFirstName = userStore.name?.split(" ")[0];
+      );
 
   /**
    * Metrics without values or not yet configured (`allMetricMetadatasWithoutValuesOrNotConfigured`) are
@@ -127,6 +113,21 @@ export const Home = observer(() => {
     ...unconfiguredMetricsTaskCardMetadata,
     ...enabledMetricsTaskCardMetadata,
   ]);
+
+  /**
+   * User has completed all tasks if:
+   *  1. User has configured all metrics and set them all to "Not Available"
+   *  2. User has entered values for all metrics in the latest annual and/or monthly
+   *     records and those records are published
+   */
+  const hasCompletedAllTasks =
+    allMetricMetadatasWithoutValuesOrNotConfigured.length === 0 &&
+    allMetricMetadatasWithValues.ANNUAL.length === 0 &&
+    allMetricMetadatasWithValues.MONTHLY.length === 0;
+  const welcomeDescription = !hasCompletedAllTasks
+    ? "See open tasks below"
+    : "Dashboards are updated with the latest published records";
+  const userFirstName = userStore.name?.split(" ")[0];
 
   useEffect(() => {
     const fetchMetricsAndRecords = async () => {
@@ -152,6 +153,7 @@ export const Home = observer(() => {
         annual: annualRecordsMetadata,
       });
       setAgencyMetrics(agencyMetrics);
+      setCurrentSystem(agencySystems[0]);
       setLoading(false);
     };
 
@@ -212,8 +214,7 @@ export const Home = observer(() => {
               {/* Publish-Ready Cards (for Monthly & Annual Records) */}
               {/* Publish latest monthly record */}
               {allMetricMetadatasWithValues.MONTHLY.length > 0 &&
-                latestMonthlyRecord &&
-                latestMonthlyRecord.status !== "PUBLISHED" && (
+                latestMonthlyRecord && (
                   <TaskCard
                     metadata={createPublishTaskCardMetadata(
                       latestMonthlyRecord.reportTitle,
@@ -227,7 +228,6 @@ export const Home = observer(() => {
                 latestMonthlyAnnualRecordsMetadata?.annual &&
                 Object.values(latestMonthlyAnnualRecordsMetadata.annual).map(
                   (record) => {
-                    if (record.status === "PUBLISHED") return null;
                     return (
                       <TaskCard
                         key={record.id}

--- a/publisher/src/components/Home/Home.tsx
+++ b/publisher/src/components/Home/Home.tsx
@@ -78,7 +78,6 @@ export const Home = observer(() => {
     currentAgencyMetrics
       .filter(metricEnabled)
       .filter(metricBelongsToCurrentSystem)
-      // .filter(metricHasUnpublishedRecord)
       .map((metric) =>
         createTaskCardMetadatas(
           metric,
@@ -109,7 +108,7 @@ export const Home = observer(() => {
     unconfiguredMetricsTaskCardMetadata.length === 0;
   const welcomeDescription = !hasCompletedAllTasks
     ? "See open tasks below"
-    : "Dashboards are updated with latest published records";
+    : "Dashboards are updated with the latest published records";
   const userFirstName = userStore.name?.split(" ")[0];
 
   /**

--- a/publisher/src/components/Home/Home.tsx
+++ b/publisher/src/components/Home/Home.tsx
@@ -144,7 +144,6 @@ export const Home = observer(() => {
   useEffect(() => {
     const fetchMetricsAndRecords = async () => {
       setLoading(true);
-
       const {
         agency_metrics: agencyMetrics,
         annual_reports: annualRecords,

--- a/publisher/src/components/Home/Home.tsx
+++ b/publisher/src/components/Home/Home.tsx
@@ -78,6 +78,7 @@ export const Home = observer(() => {
     currentAgencyMetrics
       .filter(metricEnabled)
       .filter(metricBelongsToCurrentSystem)
+      // .filter(metricHasUnpublishedRecord)
       .map((metric) =>
         createTaskCardMetadatas(
           metric,
@@ -139,9 +140,14 @@ export const Home = observer(() => {
         agencyId as string
       )) as LatestReportsAgencyMetrics;
 
-      const annualRecordsMetadata = createAnnualRecordsMetadata(annualRecords);
-      const monthlyRecordMetadata = createMonthlyRecordMetadata(monthlyRecord);
-
+      const hasMonthlyRecord = Object.values(monthlyRecord).length > 0;
+      const hasAnnualRecords = Object.values(annualRecords).length > 0;
+      const annualRecordsMetadata = hasAnnualRecords
+        ? createAnnualRecordsMetadata(annualRecords)
+        : undefined;
+      const monthlyRecordMetadata = hasMonthlyRecord
+        ? createMonthlyRecordMetadata(monthlyRecord)
+        : undefined;
       setLatestMonthlyAnnualsRecordMetadata({
         monthly: monthlyRecordMetadata,
         annual: annualRecordsMetadata,

--- a/publisher/src/components/Home/TaskCard.tsx
+++ b/publisher/src/components/Home/TaskCard.tsx
@@ -64,7 +64,7 @@ export const TaskCard: React.FC<{
                   return navigate(`./${action.path + metricSettingsParams}`);
                 }
                 if (isManualEntryAction) {
-                  return navigate(`./${action.path + reportID}`, {
+                  return navigate(`./${action.path + (reportID || `create`)}`, {
                     state: { scrollToMetricKey: metricKey },
                   });
                 }

--- a/publisher/src/components/Home/helpers.ts
+++ b/publisher/src/components/Home/helpers.ts
@@ -102,6 +102,7 @@ export const createConfigurationTaskCardMetadata = (
     description: currentMetric.description,
     actionLinks: [taskCardLabelsActionLinks.metricAvailability],
     metricSettingsParams: `?system=${currentMetric.system.key.toLowerCase()}&metric=${currentMetric.key.toLowerCase()}`,
+    status: recordMetadata?.status,
   };
 };
 
@@ -127,6 +128,7 @@ export const createDataEntryTaskCardMetadata = (
     ],
     metricFrequency,
     hasMetricValue,
+    status: recordMetadata?.status,
     metricKey: currentMetric.key,
   };
 };
@@ -191,7 +193,7 @@ export const groupMetadatasByValueAndConfiguration = (
     (acc, metric) => {
       const { metricFrequency } = metric;
       if (metric.hasMetricValue) {
-        if (metricFrequency)
+        if (metricFrequency && metric.status !== "PUBLISHED")
           acc.allMetricMetadatasWithValues[metricFrequency].push(metric);
       } else {
         acc.allMetricMetadatasWithoutValuesOrNotConfigured.push(metric);

--- a/publisher/src/components/Home/types.ts
+++ b/publisher/src/components/Home/types.ts
@@ -36,6 +36,7 @@ export type TaskCardMetadata = {
   metricFrequency?: ReportFrequency;
   metricSettingsParams?: string;
   hasMetricValue?: boolean;
+  status?: ReportStatus;
   metricKey?: string;
 };
 

--- a/publisher/src/components/Reports/DataEntryForm.tsx
+++ b/publisher/src/components/Reports/DataEntryForm.tsx
@@ -243,7 +243,7 @@ const DataEntryForm: React.FC<{
           />
           <Button
             label="Home"
-            onClick={() => navigate("/")}
+            onClick={() => navigate(`/agency/${agencyId}`)}
             borderColor="lightgrey"
           />
           {reportOverview.status === "PUBLISHED" ? (

--- a/publisher/src/components/ReviewMetrics/helpers.ts
+++ b/publisher/src/components/ReviewMetrics/helpers.ts
@@ -32,7 +32,7 @@ export const createPublishSuccessModalButtons = (
 ) => [
   {
     label: "Go Home",
-    onClick: () => navigate(`/`),
+    onClick: () => navigate(`/agency/${agencyId}`),
   },
   {
     label: "View Data",

--- a/publisher/src/stores/ReportStore.ts
+++ b/publisher/src/stores/ReportStore.ts
@@ -181,18 +181,26 @@ class ReportStore {
         );
       }
 
-      const latestReportsAndMetrics =
+      const latestRecordsAndMetrics =
         (await response.json()) as LatestReportsAgencyMetrics;
-      const allRecords = [
-        latestReportsAndMetrics.monthly_report,
-        ...Object.values(latestReportsAndMetrics.annual_reports),
-      ];
+      const annualRecords = Object.values(
+        latestRecordsAndMetrics.annual_reports
+      );
+      const hasAnnualRecords = Boolean(annualRecords.length > 0);
+      const hasMonthlyRecord = Boolean(
+        latestRecordsAndMetrics.monthly_report.id
+      );
+      const allRecords = [];
+
+      if (hasMonthlyRecord)
+        allRecords.push(latestRecordsAndMetrics.monthly_report);
+      if (hasAnnualRecords) allRecords.push(...annualRecords);
       if (allRecords.length > 0) {
         allRecords.forEach((record) =>
           this.storeMetricDetails(record.id, record.metrics, record)
         );
       }
-      return latestReportsAndMetrics;
+      return latestRecordsAndMetrics;
     } catch (error) {
       if (error instanceof Error) return new Error(error.message);
     }


### PR DESCRIPTION
## Description of the change

In PR #682 - there was a temporary solution in place for users without records (or without a record tied to a metric - e.g. a monthly metric but the user has 0 monthly records) - if there is no record, the task card doesn't appear. 

After discussing with product and design, we realized a better solution would be to still display all metrics (because users without records can still technically upload a spreadsheet), but link the "Manual Entry" action link to the Create Record page if a metric doesn't have any records to link to.

https://github.com/Recidiviz/justice-counts/assets/59492998/eea4ec5a-6afe-4864-bca5-3bdb60cb5bb5


## Related issues

Closes #744 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
