### PR TITLE
[Bug] DataEntryReview sometimes crashes when metricDisplayNames is initially undefined

### DIFF
--- a/publisher/src/components/Home/Home.tsx
+++ b/publisher/src/components/Home/Home.tsx
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import { AgencySystems, Metric } from "@justice-counts/common/types";
-import { groupBy } from "@justice-counts/common/utils";
+import { groupBy, removeSnakeCase } from "@justice-counts/common/utils";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -204,7 +204,7 @@ export const Home = observer(() => {
                   selected={system === currentSystem}
                   onClick={() => setCurrentSystem(system)}
                 >
-                  {system.toLocaleLowerCase()}
+                  {removeSnakeCase(system.toLocaleLowerCase())}
                 </Styled.SystemSelectorTab>
               ))}
           </Styled.SystemSelectorTabWrapper>

--- a/publisher/src/components/Home/Home.tsx
+++ b/publisher/src/components/Home/Home.tsx
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import { AgencySystems, Metric } from "@justice-counts/common/types";
-import { groupBy, removeSnakeCase } from "@justice-counts/common/utils";
+import { groupBy } from "@justice-counts/common/utils";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -204,7 +204,7 @@ export const Home = observer(() => {
                   selected={system === currentSystem}
                   onClick={() => setCurrentSystem(system)}
                 >
-                  {removeSnakeCase(system.toLocaleLowerCase())}
+                  {system.toLocaleLowerCase()}
                 </Styled.SystemSelectorTab>
               ))}
           </Styled.SystemSelectorTabWrapper>

--- a/publisher/src/components/Reports/DataEntryReview.tsx
+++ b/publisher/src/components/Reports/DataEntryReview.tsx
@@ -133,8 +133,9 @@ const DataEntryReview = () => {
         // Sort this list of metrics so it matches the order of the metrics list on the data entry page
         .sort(
           (a, b) =>
+            metricDisplayNames &&
             metricDisplayNames.indexOf(a.display_name) -
-            metricDisplayNames.indexOf(b.display_name)
+              metricDisplayNames.indexOf(b.display_name)
         )
     : [];
   const record = reportStore.reportOverviews[reportID];


### PR DESCRIPTION
## Description of the change

Quick bug fix - checks for `metricDisplayNames` before sorting - otherwise, if metricDisplayNames comes up `undefined`, this page crashes.

[This might've only happened while I was moving things around in my refactor and may not happen in practice - but, it exposed this possibility.]

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
