### PR TITLE
Add basic down-for-maintenance page

### DIFF
--- a/publisher/src/App.tsx
+++ b/publisher/src/App.tsx
@@ -17,20 +17,18 @@
 
 import { observer } from "mobx-react-lite";
 import React, { ReactElement, useEffect } from "react";
-import { Navigate, Route, Routes, useLocation } from "react-router-dom";
+import { useLocation } from "react-router-dom";
 
 import { trackNavigation } from "./analytics";
-import Footer from "./components/Footer";
+import MaintenancePage from "./components/Auth/Maintenance";
 import { AppWrapper, PageWrapper } from "./components/Forms";
-import { REPORTS_LOWERCASE } from "./components/Global/constants";
 import { Loading } from "./components/Loading";
-import { NoAgencies } from "./pages/NoAgencies";
-import { Router } from "./router";
 import { useStore } from "./stores";
 
 const App: React.FC = (): ReactElement => {
   const location = useLocation();
-  const { userStore, guidanceStore } = useStore();
+  const { userStore } = useStore();
+  // const { userStore, guidanceStore } = useStore();
   useEffect(() => {
     trackNavigation(location.pathname + location.search);
   }, [location]);
@@ -48,12 +46,13 @@ const App: React.FC = (): ReactElement => {
   // or we go to route associated with specific agency (like external url with specific page and maybe search params)
   // if false then we just show user page that there are no associated agencies
   // if user has agencies but route is out of pattern /agency/:agencyId then redirect to /agency/:initialAgencyId/reports
-  const initialAgency = userStore.getInitialAgencyId();
-  const { hasCompletedOnboarding } = guidanceStore;
+  // const initialAgency = userStore.getInitialAgencyId();
+  // const { hasCompletedOnboarding } = guidanceStore;
 
   return (
     <AppWrapper>
-      <PageWrapper>
+      <MaintenancePage />
+      {/* <PageWrapper>
         {initialAgency ? (
           <Routes>
             <Route
@@ -86,7 +85,7 @@ const App: React.FC = (): ReactElement => {
           <NoAgencies />
         )}
       </PageWrapper>
-      <Footer />
+      <Footer /> */}
     </AppWrapper>
   );
 };

--- a/publisher/src/App.tsx
+++ b/publisher/src/App.tsx
@@ -17,18 +17,20 @@
 
 import { observer } from "mobx-react-lite";
 import React, { ReactElement, useEffect } from "react";
-import { useLocation } from "react-router-dom";
+import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 
 import { trackNavigation } from "./analytics";
-import MaintenancePage from "./components/Auth/Maintenance";
+import Footer from "./components/Footer";
 import { AppWrapper, PageWrapper } from "./components/Forms";
+import { REPORTS_LOWERCASE } from "./components/Global/constants";
 import { Loading } from "./components/Loading";
+import { NoAgencies } from "./pages/NoAgencies";
+import { Router } from "./router";
 import { useStore } from "./stores";
 
 const App: React.FC = (): ReactElement => {
   const location = useLocation();
-  const { userStore } = useStore();
-  // const { userStore, guidanceStore } = useStore();
+  const { userStore, guidanceStore } = useStore();
   useEffect(() => {
     trackNavigation(location.pathname + location.search);
   }, [location]);
@@ -46,13 +48,12 @@ const App: React.FC = (): ReactElement => {
   // or we go to route associated with specific agency (like external url with specific page and maybe search params)
   // if false then we just show user page that there are no associated agencies
   // if user has agencies but route is out of pattern /agency/:agencyId then redirect to /agency/:initialAgencyId/reports
-  // const initialAgency = userStore.getInitialAgencyId();
-  // const { hasCompletedOnboarding } = guidanceStore;
+  const initialAgency = userStore.getInitialAgencyId();
+  const { hasCompletedOnboarding } = guidanceStore;
 
   return (
     <AppWrapper>
-      <MaintenancePage />
-      {/* <PageWrapper>
+      <PageWrapper>
         {initialAgency ? (
           <Routes>
             <Route
@@ -85,7 +86,7 @@ const App: React.FC = (): ReactElement => {
           <NoAgencies />
         )}
       </PageWrapper>
-      <Footer /> */}
+      <Footer />
     </AppWrapper>
   );
 };

--- a/publisher/src/components/Auth/Maintenance.tsx
+++ b/publisher/src/components/Auth/Maintenance.tsx
@@ -15,9 +15,9 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+import logoImg from "@justice-counts/common/assets/jc-logo-vector-new.svg";
 import React from "react";
 import styled from "styled-components/macro";
-import logoImg from "@justice-counts/common/assets/jc-logo-vector-new.svg";
 
 const MaintenanceContainer = styled.div`
   height: 100vh;

--- a/publisher/src/components/Auth/Maintenance.tsx
+++ b/publisher/src/components/Auth/Maintenance.tsx
@@ -17,18 +17,22 @@
 
 import React from "react";
 import styled from "styled-components/macro";
+import logoImg from "@justice-counts/common/assets/jc-logo-vector-new.svg";
 
 const MaintenanceContainer = styled.div`
   height: 100vh;
   width: 100vw;
   display: flex;
+  flex-direction: column;
   justify-content: center;
   align-items: center;
+  gap: 30px;
 `;
 
 const MaintenancePage = () => {
   return (
     <MaintenanceContainer>
+      <img src={logoImg} alt="" />
       Publisher is currently down for maintenance. We apologize for the
       inconvenience and should be up and running shortly.
     </MaintenanceContainer>

--- a/publisher/src/components/Auth/Maintenance.tsx
+++ b/publisher/src/components/Auth/Maintenance.tsx
@@ -1,0 +1,38 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2023 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import React from "react";
+import styled from "styled-components/macro";
+
+const MaintenanceContainer = styled.div`
+  height: 100vh;
+  width: 100vw;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`;
+
+const MaintenancePage = () => {
+  return (
+    <MaintenanceContainer>
+      Publisher is currently down for maintenance. We apologize for the
+      inconvenience and should be up and running shortly.
+    </MaintenanceContainer>
+  );
+};
+
+export default MaintenancePage;


### PR DESCRIPTION
## Description of the change

Adds a basic down-for-maintenance page.

<img width="1728" alt="Screenshot 2023-07-18 at 1 36 25 PM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/e3cc4501-0889-4df7-a7a6-2ece8b079f86">

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
