### PR TITLE
Remove useEffects from AgencyOverview

### DIFF
--- a/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
+++ b/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
@@ -29,11 +29,6 @@ import React, { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import useAsyncEffect from "use-async-effect";
 
-import { Footer } from "../Footer";
-import { HeaderBar } from "../Header";
-import { Loading } from "../Loading";
-import { NotFoundComponent } from "../NotFound";
-import { useStore } from "../stores";
 import {
   AgencyDescription,
   AgencyHomepage,
@@ -54,6 +49,10 @@ import {
   SystemChip,
   SystemChipsContainer,
 } from ".";
+import { Footer } from "../Footer";
+import { HeaderBar } from "../Header";
+import { Loading } from "../Loading";
+import { useStore } from "../stores";
 
 const orderedCategoriesMap: {
   [category: string]: { label: string; description: string };
@@ -116,8 +115,7 @@ export const AgencyOverview = observer(() => {
 
   if (agencyDataStore.loading) return <Loading />;
 
-  if (agencyHasNoAvailableSystemsOrHasNoData && !agencyDataStore.loading)
-    return <NotFoundComponent />;
+  if (agencyHasNoAvailableSystemsOrHasNoData) return <NotFoundComponent />;
 
   return (
     <>

--- a/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
+++ b/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
@@ -114,12 +114,12 @@ export const AgencyOverview = observer(() => {
     !agencyHasAvailableSystems ||
     metricsByAvailableCategoriesAndSystemsWithData.length === 0;
 
+  if (agencyDataStore.loading) return <Loading />;
+
   if (agencyHasNoAvailableSystemsOrHasNoData && !agencyDataStore.loading)
     return <NotFoundComponent />;
 
-  return agencyDataStore.loading ? (
-    <Loading />
-  ) : (
+  return (
     <>
       <HeaderBar />
       <AgencyOverviewWrapper>

--- a/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
+++ b/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
@@ -29,6 +29,11 @@ import React, { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import useAsyncEffect from "use-async-effect";
 
+import { Footer } from "../Footer";
+import { HeaderBar } from "../Header";
+import { Loading } from "../Loading";
+import { NotFound } from "../NotFound";
+import { useStore } from "../stores";
 import {
   AgencyDescription,
   AgencyHomepage,
@@ -49,10 +54,6 @@ import {
   SystemChip,
   SystemChipsContainer,
 } from ".";
-import { Footer } from "../Footer";
-import { HeaderBar } from "../Header";
-import { Loading } from "../Loading";
-import { useStore } from "../stores";
 
 const orderedCategoriesMap: {
   [category: string]: { label: string; description: string };
@@ -115,7 +116,7 @@ export const AgencyOverview = observer(() => {
 
   if (agencyDataStore.loading) return <Loading />;
 
-  if (agencyHasNoAvailableSystemsOrHasNoData) return <NotFoundComponent />;
+  if (agencyHasNoAvailableSystemsOrHasNoData) return <NotFound />;
 
   return (
     <>

--- a/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
+++ b/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
@@ -29,10 +29,6 @@ import React, { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import useAsyncEffect from "use-async-effect";
 
-import { Footer } from "../Footer";
-import { HeaderBar } from "../Header";
-import { Loading } from "../Loading";
-import { useStore } from "../stores";
 import {
   AgencyDescription,
   AgencyHomepage,
@@ -53,6 +49,11 @@ import {
   SystemChip,
   SystemChipsContainer,
 } from ".";
+import { Footer } from "../Footer";
+import { HeaderBar } from "../Header";
+import { Loading } from "../Loading";
+import { NotFoundComponent } from "../NotFound";
+import { useStore } from "../stores";
 
 const orderedCategoriesMap: {
   [category: string]: { label: string; description: string };
@@ -113,7 +114,7 @@ export const AgencyOverview = observer(() => {
     !agencyHasAvailableSystems ||
     metricsByAvailableCategoriesAndSystemsWithData.length === 0;
 
-  if (agencyHasNoAvailableSystemsOrHasNoData) navigate("/404");
+  if (agencyHasNoAvailableSystemsOrHasNoData) return <NotFoundComponent />;
 
   return agencyDataStore.loading ? (
     <Loading />

--- a/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
+++ b/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
@@ -29,6 +29,11 @@ import React, { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import useAsyncEffect from "use-async-effect";
 
+import { Footer } from "../Footer";
+import { HeaderBar } from "../Header";
+import { Loading } from "../Loading";
+import { NotFoundComponent } from "../NotFound";
+import { useStore } from "../stores";
 import {
   AgencyDescription,
   AgencyHomepage,
@@ -49,11 +54,6 @@ import {
   SystemChip,
   SystemChipsContainer,
 } from ".";
-import { Footer } from "../Footer";
-import { HeaderBar } from "../Header";
-import { Loading } from "../Loading";
-import { NotFoundComponent } from "../NotFound";
-import { useStore } from "../stores";
 
 const orderedCategoriesMap: {
   [category: string]: { label: string; description: string };

--- a/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
+++ b/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
@@ -29,11 +29,6 @@ import React, { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import useAsyncEffect from "use-async-effect";
 
-import { Footer } from "../Footer";
-import { HeaderBar } from "../Header";
-import { Loading } from "../Loading";
-import { NotFoundComponent } from "../NotFound";
-import { useStore } from "../stores";
 import {
   AgencyDescription,
   AgencyHomepage,
@@ -54,6 +49,11 @@ import {
   SystemChip,
   SystemChipsContainer,
 } from ".";
+import { Footer } from "../Footer";
+import { HeaderBar } from "../Header";
+import { Loading } from "../Loading";
+import { NotFoundComponent } from "../NotFound";
+import { useStore } from "../stores";
 
 const orderedCategoriesMap: {
   [category: string]: { label: string; description: string };
@@ -114,7 +114,8 @@ export const AgencyOverview = observer(() => {
     !agencyHasAvailableSystems ||
     metricsByAvailableCategoriesAndSystemsWithData.length === 0;
 
-  if (agencyHasNoAvailableSystemsOrHasNoData) return <NotFoundComponent />;
+  if (agencyHasNoAvailableSystemsOrHasNoData && !agencyDataStore.loading)
+    return <NotFoundComponent />;
 
   return agencyDataStore.loading ? (
     <Loading />

--- a/agency-dashboard/src/NotFound/NotFound.tsx
+++ b/agency-dashboard/src/NotFound/NotFound.tsx
@@ -16,9 +16,9 @@
 // =============================================================================
 import React from "react";
 
-import { NotFoundText, NotFoundTitle, NotFoundWrapper } from ".";
 import { Footer } from "../Footer";
 import { HeaderBar } from "../Header";
+import { NotFoundText, NotFoundTitle, NotFoundWrapper } from ".";
 
 export const NotFound = () => (
   <>

--- a/agency-dashboard/src/NotFound/NotFound.tsx
+++ b/agency-dashboard/src/NotFound/NotFound.tsx
@@ -22,25 +22,7 @@ import { HeaderBar } from "../Header";
 import { NotFoundText, NotFoundTitle, NotFoundWrapper } from ".";
 
 export const NotFound = observer(() => {
-  return (
-    <>
-      <HeaderBar />
-      <NotFoundWrapper>
-        <NotFoundTitle>Page Not Found</NotFoundTitle>
-        <NotFoundText>
-          Error 404
-          <span>
-            The page you are looking for seems to be missing. Send us an email
-            and we’ll help you find it.
-          </span>
-          <a href="mailto:justice-counts-support@csg.org">
-            justice-counts-support@csg.org
-          </a>
-        </NotFoundText>
-      </NotFoundWrapper>
-      <Footer />
-    </>
-  );
+  return <NotFoundComponent />;
 });
 
 export const NotFoundComponent = () => (

--- a/agency-dashboard/src/NotFound/NotFound.tsx
+++ b/agency-dashboard/src/NotFound/NotFound.tsx
@@ -14,18 +14,13 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-import { observer } from "mobx-react-lite";
 import React from "react";
 
+import { NotFoundText, NotFoundTitle, NotFoundWrapper } from ".";
 import { Footer } from "../Footer";
 import { HeaderBar } from "../Header";
-import { NotFoundText, NotFoundTitle, NotFoundWrapper } from ".";
 
-export const NotFound = observer(() => {
-  return <NotFoundComponent />;
-});
-
-export const NotFoundComponent = () => (
+export const NotFound = () => (
   <>
     <HeaderBar />
     <NotFoundWrapper>

--- a/agency-dashboard/src/NotFound/NotFound.tsx
+++ b/agency-dashboard/src/NotFound/NotFound.tsx
@@ -42,3 +42,23 @@ export const NotFound = observer(() => {
     </>
   );
 });
+
+export const NotFoundComponent = () => (
+  <>
+    <HeaderBar />
+    <NotFoundWrapper>
+      <NotFoundTitle>Page Not Found</NotFoundTitle>
+      <NotFoundText>
+        Error 404
+        <span>
+          The page you are looking for seems to be missing. Send us an email and
+          we’ll help you find it.
+        </span>
+        <a href="mailto:justice-counts-support@csg.org">
+          justice-counts-support@csg.org
+        </a>
+      </NotFoundText>
+    </NotFoundWrapper>
+    <Footer />
+  </>
+);


### PR DESCRIPTION
## Description of the change

Removes dependency tracking and management from AgencyOverview

## Related issues

Relates to #770

## Test Plan

* Navigate to playtesting https://alfonsotest---agency-dashboard-web-b47yvyxs3q-uc.a.run.app/
* Click on an agency
* Verify that agency loads after some loading time during which you see the spinner

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [x] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [x] This pull request has a descriptive title and information useful to a reviewer
- [x] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [x] Potential security implications or infrastructural changes have been considered, if relevant
