### PR TITLE
New Homepage: Playtesting Followups (P0)

### DIFF
--- a/publisher/src/components/Home/Home.tsx
+++ b/publisher/src/components/Home/Home.tsx
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import { AgencySystems, Metric } from "@justice-counts/common/types";
+import { groupBy } from "@justice-counts/common/utils";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -68,6 +69,11 @@ export const Home = observer(() => {
   /** Does the given metric belong to the currently selected system? */
   const metricBelongsToCurrentSystem = (metric: Metric) =>
     currentSystem === "ALL" || metric.system.key === currentSystem;
+  /** Agency metrics by metric key */
+  const currentAgencyMetricsByMetricKey = groupBy(
+    currentAgencyMetrics,
+    (metric) => metric.key
+  );
 
   /** Task Card Metadatas */
   const allTasksCompleteTaskCardMetadata: TaskCardMetadata = {
@@ -80,6 +86,7 @@ export const Home = observer(() => {
       .filter(metricBelongsToCurrentSystem)
       .map((metric) =>
         createTaskCardMetadatas(
+          currentAgencyMetricsByMetricKey,
           metric,
           { latestMonthlyRecord, latestAnnualRecord },
           createDataEntryTaskCardMetadata
@@ -91,6 +98,7 @@ export const Home = observer(() => {
       .filter(metricBelongsToCurrentSystem)
       .map((metric) =>
         createTaskCardMetadatas(
+          currentAgencyMetricsByMetricKey,
           metric,
           { latestMonthlyRecord, latestAnnualRecord },
           createConfigurationTaskCardMetadata

--- a/publisher/src/components/Home/helpers.ts
+++ b/publisher/src/components/Home/helpers.ts
@@ -186,14 +186,15 @@ export const createTaskCardMetadatas = (
    * If this is a supervision subsystem, use the parent supervision metric's starting month,
    * otherwise use the current metric's starting month.
    */
-  const startingMonth = metric.disaggregated_by_supervision_subsystems
-    ? currentAgencyMetricsByMetricKey[
-        `SUPERVISION_${stripSystemKeyFromMetricKey(
-          metric.key,
-          metric.system.key
-        )}`
-      ]?.[0].starting_month
-    : metric.starting_month;
+  const startingMonth =
+    metric.disaggregated_by_supervision_subsystems && !metric.starting_month
+      ? currentAgencyMetricsByMetricKey[
+          `SUPERVISION_${stripSystemKeyFromMetricKey(
+            metric.key,
+            metric.system.key
+          )}`
+        ]?.[0].starting_month
+      : metric.starting_month;
   const { latestMonthlyRecord, latestAnnualRecord } = recordMetadatas;
   /** Create Task Card linked to the latest Monthly Record */
   if (metricFrequency === "MONTHLY") {

--- a/publisher/src/components/Home/helpers.ts
+++ b/publisher/src/components/Home/helpers.ts
@@ -193,7 +193,7 @@ export const createTaskCardMetadatas = (
             metric.key,
             metric.system.key
           )}`
-        ]?.[0].starting_month
+        ]?.[0]?.starting_month
       : metric.starting_month;
   const { latestMonthlyRecord, latestAnnualRecord } = recordMetadatas;
   /** Create Task Card linked to the latest Monthly Record */

--- a/publisher/src/components/Home/helpers.ts
+++ b/publisher/src/components/Home/helpers.ts
@@ -182,9 +182,9 @@ export const createTaskCardMetadatas = (
 ) => {
   const metricFrequency = metric.custom_frequency || metric.frequency;
   /**
-   * Supervision subsystems metrics have a default `null` value for `starting_month`.
-   * If this is a supervision subsystem, use the parent supervision metric's starting month,
-   * otherwise use the current metric's starting month.
+   * If this is a supervision subsystem (with an annual frequency) that does not have a
+   * starting month set, use the parent supervision metric's starting month, otherwise
+   * use the current metric's starting month.
    */
   const startingMonth =
     metric.disaggregated_by_supervision_subsystems && !metric.starting_month


### PR DESCRIPTION
## Description of the change

There was an issue with supervision subsystem metric task cards that were incorrectly linking the "Manual Entry" to the Create Record page (thank you for catching this, Michelle!). This was because the supervision subsystem metric objects have a default `null` value in the `starting_month` property. When we create task cards, we need a `starting_month` for annual metrics in order to link them to the appropriate latest annual record.

To solve for this, when we create task cards, before assigning the `startingMonth` we can do a boolean check of `metric.disaggregated_by_supervision_subsystems`. If it's `true`, then we can assume this is a supervision subsystem that will have a `null` value for `starting_month`, so we check the parent `SUPERVISION_<METRIC KEY>` metric object for the `starting_month`. If it's `false`, then we can assume this is not a supervision subsystem, and should have a value for `starting_month`. Do these assumptions feel reliable?

## Related issues

Closes #760

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
