### PR TITLE
[Agency Dashboard] Hide homepage in production

### DIFF
--- a/agency-dashboard/src/App.tsx
+++ b/agency-dashboard/src/App.tsx
@@ -23,11 +23,16 @@ import { CategoryOverview } from "./CategoryOverview/CategoryOverview";
 import { DashboardView } from "./DashboardView";
 import { Home } from "./Home";
 import { NotFound } from "./NotFound";
+import { environment, getEnv } from "./utils/env";
 
 function App() {
+  const env = getEnv();
   return (
     <Routes>
-      <Route path="/" element={<Home />} />
+      <Route
+        path="/"
+        element={env === environment.PRODUCTION ? <NotFound /> : <Home />}
+      />
       <Route path="/agency/:slug" element={<AgencyOverview />} />
       <Route path="/agency/:slug/:category" element={<CategoryOverview />} />
       <Route path="/agency/:slug/dashboard" element={<DashboardView />} />

--- a/agency-dashboard/src/App.tsx
+++ b/agency-dashboard/src/App.tsx
@@ -23,16 +23,11 @@ import { CategoryOverview } from "./CategoryOverview/CategoryOverview";
 import { DashboardView } from "./DashboardView";
 import { Home } from "./Home";
 import { NotFound } from "./NotFound";
-import { environment, getEnv } from "./utils/env";
 
 function App() {
-  const env = getEnv();
   return (
     <Routes>
-      <Route
-        path="/"
-        element={env === environment.PRODUCTION ? <NotFound /> : <Home />}
-      />
+      <Route path="/" element={<Home />} />
       <Route path="/agency/:slug" element={<AgencyOverview />} />
       <Route path="/agency/:slug/:category" element={<CategoryOverview />} />
       <Route path="/agency/:slug/dashboard" element={<DashboardView />} />

--- a/agency-dashboard/src/Home/Home.tsx
+++ b/agency-dashboard/src/Home/Home.tsx
@@ -40,9 +40,10 @@ export const Home = observer(() => {
       const result = await agencyDataStore.fetchAllAgencies();
       setAgenciesMetadata(result.agencies);
     };
-    fetchData();
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [agencyDataStore]);
+    if (api.environment !== environment.PRODUCTION) {
+      fetchData();
+    }
+  }, [agencyDataStore, api]);
 
   if (api.environment === environment.PRODUCTION) {
     return <NotFound />;

--- a/agency-dashboard/src/Home/Home.tsx
+++ b/agency-dashboard/src/Home/Home.tsx
@@ -20,15 +20,17 @@ import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { WelcomeHeaderBar } from "../Header";
-import { Loader } from "../Loading";
+import { Loading } from "../Loading";
+import { NotFound } from "../NotFound";
 import { useStore } from "../stores";
+import { environment } from "../stores/API";
 import { slugify } from "../utils/formatting";
 import * as Styled from "./Home.styles";
 import { AgencyMetadata } from "./types";
 
 export const Home = observer(() => {
   const navigate = useNavigate();
-  const { agencyDataStore } = useStore();
+  const { agencyDataStore, api } = useStore();
   const [agenciesMetadata, setAgenciesMetadata] = useState<AgencyMetadata[]>(
     []
   );
@@ -42,35 +44,37 @@ export const Home = observer(() => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agencyDataStore]);
 
+  if (api.environment === environment.STAGING) {
+    return <NotFound />;
+  }
+
+  if (agencyDataStore.loading) {
+    return <Loading />;
+  }
+
   return (
     <Styled.HomeContainer>
       <WelcomeHeaderBar />
       <Styled.Title>Welcome to Agency Dashboards</Styled.Title>
 
-      {agencyDataStore.loading ? (
-        <Loader />
-      ) : (
-        <Styled.AgencyDetailsContainer>
-          {agenciesMetadata
-            .sort((a, b) => a.name.localeCompare(b.name))
-            .map((agency) => (
-              <Styled.AgencyDetailsWrapper
-                key={agency.id}
-                onClick={() =>
-                  navigate(
-                    `/agency/${encodeURIComponent(slugify(agency.name))}`
-                  )
-                }
-              >
-                <Styled.AgencyName>{agency.name}</Styled.AgencyName>
-                <Styled.NumberOfPublishedMetrics>
-                  <span>{agency.number_of_published_metrics}</span> published
-                  metrics
-                </Styled.NumberOfPublishedMetrics>
-              </Styled.AgencyDetailsWrapper>
-            ))}
-        </Styled.AgencyDetailsContainer>
-      )}
+      <Styled.AgencyDetailsContainer>
+        {agenciesMetadata
+          .sort((a, b) => a.name.localeCompare(b.name))
+          .map((agency) => (
+            <Styled.AgencyDetailsWrapper
+              key={agency.id}
+              onClick={() =>
+                navigate(`/agency/${encodeURIComponent(slugify(agency.name))}`)
+              }
+            >
+              <Styled.AgencyName>{agency.name}</Styled.AgencyName>
+              <Styled.NumberOfPublishedMetrics>
+                <span>{agency.number_of_published_metrics}</span> published
+                metrics
+              </Styled.NumberOfPublishedMetrics>
+            </Styled.AgencyDetailsWrapper>
+          ))}
+      </Styled.AgencyDetailsContainer>
     </Styled.HomeContainer>
   );
 });

--- a/agency-dashboard/src/Home/Home.tsx
+++ b/agency-dashboard/src/Home/Home.tsx
@@ -44,7 +44,7 @@ export const Home = observer(() => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [agencyDataStore]);
 
-  if (api.environment === environment.STAGING) {
+  if (api.environment === environment.PRODUCTION) {
     return <NotFound />;
   }
 

--- a/agency-dashboard/src/stores/API.ts
+++ b/agency-dashboard/src/stores/API.ts
@@ -18,6 +18,11 @@ import { makeAutoObservable, runInAction } from "mobx";
 
 import { request } from "../utils/networking";
 
+export enum environment {
+  PRODUCTION = "production",
+  STAGING = "staging",
+  DEVELOPMENT = "development",
+}
 export interface RequestProps {
   path: string;
   method: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";


### PR DESCRIPTION
## Description of the change

Hides the home page in production (`path="/"`) and displays the 404 not found page instead.

<img width="1728" alt="Screenshot 2023-08-02 at 3 54 56 PM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/3d7449fa-f0da-460a-8fb2-33a02965c623">


https://github.com/Recidiviz/justice-counts/assets/59492998/9316b1b0-4c4b-497c-93bf-f8d04c90ac49


## Related issues

Closes #772

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
