### PR TITLE
New Homepage: Playtesting Followup - add helpful message to Create Records page when redirected from task card

### DIFF
--- a/publisher/src/components/Home/TaskCard.tsx
+++ b/publisher/src/components/Home/TaskCard.tsx
@@ -65,7 +65,7 @@ export const TaskCard: React.FC<{
                 }
                 if (isManualEntryAction) {
                   return navigate(`./${action.path + (reportID || `create`)}`, {
-                    state: { scrollToMetricKey: metricKey },
+                    state: { scrollToMetricKey: metricKey, from: "Home" },
                   });
                 }
                 if (isPublishAction) {

--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -228,7 +228,8 @@ const Menu: React.FC = () => {
               }}
               active={
                 pathWithoutAgency === "data-entry" ||
-                pathWithoutAgency === REPORTS_LOWERCASE
+                pathWithoutAgency === REPORTS_LOWERCASE ||
+                pathWithoutAgency === `${REPORTS_LOWERCASE}/create`
               }
             >
               Data Entry

--- a/publisher/src/components/Reports/CreateReport.styled.tsx
+++ b/publisher/src/components/Reports/CreateReport.styled.tsx
@@ -108,3 +108,10 @@ export const FormCreateButtonContainer = styled.div`
     display: block;
   }
 `;
+
+export const NoRecordsForTaskCardManualEntryMessage = styled.div`
+  ${typography.sizeCSS.normal};
+  text-align: center;
+  color: ${palette.solid.red};
+  margin-bottom: 16px;
+`;

--- a/publisher/src/components/Reports/CreateReport.tsx
+++ b/publisher/src/components/Reports/CreateReport.tsx
@@ -204,10 +204,14 @@ const CreateReport = () => {
 
       {/* Create Report Form */}
       <Styled.CreateReportFormWrapper>
-        <Styled.NoRecordsForTaskCardManualEntryMessage>
-          {state?.from === "Home" &&
-            `It looks like there are no ${REPORTS_LOWERCASE} for the metric you would like to manually input data for. Please create a new ${REPORT_LOWERCASE}.`}
-        </Styled.NoRecordsForTaskCardManualEntryMessage>
+        {state?.from === "Home" && (
+          <Styled.NoRecordsForTaskCardManualEntryMessage>
+            It looks like there are no {REPORTS_LOWERCASE} for the metric you
+            would like to manually input data for. Please create a new{" "}
+            {REPORT_LOWERCASE}.
+          </Styled.NoRecordsForTaskCardManualEntryMessage>
+        )}
+
         <Styled.CreateReportForm>
           {/* Form Title */}
           <OnePanelBackLinkContainer>

--- a/publisher/src/components/Reports/CreateReport.tsx
+++ b/publisher/src/components/Reports/CreateReport.tsx
@@ -30,7 +30,12 @@ import {
   ReportOverview,
 } from "@justice-counts/common/types";
 import React, { useState } from "react";
-import { Navigate, useNavigate, useParams } from "react-router-dom";
+import {
+  Navigate,
+  useLocation,
+  useNavigate,
+  useParams,
+} from "react-router-dom";
 
 import { trackReportCreated } from "../../analytics";
 import { useStore } from "../../stores";
@@ -72,6 +77,8 @@ const CreateReport = () => {
   const { reportStore, userStore } = useStore();
   const { agencyId } = useParams() as { agencyId: string };
   const navigate = useNavigate();
+  const { state } = useLocation();
+
   const [createReportFormValues, setCreateReportFormValues] = useState(
     initialCreateReportFormValues
   );
@@ -197,6 +204,10 @@ const CreateReport = () => {
 
       {/* Create Report Form */}
       <Styled.CreateReportFormWrapper>
+        <Styled.NoRecordsForTaskCardManualEntryMessage>
+          {state?.from === "Home" &&
+            `It looks like there are no ${REPORTS_LOWERCASE} for the metric you would like to manually input data for. Please create a new ${REPORT_LOWERCASE}.`}
+        </Styled.NoRecordsForTaskCardManualEntryMessage>
         <Styled.CreateReportForm>
           {/* Form Title */}
           <OnePanelBackLinkContainer>


### PR DESCRIPTION
## Description of the change

When a user clicks on the "Manual Entry" link in a metric's 'add data' task card and there are no records that match the metric's frequency, the user is redirected to the Create Record page where they will now see the following copy that will explain how they got there:

"It looks like there are no records for the metric you would like to manually input data for. Please create a new record."

Took some small liberties design and copy-wise - _**always**_ open to suggestions to improve both!

https://github.com/Recidiviz/justice-counts/assets/59492998/ac17f9f6-12a4-402e-816a-e07236b52a81


## Related issues

Closes #761

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
