### PR TITLE
[Justice Counts] Standalone Errors/Warnings Page Close Fix

### DIFF
--- a/publisher/src/components/DataUpload/ShareUploadErrorWarnings.tsx
+++ b/publisher/src/components/DataUpload/ShareUploadErrorWarnings.tsx
@@ -130,7 +130,7 @@ function ShareUploadErrorWarnings() {
         >
           <Button
             label={errorsWarningsMetrics ? "Close" : "Cancel"}
-            onClick={() => navigate(-1)}
+            onClick={() => navigate(`/agency/${agencyId}`)}
             buttonColor={errorsWarningsMetrics ? "red" : undefined}
             borderColor={errorsWarningsMetrics ? undefined : "white"}
             labelColor={errorsWarningsMetrics ? undefined : "white"}


### PR DESCRIPTION
## Description of the change

For the new standalone errors/warnings page, the 'Close' button did not lead anywhere when clicked. Since this is a 'standalone' page, we assume that the user does not have a previous page in the history stack. So  `onClick={() => navigate(-1)}` does not go anywhere. To resolve this, this PR changes the onClick so that the user is navigated to the home page when the click the 'Close' button.

Before:

https://github.com/Recidiviz/justice-counts/assets/82831800/d640abf1-9dde-431b-910b-3760575fa748


## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Closes #XXXX

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
