### PR TITLE
Superagencies: Add copy for non-superagency systems within Metric Settings

### DIFF
--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.styled.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.styled.tsx
@@ -27,14 +27,22 @@ const OVERVIEW_WRAPPER_WIDTH = 470;
 export const Wrapper = styled.div`
   width: 100%;
   height: 100%;
-  padding: 56px 24px 100px 24px;
+`;
+
+export const MetricsOverviewWrapper = styled.div<{
+  isSuperagencyNotSuperagencySystem?: boolean;
+}>`
+  display: flex;
+  padding: ${({ isSuperagencyNotSuperagencySystem }) =>
+    isSuperagencyNotSuperagencySystem
+      ? `26px 24px 100px 24px`
+      : `56px 24px 100px 24px`};
 `;
 
 export const OverviewWrapper = styled.div`
-  position: fixed;
   top: ${HEADER_BAR_HEIGHT + 48}px;
   left: 24px;
-  width: ${OVERVIEW_WRAPPER_WIDTH}px;
+  max-width: ${OVERVIEW_WRAPPER_WIDTH}px;
   display: flex;
   flex-direction: column;
 `;
@@ -79,7 +87,7 @@ export const SystemMenuItem = styled.div<{ selected: boolean }>`
 
 export const MetricsWrapper = styled.div`
   width: 100%;
-  padding-left: 550px;
+  padding-left: 80px;
   display: flex;
   flex-direction: column;
   gap: 56px;

--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.styled.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.styled.tsx
@@ -90,11 +90,23 @@ export const MetricsSection = styled.div`
   flex-direction: column;
 `;
 
-export const MetricsSectionTitle = styled.div<{ textColor?: string }>`
+export const MetricsSectionTitle = styled.div<{
+  textColor?: string;
+  width?: number;
+}>`
   ${typography.sizeCSS.medium};
+  ${({ width }) => width && `width: ${width}%;`};
+  color: ${({ textColor }) => {
+    if (textColor === "red") {
+      return palette.solid.red;
+    }
+    if (textColor === "blue") {
+      return palette.solid.blue;
+    }
+    return palette.highlight.grey9;
+  }};
+
   margin-bottom: 12px;
-  color: ${({ textColor }) =>
-    textColor === "red" ? palette.solid.red : palette.highlight.grey9};
 `;
 
 export const MetricItem = styled.div`

--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.styled.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.styled.tsx
@@ -108,28 +108,10 @@ export const MetricsSectionTitle = styled.div<{
     if (textColor === "red") {
       return palette.solid.red;
     }
-    if (textColor === "blue") {
-      return palette.solid.blue;
-    }
     return palette.highlight.grey9;
   }};
 
   margin-bottom: 12px;
-`;
-
-export const DisclaimerText = styled.div<{
-  textColor?: string;
-  width?: number;
-}>`
-  ${typography.sizeCSS.medium};
-  font-weight: 400;
-  ${({ width }) => width && `width: ${width}%;`};
-
-  &:before {
-    content: "*";
-    position: relative;
-    color: ${palette.solid.red};
-  }
 `;
 
 export const MetricItem = styled.div`

