### PR TITLE
New Homepage: P0 Mobile Responsiveness [7/n]

### DIFF
--- a/common/components/Badge/Badge.tsx
+++ b/common/components/Badge/Badge.tsx
@@ -14,7 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-import { palette } from "@justice-counts/common/components/GlobalStyles";
+import {
+  MIN_TABLET_WIDTH,
+  palette,
+} from "@justice-counts/common/components/GlobalStyles";
 import { MiniLoader } from "@justice-counts/common/components/MiniLoader";
 import React from "react";
 import styled from "styled-components/macro";
@@ -64,6 +67,10 @@ export const BadgeElement = styled.div<{
   text-transform: capitalize;
   ${({ noMargin, leftMargin }) =>
     !noMargin && `margin-left: ${leftMargin || 10}px;`};
+
+  @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
+    display: none;
+  }
 `;
 
 export const reportFrequencyBadgeColors: BadgeColorMapping = {

--- a/common/components/Dropdown/Dropdown.styled.tsx
+++ b/common/components/Dropdown/Dropdown.styled.tsx
@@ -83,7 +83,7 @@ export const CustomDropdownMenu = styled(DropdownMenu)<{
 }>`
   border-radius: 3px;
   margin-top: 4px;
-  max-height: 250px;
+  max-height: 300px;
   overflow-y: auto;
   z-index: 5;
   transform: unset;

