### PR TITLE
[Publisher] Remove HeaderBar label from standalone errors/warnings page

### DIFF
--- a/publisher/src/components/DataUpload/ShareUploadErrorWarnings.tsx
+++ b/publisher/src/components/DataUpload/ShareUploadErrorWarnings.tsx
@@ -125,7 +125,6 @@ function ShareUploadErrorWarnings() {
           onLogoClick={() => navigate(`/agency/${agencyId}`)}
           background={headerBackground()}
           hasBottomBorder={!!errorsWarningsMetrics}
-          label="Justice Counts"
           badge={headerBadge}
         >
           <Button


### PR DESCRIPTION
## Description of the change

Removes HeaderBar label from standalone errors/warnings page because it is not needed.

Before:
![image](https://github.com/Recidiviz/justice-counts/assets/59492998/7b43dfe3-1f18-4523-8fbd-9ca068e36ffc)

After:
<img width="1728" alt="Screenshot 2023-08-16 at 4 59 26 PM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/658f7e42-1b5f-4bc0-a06e-fbcdd30d5b21">


## Related issues

Closes #861

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