--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.styled.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.styled.tsx
@@ -109,6 +109,26 @@ export const MetricsSectionTitle = styled.div<{
   margin-bottom: 12px;
 `;
 
+export const DisclaimerText = styled.div<{
+  textColor?: string;
+  width?: number;
+}>`
+  ${typography.sizeCSS.normal};
+  ${({ width }) => width && `width: ${width}%;`};
+  color: ${({ textColor }) => {
+    if (textColor === "red") {
+      return palette.solid.red;
+    }
+    if (textColor === "blue") {
+      return palette.solid.blue;
+    }
+    if (textColor === "orange") {
+      return palette.solid.orange;
+    }
+    return palette.highlight.grey9;
+  }};
+`;
+
 export const MetricItem = styled.div`
   width: 100%;
   padding: 32px 16px;

--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.styled.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.styled.tsx
@@ -113,20 +113,15 @@ export const DisclaimerText = styled.div<{
   textColor?: string;
   width?: number;
 }>`
-  ${typography.sizeCSS.normal};
+  ${typography.sizeCSS.medium};
+  font-weight: 400;
   ${({ width }) => width && `width: ${width}%;`};
-  color: ${({ textColor }) => {
-    if (textColor === "red") {
-      return palette.solid.red;
-    }
-    if (textColor === "blue") {
-      return palette.solid.blue;
-    }
-    if (textColor === "orange") {
-      return palette.solid.orange;
-    }
-    return palette.highlight.grey9;
-  }};
+
+  &:before {
+    content: "*";
+    position: relative;
+    color: ${palette.solid.red};
+  }
 `;
 
 export const MetricItem = styled.div`

--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
@@ -17,6 +17,7 @@
 
 import { AgencySystems } from "@justice-counts/common/types";
 import { frequencyString } from "@justice-counts/common/utils/helperUtils";
+import { observer } from "mobx-react-lite";
 import React from "react";
 import { useParams } from "react-router-dom";
 
@@ -27,7 +28,7 @@ import { ReactComponent as RightArrowIcon } from "../assets/bold-right-arrow-ico
 import { useSettingsSearchParams } from "../Settings";
 import * as Styled from "./MetricsOverview.styled";
 
-export function MetricsOverview() {
+export const MetricsOverview = observer(() => {
   const [settingsSearchParams, setSettingsSearchParams] =
     useSettingsSearchParams();
   const { agencyId } = useParams() as { agencyId: string };
@@ -48,6 +49,10 @@ export function MetricsOverview() {
 
   const currentAgency = userStore.getAgency(agencyId);
   const currentSystem = systemSearchParam || currentAgency?.systems[0];
+
+  const isSuperagency = userStore.isAgencySuperagency(agencyId);
+
+  const isSuperagencySystem = systemSearchParam === "SUPERAGENCY";
 
   const showSystems =
     currentAgency?.systems && currentAgency?.systems?.length > 1;
@@ -100,6 +105,16 @@ export function MetricsOverview() {
         </Styled.SystemsList>
       </Styled.OverviewWrapper>
       <Styled.MetricsWrapper>
+        {isSuperagency && !isSuperagencySystem && (
+          <Styled.MetricsSection>
+            <Styled.MetricsSectionTitle textColor="blue" width={80}>
+              The settings you enter here will become the default for the
+              agencies you manage. However, each agency has the flexibility to
+              override these defaults and adapt them to their unique
+              requirements.
+            </Styled.MetricsSectionTitle>
+          </Styled.MetricsSection>
+        )}
         {hasActionRequiredMetrics && (
           <Styled.MetricsSection>
             <Styled.MetricsSectionTitle textColor="red">
@@ -171,4 +186,4 @@ export function MetricsOverview() {
       </Styled.MetricsWrapper>
     </Styled.Wrapper>
   );
-}
+});

--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
@@ -25,6 +25,7 @@ import { NotFound } from "../../pages/NotFound";
 import { useStore } from "../../stores";
 import { formatSystemName } from "../../utils";
 import { ReactComponent as RightArrowIcon } from "../assets/bold-right-arrow-icon.svg";
+import { DisclaimerBanner } from "../primitives";
 import { useSettingsSearchParams } from "../Settings";
 import * as Styled from "./MetricsOverview.styled";
 
@@ -54,6 +55,9 @@ export const MetricsOverview = observer(() => {
 
   const isSuperagencySystem = currentSystem === "SUPERAGENCY";
 
+  const isSuperagencyNotSuperagencySystem =
+    isSuperagency && !isSuperagencySystem;
+
   const showSystems =
     currentAgency?.systems && currentAgency?.systems?.length > 1;
 
@@ -79,112 +83,114 @@ export const MetricsOverview = observer(() => {
 
   return (
     <Styled.Wrapper>
-      <Styled.OverviewWrapper>
-        <Styled.OverviewHeader>Metric Settings</Styled.OverviewHeader>
-        <Styled.OverviewDescription>
-          Click on each metric to edit the availability of the metric and
-          relevant breakdown categories, as well as the definitions of each.
-        </Styled.OverviewDescription>
-        <Styled.SystemsList>
-          {showSystems &&
-            currentAgency?.systems
-              .filter((system) => getMetricsBySystem(system)?.length !== 0)
-              .map((system) => {
-                return (
-                  <Styled.SystemMenuItem
-                    key={system}
-                    selected={currentSystem === system}
-                    onClick={() => handleSystemClick(system)}
-                  >
-                    {formatSystemName(system, {
-                      allUserSystems: currentAgency?.systems,
-                    })}
-                  </Styled.SystemMenuItem>
-                );
-              })}
-        </Styled.SystemsList>
-      </Styled.OverviewWrapper>
-      <Styled.MetricsWrapper>
-        {isSuperagency && !isSuperagencySystem && (
-          <Styled.MetricsSection>
-            <Styled.DisclaimerText>
-              Once settings have been edited, please reach out to{" "}
-              <a href="mailto:justice-counts-support@csg.org">
-                justice-counts-support@csg.org
-              </a>{" "}
-              to apply these settings to other agencies.
-            </Styled.DisclaimerText>
-          </Styled.MetricsSection>
-        )}
-        {hasActionRequiredMetrics && (
-          <Styled.MetricsSection>
-            <Styled.MetricsSectionTitle textColor="red">
-              Action required
-            </Styled.MetricsSectionTitle>
-            {actionRequiredMetrics?.map(({ key, metric }) => (
-              <Styled.MetricItem
-                key={key}
-                onClick={() =>
-                  setSettingsSearchParams({
-                    system: currentSystem,
-                    metric: key,
-                  })
-                }
-              >
-                <Styled.MetricItemName>{metric.label}</Styled.MetricItemName>
-                <RightArrowIcon />
-              </Styled.MetricItem>
-            ))}
-          </Styled.MetricsSection>
-        )}
-        {hasAvailableMetrics && (
-          <Styled.MetricsSection>
-            <Styled.MetricsSectionTitle>
-              Available Metrics
-            </Styled.MetricsSectionTitle>
-            {availableMetrics?.map(({ key, metric }) => (
-              <Styled.MetricItem
-                key={key}
-                onClick={() =>
-                  setSettingsSearchParams({
-                    system: currentSystem,
-                    metric: key,
-                  })
-                }
-              >
-                <Styled.MetricItemName>
-                  {metric.label}
-                  <span>
-                    {frequencyString(metric.customFrequency)?.toLowerCase()}
-                  </span>
-                </Styled.MetricItemName>
-                <RightArrowIcon />
-              </Styled.MetricItem>
-            ))}
-          </Styled.MetricsSection>
-        )}
-        {hasUnavailableMetrics && (
-          <Styled.MetricsSection>
-            <Styled.MetricsSectionTitle>
-              Unavailable Metrics
-            </Styled.MetricsSectionTitle>
-            {unavailableMetrics?.map(({ key, metric }) => (
-              <Styled.MetricItem
-                key={key}
-                onClick={() =>
-                  setSettingsSearchParams({
-                    system: currentSystem,
-                    metric: key,
-                  })
-                }
-              >
-                <Styled.MetricItemName>{metric.label}</Styled.MetricItemName>
-                <RightArrowIcon />
-              </Styled.MetricItem>
-            ))}
-          </Styled.MetricsSection>
-        )}
-      </Styled.MetricsWrapper>
+      {isSuperagencyNotSuperagencySystem && (
+        <DisclaimerBanner>
+          Once settings have been edited, please reach out to&nbsp;
+          <a href="mailto:justice-counts-support@csg.org">
+            justice-counts-support@csg.org
+          </a>
+          &nbsp; to apply these settings to other agencies.
+        </DisclaimerBanner>
+      )}
+      <Styled.MetricsOverviewWrapper
+        isSuperagencyNotSuperagencySystem={isSuperagencyNotSuperagencySystem}
+      >
+        <Styled.OverviewWrapper>
+          <Styled.OverviewHeader>Metric Settings</Styled.OverviewHeader>
+          <Styled.OverviewDescription>
+            Click on each metric to edit the availability of the metric and
+            relevant breakdown categories, as well as the definitions of each.
+          </Styled.OverviewDescription>
+          <Styled.SystemsList>
+            {showSystems &&
+              currentAgency?.systems
+                .filter((system) => getMetricsBySystem(system)?.length !== 0)
+                .map((system) => {
+                  return (
+                    <Styled.SystemMenuItem
+                      key={system}
+                      selected={currentSystem === system}
+                      onClick={() => handleSystemClick(system)}
+                    >
+                      {formatSystemName(system, {
+                        allUserSystems: currentAgency?.systems,
+                      })}
+                    </Styled.SystemMenuItem>
+                  );
+                })}
+          </Styled.SystemsList>
+        </Styled.OverviewWrapper>
+        <Styled.MetricsWrapper>
+          {hasActionRequiredMetrics && (
+            <Styled.MetricsSection>
+              <Styled.MetricsSectionTitle textColor="red">
+                Action required
+              </Styled.MetricsSectionTitle>
+              {actionRequiredMetrics?.map(({ key, metric }) => (
+                <Styled.MetricItem
+                  key={key}
+                  onClick={() =>
+                    setSettingsSearchParams({
+                      system: currentSystem,
+                      metric: key,
+                    })
+                  }
+                >
+                  <Styled.MetricItemName>{metric.label}</Styled.MetricItemName>
+                  <RightArrowIcon />
+                </Styled.MetricItem>
+              ))}
+            </Styled.MetricsSection>
+          )}
+          {hasAvailableMetrics && (
+            <Styled.MetricsSection>
+              <Styled.MetricsSectionTitle>
+                Available Metrics
+              </Styled.MetricsSectionTitle>
+              {availableMetrics?.map(({ key, metric }) => (
+                <Styled.MetricItem
+                  key={key}
+                  onClick={() =>
+                    setSettingsSearchParams({
+                      system: currentSystem,
+                      metric: key,
+                    })
+                  }
+                >
+                  <Styled.MetricItemName>
+                    {metric.label}
+                    <span>
+                      {frequencyString(metric.customFrequency)?.toLowerCase()}
+                    </span>
+                  </Styled.MetricItemName>
+                  <RightArrowIcon />
+                </Styled.MetricItem>
+              ))}
+            </Styled.MetricsSection>
+          )}
+          {hasUnavailableMetrics && (
+            <Styled.MetricsSection>
+              <Styled.MetricsSectionTitle>
+                Unavailable Metrics
+              </Styled.MetricsSectionTitle>
+              {unavailableMetrics?.map(({ key, metric }) => (
+                <Styled.MetricItem
+                  key={key}
+                  onClick={() =>
+                    setSettingsSearchParams({
+                      system: currentSystem,
+                      metric: key,
+                    })
+                  }
+                >
+                  <Styled.MetricItemName>{metric.label}</Styled.MetricItemName>
+                  <RightArrowIcon />
+                </Styled.MetricItem>
+              ))}
+            </Styled.MetricsSection>
+          )}
+        </Styled.MetricsWrapper>
+      </Styled.MetricsOverviewWrapper>
     </Styled.Wrapper>
   );
 });

--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
@@ -107,12 +107,12 @@ export const MetricsOverview = observer(() => {
       <Styled.MetricsWrapper>
         {isSuperagency && !isSuperagencySystem && (
           <Styled.MetricsSection>
-            <Styled.MetricsSectionTitle textColor="blue" width={80}>
+            <Styled.DisclaimerText textColor="orange" width={65}>
               The settings you enter here will become the default for the
               agencies you manage. However, each agency has the flexibility to
               override these defaults and adapt them to their unique
               requirements.
-            </Styled.MetricsSectionTitle>
+            </Styled.DisclaimerText>
           </Styled.MetricsSection>
         )}
         {hasActionRequiredMetrics && (

--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
@@ -52,7 +52,7 @@ export const MetricsOverview = observer(() => {
 
   const isSuperagency = userStore.isAgencySuperagency(agencyId);
 
-  const isSuperagencySystem = systemSearchParam === "SUPERAGENCY";
+  const isSuperagencySystem = currentSystem === "SUPERAGENCY";
 
   const showSystems =
     currentAgency?.systems && currentAgency?.systems?.length > 1;
@@ -107,11 +107,12 @@ export const MetricsOverview = observer(() => {
       <Styled.MetricsWrapper>
         {isSuperagency && !isSuperagencySystem && (
           <Styled.MetricsSection>
-            <Styled.DisclaimerText textColor="orange" width={65}>
-              The settings you enter here will become the default for the
-              agencies you manage. However, each agency has the flexibility to
-              override these defaults and adapt them to their unique
-              requirements.
+            <Styled.DisclaimerText>
+              Once settings have been edited, please reach out to{" "}
+              <a href="mailto:justice-counts-support@csg.org">
+                justice-counts-support@csg.org
+              </a>{" "}
+              to apply these settings to other agencies.
             </Styled.DisclaimerText>
           </Styled.MetricsSection>
         )}

--- a/publisher/src/components/primitives/index.tsx
+++ b/publisher/src/components/primitives/index.tsx
@@ -15,6 +15,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+import {
+  MIN_TABLET_WIDTH,
+  palette,
+  typography,
+} from "@justice-counts/common/components/GlobalStyles";
 import { AgencyTeamMemberRole } from "@justice-counts/common/types";
 import React from "react";
 import styled from "styled-components/macro";
@@ -42,6 +47,31 @@ const StyledRecidivizAdmin = styled(RecidivizAdmin)`
 
 const NameContainer = styled.span`
   padding: 0 !important;
+`;
+
+export const DisclaimerBanner = styled.div`
+  ${typography.sizeCSS.normal}
+  width: 100;
+  height: 54px;
+  background: ${palette.solid.blue};
+  color: ${palette.solid.white};
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+
+  a,
+  a:hover,
+  a:visited {
+    color: ${palette.solid.white};
+    display: block;
+  }
+
+  @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
+    flex-direction: column;
+    height: fit-content;
+    padding: 16px 0;
+  }
 `;
 
 export const TeamMemberNameWithBadge: React.FC<{


### PR DESCRIPTION
## Description of the change

Adds copy within the Metric Settings overview for the non-superagency systems clarifying that the settings they enter will become the defaults for child agencies - but, those child agencies can override the default.

Example (this only appears on the non-superagency systems' metric overview):
<img width="1728" alt="Screenshot 2023-08-18 at 7 56 33 PM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/827125ec-4f14-4050-aa17-233459ed5f3f">

## Related issues

Closes #874

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