--- a/common/components/GlobalStyles/Palette.ts
+++ b/common/components/GlobalStyles/Palette.ts
@@ -25,6 +25,7 @@ export const palette = {
     darkblue: `rgba(0, 86, 224, 1)`,
     darkblue2: `rgba(19, 49, 88, 1)`,
     grey: `rgba(119, 119, 119, 1)`,
+    grey3: `rgb(222, 222, 222)`, // solid color version of `highlight.grey3`
     darkgrey: `rgba(0, 17, 51, 1)`,
     white: `rgba(255,255,255, 1)`,
     offwhite: `rgba(239, 244, 245, 1)`,

--- a/common/components/GlobalStyles/Palette.ts
+++ b/common/components/GlobalStyles/Palette.ts
@@ -24,8 +24,8 @@ export const palette = {
     blue: `rgba(0, 115, 229, 1)`,
     darkblue: `rgba(0, 86, 224, 1)`,
     darkblue2: `rgba(19, 49, 88, 1)`,
-    grey: `rgba(119, 119, 119, 1)`,
-    grey3: `rgb(222, 222, 222)`, // solid color version of `highlight.grey3`
+    grey1: `rgba(119, 119, 119, 1)`,
+    grey2: `rgb(222, 222, 222)`, // solid color version of `highlight.grey3`
     darkgrey: `rgba(0, 17, 51, 1)`,
     white: `rgba(255,255,255, 1)`,
     offwhite: `rgba(239, 244, 245, 1)`,

--- a/common/components/HeaderBar/HeaderBar.styled.tsx
+++ b/common/components/HeaderBar/HeaderBar.styled.tsx
@@ -20,6 +20,7 @@ import styled from "styled-components/macro";
 import {
   HEADER_BAR_HEIGHT,
   MIN_DESKTOP_WIDTH,
+  MIN_TABLET_WIDTH,
   palette,
   typography,
 } from "../GlobalStyles";
@@ -48,6 +49,10 @@ export const HeaderBar = styled.div<{
 
   border-bottom: ${({ hasBottomBorder }) =>
     hasBottomBorder ? `1px solid ${palette.highlight.grey3}` : "none"};
+
+  @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
+    padding: 0;
+  }
 `;
 
 export const LogoContainer = styled.div`

--- a/common/components/HeaderBar/HeaderBar.styled.tsx
+++ b/common/components/HeaderBar/HeaderBar.styled.tsx
@@ -29,6 +29,7 @@ import { HeaderBarBackground } from "./types";
 export const HeaderBar = styled.div<{
   background?: HeaderBarBackground;
   hasBottomBorder?: boolean;
+  noPaddingInSmallScreenWidth?: boolean;
 }>`
   width: 100%;
   height: ${HEADER_BAR_HEIGHT}px;
@@ -50,9 +51,13 @@ export const HeaderBar = styled.div<{
   border-bottom: ${({ hasBottomBorder }) =>
     hasBottomBorder ? `1px solid ${palette.highlight.grey3}` : "none"};
 
-  @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
-    padding: 0;
-  }
+  ${({ noPaddingInSmallScreenWidth }) =>
+    noPaddingInSmallScreenWidth &&
+    `
+      @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
+        padding: 0;
+      }
+  `}
 `;
 
 export const LogoContainer = styled.div`

--- a/common/components/HeaderBar/HeaderBar.tsx
+++ b/common/components/HeaderBar/HeaderBar.tsx
@@ -28,6 +28,7 @@ type HeaderBarProps = {
   badge?: React.ReactNode;
   background?: HeaderBarBackground;
   hasBottomBorder?: boolean;
+  noPaddingInSmallScreenWidth?: boolean;
 };
 
 export function HeaderBar({
@@ -37,9 +38,14 @@ export function HeaderBar({
   badge,
   background,
   hasBottomBorder,
+  noPaddingInSmallScreenWidth,
 }: HeaderBarProps) {
   return (
-    <Styled.HeaderBar background={background} hasBottomBorder={hasBottomBorder}>
+    <Styled.HeaderBar
+      background={background}
+      hasBottomBorder={hasBottomBorder}
+      noPaddingInSmallScreenWidth={noPaddingInSmallScreenWidth}
+    >
       <Styled.LogoContainer onClick={onLogoClick}>
         <Styled.LogoImg src={logoImg} alt="" />
         <Styled.Label>{label}</Styled.Label>

--- a/common/components/Toast/Toast.ts
+++ b/common/components/Toast/Toast.ts
@@ -49,7 +49,7 @@ const getToastStyles = (color?: ToastColor, positionNextToIcon?: boolean) => {
       display: flex;
       align-items: center;
       background-color: ${toastBackgroundColor};
-      color: ${color === "grey" ? palette.solid.grey : palette.solid.white};
+      color: ${color === "grey" ? palette.solid.grey1 : palette.solid.white};
       padding: 20px 24px;
       border-radius: 2px;
       white-space: nowrap;

--- a/publisher/src/components/Auth/VerificationPage.tsx
+++ b/publisher/src/components/Auth/VerificationPage.tsx
@@ -61,7 +61,7 @@ export const ParagraphContainer = styled.div`
   ${typography.sizeCSS.medium}
   padding-top: 24px;
   padding-bottom: 32px;
-  color: ${palette.solid.grey};
+  color: ${palette.solid.grey1};
 `;
 
 export const JusticeCountsSupportLink = styled.a`

--- a/publisher/src/components/DataEntryInterstitial/DataEntryInterstitial.styled.tsx
+++ b/publisher/src/components/DataEntryInterstitial/DataEntryInterstitial.styled.tsx
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import {
+  MIN_TABLET_WIDTH,
   palette,
   typography,
 } from "@justice-counts/common/components/GlobalStyles";
@@ -29,16 +30,9 @@ export const InterstitialContainer = styled.div`
   align-items: center;
 `;
 
-export const OptionsWrapper = styled.div`
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  gap: 64px;
-`;
-
 export const OptionBox = styled.div`
-  width: 424px;
-  height: 264px;
+  min-width: 424px;
+  min-height: 264px;
   border: 0.5px solid ${palette.highlight.grey4};
   display: flex;
   flex-direction: column;
@@ -49,6 +43,22 @@ export const OptionBox = styled.div`
   &:hover {
     cursor: pointer;
     background: ${palette.highlight.grey1};
+  }
+`;
+
+export const OptionsWrapper = styled.div`
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 64px;
+
+  @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
+    flex-direction: column;
+
+    ${OptionBox} {
+      min-width: 374px;
+      min-height: 240px;
+    }
   }
 `;
 

--- a/publisher/src/components/DataUpload/DataUpload.styles.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.styles.tsx
@@ -263,13 +263,13 @@ export const DragDropContainer = styled.div<{ dragging?: boolean }>`
   }
 
   @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
