### PR TITLE
Remove Delete button in UploadedFiles

### DIFF
--- a/publisher/src/components/DataUpload/UploadedFiles.tsx
+++ b/publisher/src/components/DataUpload/UploadedFiles.tsx
@@ -79,8 +79,6 @@ export const UploadedFileRow: React.FC<{
     const [rowHovered, setRowHovered] = useState(false);
     const { agencyId } = useParams() as { agencyId: string };
 
-    const isReadOnly = userStore.isUserReadOnly(agencyId);
-
     const handleDownload = async (spreadsheetID: number, name: string) => {
       setIsDownloading(true);
 
@@ -197,13 +195,6 @@ export const UploadedFileRow: React.FC<{
                   />
                 )}
               </>
-            )}
-            {!isReadOnly && (
-              <Button
-                label="Delete"
-                onClick={() => deleteUploadedFile(id)}
-                labelColor="red"
-              />
             )}
           </ActionsContainer>
         )}


### PR DESCRIPTION
## Description of the change

We decided to (for now) remove users' ability to delete uploaded files in Settings > Uploaded Files page.

## Related issues

Closes #755 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
