### PR TITLE
[Publisher] Styling fix for long system names

### DIFF
--- a/publisher/src/components/Home/Home.styled.tsx
+++ b/publisher/src/components/Home/Home.styled.tsx
@@ -191,6 +191,7 @@ export const SystemSelectorTabWrapper = styled.div`
 
 export const SystemSelectorTab = styled.div<{ selected?: boolean }>`
   text-transform: capitalize;
+  white-space: nowrap;
   color: ${({ selected }) =>
     selected ? palette.solid.blue : palette.solid.darkgrey};
   border-bottom: 1.5px solid

--- a/publisher/src/components/Home/Home.styled.tsx
+++ b/publisher/src/components/Home/Home.styled.tsx
@@ -168,11 +168,12 @@ export const SubmenuItem = styled.a`
 
 export const SystemSelectorContainer = styled.div`
   ${typography.sizeCSS.normal};
+  width: 100%;
   display: flex;
   gap: 32px;
 
   & > div:nth-child(1) {
-    flex: 1 4 280px;
+    flex: 1 1 280px;
   }
   & > div:nth-child(2) {
     width: 500px;
@@ -180,11 +181,24 @@ export const SystemSelectorContainer = styled.div`
   & > div:nth-child(3) {
     flex: 1 1 280px;
   }
+
+  @media only screen and (max-width: 1024px) {
+    & > div:nth-child(1) {
+      flex: 1 1 0px;
+    }
+    & > div:nth-child(2) {
+      width: 500px;
+    }
+    & > div:nth-child(3) {
+      flex: 1 1 0px;
+    }
+  }
 `;
 
 export const SystemSelectorTabWrapper = styled.div`
   display: flex;
   justify-content: flex-start;
+  flex-wrap: wrap;
   gap: 16px;
   margin-bottom: 24px;
 `;


### PR DESCRIPTION
## Description of the change

Quick follow up to @morden35's snake case fix (thank you again so much!) - adjusts the styling so the system name doesn't wrap:

From:
<img width="613" alt="Screenshot 2023-08-15 at 11 11 01 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/08c29f68-27a0-402f-bf28-349026b69003">

To:
<img width="676" alt="Screenshot 2023-08-15 at 11 14 00 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/a721e51d-fb1d-4913-8f5e-eefbff854dc3">

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