-    justify-content: end;
+    justify-content: center;
 
     div {
       ${typography.sizeCSS.small};
       flex-direction: column;
       gap: 4px;
-      align-items: start;
+      align-items: center;
     }
   }
 `;

--- a/publisher/src/components/Footer/Footer.styles.tsx
+++ b/publisher/src/components/Footer/Footer.styles.tsx
@@ -22,10 +22,10 @@ import {
 } from "@justice-counts/common/components/GlobalStyles";
 import styled from "styled-components/macro";
 
-export const FOOTER_HEIGHT_WITH_MARGIN = 156;
+export const FOOTER_HEIGHT_WITHOUT_MARGIN = 96;
+export const FOOTER_HEIGHT_WITH_MARGIN = FOOTER_HEIGHT_WITHOUT_MARGIN + 60;
 
 export const FooterWrapper = styled.footer<{ isPageDataUpload?: boolean }>`
-  margin-top: 48px;
   padding: 14px 24px;
   z-index: ${({ isPageDataUpload }) => (isPageDataUpload ? "5" : "0")};
   width: 100%;

--- a/publisher/src/components/Footer/Footer.styles.tsx
+++ b/publisher/src/components/Footer/Footer.styles.tsx
@@ -22,7 +22,7 @@ import {
 } from "@justice-counts/common/components/GlobalStyles";
 import styled from "styled-components/macro";
 
-export const FOOTER_HEIGHT_WITHOUT_MARGIN = 96;
+export const FOOTER_HEIGHT_WITHOUT_MARGIN = 82;
 export const FOOTER_HEIGHT_WITH_MARGIN = FOOTER_HEIGHT_WITHOUT_MARGIN + 60;
 
 export const FooterWrapper = styled.footer<{ isPageDataUpload?: boolean }>`

--- a/publisher/src/components/Forms/Form.styles.tsx
+++ b/publisher/src/components/Forms/Form.styles.tsx
@@ -39,6 +39,10 @@ export const AppWrapper = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: space-between;
+
+  @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
+    padding-bottom: ${HEADER_BAR_HEIGHT}px;
+  }
 `;
 
 export const PageWrapper = styled.div`

--- a/publisher/src/components/Header/Header.tsx
+++ b/publisher/src/components/Header/Header.tsx
@@ -34,7 +34,11 @@ const Header = observer(() => {
     navigate(`/agency/${isAgencyValid ? agencyId : defaultAgency}/`);
 
   return (
-    <HeaderBar onLogoClick={onLogoClick} hasBottomBorder>
+    <HeaderBar
+      onLogoClick={onLogoClick}
+      hasBottomBorder
+      noPaddingInSmallScreenWidth
+    >
       <Menu />
     </HeaderBar>
   );

--- a/publisher/src/components/Home/Home.styled.tsx
+++ b/publisher/src/components/Home/Home.styled.tsx
@@ -22,9 +22,9 @@ import {
 } from "@justice-counts/common/components/GlobalStyles";
 import styled from "styled-components/macro";
 
-import { FOOTER_HEIGHT_WITH_MARGIN } from "../Footer";
+import { FOOTER_HEIGHT_WITHOUT_MARGIN } from "../Footer";
 
-const containerHeight = `100vh - ${FOOTER_HEIGHT_WITH_MARGIN}px - ${HEADER_BAR_HEIGHT}px`;
+const containerHeight = `100vh - ${FOOTER_HEIGHT_WITHOUT_MARGIN}px - ${HEADER_BAR_HEIGHT}px`;
 
 export const HomeContainer = styled.div`
   width: 100%;
@@ -32,7 +32,7 @@ export const HomeContainer = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: 80px;
+  padding: 80px 0;
   overflow: auto;
 `;
 

--- a/publisher/src/components/Menu/Menu.styles.tsx
+++ b/publisher/src/components/Menu/Menu.styles.tsx
@@ -235,7 +235,7 @@ export const ProfileDropdownWrapper = styled.div`
     right: 1px;
     bottom: 1px;
     border-radius: 50%;
-    background: rgb(222, 222, 222);
+    background: ${palette.solid.grey2};
   }
 
   &:hover {

--- a/publisher/src/components/Menu/Menu.styles.tsx
+++ b/publisher/src/components/Menu/Menu.styles.tsx
@@ -14,10 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-import {
-  CustomDropdown,
-  CustomDropdownToggle,
-} from "@justice-counts/common/components/Dropdown";
+import { CustomDropdown } from "@justice-counts/common/components/Dropdown";
 import {
   HEADER_BAR_HEIGHT,
   MIN_TABLET_WIDTH,

--- a/publisher/src/components/Menu/Menu.styles.tsx
+++ b/publisher/src/components/Menu/Menu.styles.tsx
@@ -60,6 +60,11 @@ export const MenuItemsProfileWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 56px;
+
+  @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
+    width: 100%;
+    justify-content: flex-end;
+  }
 `;
 
 export const MenuItem = styled.div<{
@@ -170,6 +175,19 @@ export const AgencyDropdownWrapper = styled.div`
 
   button + div {
     border-radius: 0;
+  }
+`;
+
+export const ProfileDropdownContainer = styled.div`
+  @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
+    height: ${HEADER_BAR_HEIGHT}px;
+    width: calc(100% - 1px);
+    min-width: ${HEADER_BAR_HEIGHT}px;
+    display: flex;
+    justify-content: flex-end;
+    align-items: center;
+    background: ${palette.solid.darkgrey};
+    padding-right: 16px;
   }
 `;
 

--- a/publisher/src/components/Menu/Menu.styles.tsx
+++ b/publisher/src/components/Menu/Menu.styles.tsx
@@ -34,39 +34,29 @@ export const MenuContainer = styled.nav<{ isMobileMenuOpen: boolean }>`
   display: flex;
   align-items: center;
   justify-content: space-between;
-
-  @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
-    display: ${({ isMobileMenuOpen }) => (isMobileMenuOpen ? "flex" : "none")};
-    flex-direction: column;
-    align-items: start;
-    position: fixed;
-    top: ${HEADER_BAR_HEIGHT + 1}px;
-    left: 0;
-    width: 100%;
-    height: 100%;
-    background-color: ${palette.solid.white};
-    padding: 48px 32px ${HEADER_BAR_HEIGHT + 32}px 32px;
-    gap: 32px;
-    overflow-y: auto;
-
-    #upload {
-      width: 100%;
-      height: 56px;
-      margin-top: auto;
-
-      div {
-        width: 100%;
-        height: 100%;
-        ${typography.sizeCSS.medium}
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
-      }
-    }
-  }
 `;
 
 export const MenuItemsWrapper = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 56px;
+
+  @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
+    width: 100%;
+    height: ${HEADER_BAR_HEIGHT}px;
+    display: flex;
+    align-items: center;
+    justify-content: space-evenly;
+    position: absolute;
+    bottom: calc(-100vh + ${HEADER_BAR_HEIGHT}px);
+    left: 0;
+    gap: unset;
+    background: ${palette.solid.white};
+    border-top: 1px solid ${palette.highlight.grey5};
+  }
+`;
+
+export const MenuItemsProfileWrapper = styled.div`
   display: flex;
   align-items: center;
   gap: 56px;
@@ -113,14 +103,11 @@ export const MenuItem = styled.div<{
   }
 
   @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
-    border-top: none;
-    ${typography.sizeCSS.large};
+    height: 100%;
     padding: 0;
-    height: auto;
-
-    & ${CustomDropdownToggle} {
-      ${typography.sizeCSS.large};
-    }
+    border-top: 3px solid
+      ${({ active }) => (active ? palette.solid.blue : "transparent")};
+    border-bottom: none;
   }
 `;
 

--- a/publisher/src/components/Menu/Menu.styles.tsx
+++ b/publisher/src/components/Menu/Menu.styles.tsx
@@ -38,6 +38,11 @@ export const MenuItemsWrapper = styled.div`
   align-items: center;
   gap: 56px;
 
+  @media only screen and (max-width: ${MIN_TABLET_WIDTH + 180}px) {
+    gap: 20px;
+    height: ${HEADER_BAR_HEIGHT}px;
+  }
+
   @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
     width: 100%;
     height: ${HEADER_BAR_HEIGHT}px;
@@ -230,11 +235,17 @@ export const ProfileDropdownWrapper = styled.div`
     right: 1px;
     bottom: 1px;
     border-radius: 50%;
-    background: ${palette.highlight.grey3};
+    background: rgb(222, 222, 222);
   }
 
   &:hover {
     cursor: pointer;
+  }
+
+  @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
+    &::before {
+      background: ${palette.solid.darkgrey};
+    }
   }
 `;
 
@@ -242,6 +253,7 @@ export const Caret = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
+  z-index: 2;
 
   &::before {
     content: "";

--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -25,14 +25,11 @@ import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 
-import { settingsMenuPaths } from "../../pages/Settings";
 import { useStore } from "../../stores";
 import { removeAgencyFromPath } from "../../utils";
-import { ReactComponent as CloseMenuBurger } from "../assets/close-header-menu-icon.svg";
 import { ReactComponent as TeamManagementIcon } from "../assets/data-line-icon.svg";
 import { ReactComponent as UploadedFilesIcon } from "../assets/folder-icon.svg";
 import { ReactComponent as LogoutIcon } from "../assets/logout-icon.svg";
-import { ReactComponent as MenuBurger } from "../assets/menu-burger-icon.svg";
 import { ReactComponent as AgencySettingsIcon } from "../assets/pillar-icon.svg";
 import { ReactComponent as YourAccountIcon } from "../assets/profile-icon.svg";
 import { REPORTS_LOWERCASE } from "../Global/constants";
@@ -247,22 +244,6 @@ const Menu: React.FC = () => {
             >
               View Data
             </Styled.MenuItem>
-
-            {/* {isMobileMenuOpen && (
-            <Styled.SubMenuContainer>
-              {settingsMenuPaths.map(({ displayLabel, path }) => (
-                <Styled.SubMenuItem
-                  key={path}
-                  onClick={() => {
-                    navigate(`settings/${path}`);
-                    handleCloseMobileMenu();
-                  }}
-                >
-                  {displayLabel}
-                </Styled.SubMenuItem>
-              ))}
-            </Styled.SubMenuContainer>
-          )} */}
           </Styled.MenuItemsWrapper>
           {/* Profile */}
           <Styled.ProfileDropdownContainer>

--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -261,11 +261,6 @@ const Menu: React.FC = () => {
           </Styled.ProfileDropdownContainer>
         </Styled.MenuItemsProfileWrapper>
       </Styled.MenuContainer>
-      {/* <Styled.MobileMenuIconWrapper
-        onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
-      >
-        {isMobileMenuOpen ? <CloseMenuBurger /> : <MenuBurger />}
-      </Styled.MobileMenuIconWrapper> */}
     </>
   );
 };

--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -195,59 +195,60 @@ const Menu: React.FC = () => {
           {headerBadge}
         </Styled.AgencyDropdownHeaderBadgeWrapper>
 
-        {/* Home */}
-        <Styled.MenuItemsWrapper>
-          <Styled.MenuItem
-            onClick={() => navigate(`/agency/${agencyId}/`)}
-            active={pathWithoutAgency === ""}
-          >
-            Home
-          </Styled.MenuItem>
+        <Styled.MenuItemsProfileWrapper>
+          {/* Home */}
+          <Styled.MenuItemsWrapper>
+            <Styled.MenuItem
+              onClick={() => navigate(`/agency/${agencyId}/`)}
+              active={pathWithoutAgency === ""}
+            >
+              Home
+            </Styled.MenuItem>
 
-          {/* Metric Config */}
-          <Styled.MenuItem
-            onClick={() => {
-              if (pathWithoutAgency === "metric-config") {
-                setSettingsSearchParams({
-                  ...settingsSearchParams,
-                  metric: undefined,
-                });
-              } else {
-                navigate("metric-config");
+            {/* Metric Config */}
+            <Styled.MenuItem
+              onClick={() => {
+                if (pathWithoutAgency === "metric-config") {
+                  setSettingsSearchParams({
+                    ...settingsSearchParams,
+                    metric: undefined,
+                  });
+                } else {
+                  navigate("metric-config");
+                }
+                handleCloseMobileMenu();
+              }}
+              active={pathWithoutAgency === "metric-config"}
+            >
+              Metric Settings
+            </Styled.MenuItem>
+
+            {/* Data Entry */}
+            <Styled.MenuItem
+              onClick={() => {
+                if (pathWithoutAgency !== "data-entry") navigate("data-entry");
+                handleCloseMobileMenu();
+              }}
+              active={
+                pathWithoutAgency === "data-entry" ||
+                pathWithoutAgency === REPORTS_LOWERCASE
               }
-              handleCloseMobileMenu();
-            }}
-            active={pathWithoutAgency === "metric-config"}
-          >
-            Metric Settings
-          </Styled.MenuItem>
+            >
+              Data Entry
+            </Styled.MenuItem>
 
-          {/* Data Entry */}
-          <Styled.MenuItem
-            onClick={() => {
-              if (pathWithoutAgency !== "data-entry") navigate("data-entry");
-              handleCloseMobileMenu();
-            }}
-            active={
-              pathWithoutAgency === "data-entry" ||
-              pathWithoutAgency === REPORTS_LOWERCASE
-            }
-          >
-            Data Entry
-          </Styled.MenuItem>
+            {/* Data (Visualizations) */}
+            <Styled.MenuItem
+              onClick={() => {
+                if (pathWithoutAgency !== "data") navigate("data");
+                handleCloseMobileMenu();
+              }}
+              active={pathWithoutAgency === "data"}
+            >
+              View Data
+            </Styled.MenuItem>
 
-          {/* Data (Visualizations) */}
-          <Styled.MenuItem
-            onClick={() => {
-              if (pathWithoutAgency !== "data") navigate("data");
-              handleCloseMobileMenu();
-            }}
-            active={pathWithoutAgency === "data"}
-          >
-            View Data
-          </Styled.MenuItem>
-
-          {isMobileMenuOpen && (
+            {/* {isMobileMenuOpen && (
             <Styled.SubMenuContainer>
               {settingsMenuPaths.map(({ displayLabel, path }) => (
                 <Styled.SubMenuItem
@@ -261,8 +262,8 @@ const Menu: React.FC = () => {
                 </Styled.SubMenuItem>
               ))}
             </Styled.SubMenuContainer>
-          )}
-
+          )} */}
+          </Styled.MenuItemsWrapper>
           {/* Profile */}
           <Styled.ProfileDropdownWrapper>
             {usernameToInitials()}
@@ -275,13 +276,13 @@ const Menu: React.FC = () => {
               alignment="right"
             />
           </Styled.ProfileDropdownWrapper>
-        </Styled.MenuItemsWrapper>
+        </Styled.MenuItemsProfileWrapper>
       </Styled.MenuContainer>
-      <Styled.MobileMenuIconWrapper
+      {/* <Styled.MobileMenuIconWrapper
         onClick={() => setIsMobileMenuOpen(!isMobileMenuOpen)}
       >
         {isMobileMenuOpen ? <CloseMenuBurger /> : <MenuBurger />}
-      </Styled.MobileMenuIconWrapper>
+      </Styled.MobileMenuIconWrapper> */}
     </>
   );
 };

--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -265,17 +265,19 @@ const Menu: React.FC = () => {
           )} */}
           </Styled.MenuItemsWrapper>
           {/* Profile */}
-          <Styled.ProfileDropdownWrapper>
-            {usernameToInitials()}
-            <Styled.Caret />
-            <Dropdown
-              label=""
-              options={profileDropdownOptions}
-              size="small"
-              hover="label"
-              alignment="right"
-            />
-          </Styled.ProfileDropdownWrapper>
+          <Styled.ProfileDropdownContainer>
+            <Styled.ProfileDropdownWrapper>
+              {usernameToInitials()}
+              <Styled.Caret />
+              <Dropdown
+                label=""
+                options={profileDropdownOptions}
+                size="small"
+                hover="label"
+                alignment="right"
+              />
+            </Styled.ProfileDropdownWrapper>
+          </Styled.ProfileDropdownContainer>
         </Styled.MenuItemsProfileWrapper>
       </Styled.MenuContainer>
       {/* <Styled.MobileMenuIconWrapper


### PR DESCRIPTION
## Description of the change

Implements a P0 of tablet & mobile responsiveness. It's not 100% to spec - the only thing missing is the profile and agency dropdowns appearing at bottom (Figma screenshot below) -

<img width="293" alt="Screenshot 2023-07-06 at 6 51 33 PM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/27790b3a-8daf-405d-81f2-337623381c30">


-- for now, the dropdowns appear as they usually do.

Demo:

https://github.com/Recidiviz/justice-counts/assets/59492998/226d9b67-26b6-4d27-bab5-f677eaf8a478



## Related issues

Closes #668

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
