### PR TITLE
Superagencies: Only show superagency system data and add copy explaining how to view child agency data

### DIFF
--- a/publisher/src/components/DataViz/MetricsDataChart.styled.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.styled.tsx
@@ -161,8 +161,14 @@ export const DisclaimerTitle = styled.div`
   ${typography.sizeCSS.small}
 `;
 
-export const DisclaimerText = styled.div`
+export const DisclaimerText = styled.div<{
+  textColor?: string;
+  topSpacing?: boolean;
+}>`
   ${typography.sizeCSS.normal}
+  ${({ topSpacing }) => topSpacing && `padding-top: 24px;`};
+  color: ${({ textColor }) =>
+    textColor === "orange" ? palette.solid.orange : palette.solid.darkgrey};
 `;
 
 export const DisclaimerLink = styled.span`

--- a/publisher/src/components/DataViz/MetricsDataChart.styled.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.styled.tsx
@@ -18,17 +18,12 @@
 import {
   HEADER_BAR_HEIGHT,
   MIN_DESKTOP_WIDTH,
-  MIN_TABLET_WIDTH,
   palette,
   typography,
 } from "@justice-counts/common/components/GlobalStyles";
 import styled from "styled-components/macro";
 
 const INNER_PANEL_LEFT_CONTAINER_MAX_WIDTH = 314;
-const STICKY_HEADER_WITH_PADDING_HEIGHT = 48;
-const DROPDOWN_WITH_MARGIN_HEIGHT = 79;
-const FIXED_HEADER_WITH_DROPDOWN_HEIGHT = 92;
-const FIXED_HEADER_WITHOUT_DROPDOWN_HEIGHT = 24;
 
 export const NoEnabledMetricsMessage = styled.div`
   min-height: 100%;
@@ -59,13 +54,6 @@ export const MetricsViewPanel = styled.div<{
 
   @media only screen and (max-width: ${MIN_DESKTOP_WIDTH}px) {
     justify-content: unset;
-  }
-
-  @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
-    padding-top: ${({ hasSystemsDropdown }) =>
-      hasSystemsDropdown
-        ? `${FIXED_HEADER_WITH_DROPDOWN_HEIGHT + 24}px`
-        : `${FIXED_HEADER_WITHOUT_DROPDOWN_HEIGHT + 24}px`};
   }
 `;
 
@@ -216,7 +204,6 @@ export const CurrentMetricsSystem = styled.div<{
     text-transform: capitalize;
     padding-bottom: 12px;
     padding-top: 24px;
-    position: fixed;
     top: ${({ isSuperagency }) =>
       isSuperagency
         ? `${HEADER_BAR_HEIGHT + 76}px;`
@@ -247,6 +234,12 @@ export const MetricsViewDropdownContainerFixed = styled.div<{
   }
 `;
 
+export const MetricsViewDropdownContainer = styled(
+  MetricsViewDropdownContainerFixed
+)`
+  position: unset;
+`;
+
 export const MetricsViewDropdownLabel = styled.div`
   width: 100%;
   display: flex;
@@ -274,8 +267,7 @@ export const MobileDisclaimerContainer = styled(DisclaimerContainer)`
   height: auto;
   justify-content: flex-start;
   padding-bottom: 24px;
-  padding-top: ${STICKY_HEADER_WITH_PADDING_HEIGHT +
-  DROPDOWN_WITH_MARGIN_HEIGHT}px;
+  padding-top: 16px;
 `;
 
 export const PanelRightTopButtonsContainer = styled.div`

--- a/publisher/src/components/DataViz/MetricsDataChart.styled.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.styled.tsx
@@ -204,24 +204,31 @@ export const MobileDatapointsControls = styled.div`
   }
 `;
 
-export const CurrentMetricsSystem = styled.div`
+export const CurrentMetricsSystem = styled.div<{
+  isSuperagency?: boolean;
+}>`
   display: none;
 
   @media only screen and (max-width: ${MIN_DESKTOP_WIDTH}px) {
-    position: fixed;
-    top: ${HEADER_BAR_HEIGHT}px;
     display: block;
     width: calc(100% - 48px);
     ${typography.sizeCSS.medium};
     text-transform: capitalize;
     padding-bottom: 12px;
     padding-top: 24px;
+    position: fixed;
+    top: ${({ isSuperagency }) =>
+      isSuperagency
+        ? `${HEADER_BAR_HEIGHT + 76}px;`
+        : `${HEADER_BAR_HEIGHT}px`};
     z-index: 2;
     background-color: ${palette.solid.white};
   }
 `;
 
-export const MetricsViewDropdownContainerFixed = styled.div`
+export const MetricsViewDropdownContainerFixed = styled.div<{
+  isSuperagency?: boolean;
+}>`
   display: none;
   position: fixed;
   top: ${HEADER_BAR_HEIGHT + 24 + 36}px;
@@ -235,6 +242,8 @@ export const MetricsViewDropdownContainerFixed = styled.div`
 
   @media only screen and (max-width: ${MIN_DESKTOP_WIDTH}px) {
     display: flex;
+    ${({ isSuperagency }) =>
+      isSuperagency && `top: ${HEADER_BAR_HEIGHT + 135}px;`};
   }
 `;
 

--- a/publisher/src/components/DataViz/MetricsDataChart.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.tsx
@@ -279,9 +279,7 @@ export const MetricsDataChart: React.FC = observer(() => {
             <Styled.CurrentMetricsSystem isSuperagency={isSuperagency}>
               {formatSystemName(currentSystem)}
             </Styled.CurrentMetricsSystem>
-            <Styled.MetricsViewDropdownContainerFixed
-              isSuperagency={isSuperagency}
-            >
+            <Styled.MetricsViewDropdownContainer isSuperagency={isSuperagency}>
               <Dropdown
                 label={
                   <>
@@ -301,7 +299,7 @@ export const MetricsDataChart: React.FC = observer(() => {
                 caretPosition={agencyMetrics.length > 1 ? "left" : undefined}
                 fullWidth
               />
-            </Styled.MetricsViewDropdownContainerFixed>
+            </Styled.MetricsViewDropdownContainer>
             <Styled.MobileDisclaimerContainer>
               <Styled.DisclaimerTitle>Note</Styled.DisclaimerTitle>
               <Styled.DisclaimerText>

--- a/publisher/src/components/DataViz/MetricsDataChart.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.tsx
@@ -186,7 +186,7 @@ export const MetricsDataChart: React.FC = observer(() => {
   return (
     <Styled.MetricsViewContainer>
       {isSuperagency && (
-        <DisclaimerBanner fixed>
+        <DisclaimerBanner>
           If you would like to view data for the agencies you manage, please
           switch to specific agency you would like to view data for.
         </DisclaimerBanner>

--- a/publisher/src/components/DataViz/MetricsDataChart.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.tsx
@@ -42,6 +42,7 @@ import { formatSystemName } from "../../utils";
 import { ReactComponent as SwitchToChartIcon } from "../assets/switch-to-chart-icon.svg";
 import { ReactComponent as SwitchToDataTableIcon } from "../assets/switch-to-data-table-icon.svg";
 import { Loading } from "../Loading";
+import { DisclaimerBanner } from "../primitives";
 import { useSettingsSearchParams } from "../Settings";
 import ConnectedDatapointsView from "./ConnectedDatapointsView";
 import * as Styled from "./MetricsDataChart.styled";
@@ -184,6 +185,12 @@ export const MetricsDataChart: React.FC = observer(() => {
 
   return (
     <Styled.MetricsViewContainer>
+      {isSuperagency && (
+        <DisclaimerBanner fixed>
+          If you would like to view data for the agencies you manage, please
+          switch to specific agency you would like to view data for.
+        </DisclaimerBanner>
+      )}
       <Styled.MetricsViewPanel>
         {/* List Of Metrics */}
         <Styled.PanelContainerLeft>
@@ -269,10 +276,12 @@ export const MetricsDataChart: React.FC = observer(() => {
         {/* Data Visualization */}
         <Styled.PanelContainerRight>
           <Styled.MobileDatapointsControls>
-            <Styled.CurrentMetricsSystem>
+            <Styled.CurrentMetricsSystem isSuperagency={isSuperagency}>
               {formatSystemName(currentSystem)}
             </Styled.CurrentMetricsSystem>
-            <Styled.MetricsViewDropdownContainerFixed>
+            <Styled.MetricsViewDropdownContainerFixed
+              isSuperagency={isSuperagency}
+            >
               <Dropdown
                 label={
                   <>
@@ -310,12 +319,6 @@ export const MetricsDataChart: React.FC = observer(() => {
               </Styled.DisclaimerText>
             </Styled.MobileDisclaimerContainer>
           </Styled.MobileDatapointsControls>
-          {isSuperagency && (
-            <Styled.DisclaimerText textColor="orange" topSpacing>
-              If you would like to view data for the agencies you manage, please
-              switch to specific agency you would like to view data for.
-            </Styled.DisclaimerText>
-          )}
           <Styled.PanelRightTopButtonsContainer>
             {dataView === ChartView.Chart &&
               !!datapointsStore.datapointsByMetric[currentMetric.key] && (

--- a/publisher/src/components/DataViz/MetricsDataChart.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.tsx
@@ -310,7 +310,7 @@ export const MetricsDataChart: React.FC = observer(() => {
               </Styled.DisclaimerText>
             </Styled.MobileDisclaimerContainer>
           </Styled.MobileDatapointsControls>
-          {!isSuperagency && (
+          {isSuperagency && (
             <Styled.DisclaimerText textColor="orange" topSpacing>
               If you would like to view data for the agencies you manage, please
               switch to specific agency you would like to view data for.

--- a/publisher/src/components/DataViz/MetricsDataChart.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.tsx
@@ -78,6 +78,7 @@ export const MetricsDataChart: React.FC = observer(() => {
     currentMetric?.custom_frequency || currentMetric?.frequency;
   const systemBelongsToAgency =
     currentSystem && currentAgency?.systems.includes(currentSystem);
+  const isSuperagency = userStore.isAgencySuperagency(agencyId);
 
   const handleChartDownload = useCallback(
     async (system: string, metric: string) => {
@@ -188,6 +189,7 @@ export const MetricsDataChart: React.FC = observer(() => {
         <Styled.PanelContainerLeft>
           <Styled.SystemsContainer>
             {Object.entries(metricsBySystem).map(([system, metrics]) => {
+              if (isSuperagency && system !== "SUPERAGENCY") return;
               const currEnabledMetrics = metrics.filter(
                 (metric) => metric.enabled
               );
@@ -308,6 +310,12 @@ export const MetricsDataChart: React.FC = observer(() => {
               </Styled.DisclaimerText>
             </Styled.MobileDisclaimerContainer>
           </Styled.MobileDatapointsControls>
+          {!isSuperagency && (
+            <Styled.DisclaimerText textColor="orange" topSpacing>
+              If you would like to view data for the agencies you manage, please
+              switch to specific agency you would like to view data for.
+            </Styled.DisclaimerText>
+          )}
           <Styled.PanelRightTopButtonsContainer>
             {dataView === ChartView.Chart &&
               !!datapointsStore.datapointsByMetric[currentMetric.key] && (

--- a/publisher/src/components/primitives/index.tsx
+++ b/publisher/src/components/primitives/index.tsx
@@ -51,7 +51,7 @@ const NameContainer = styled.span`
 
 export const DisclaimerBanner = styled.div`
   ${typography.sizeCSS.normal}
-  width: 100;
+  width: 100%;
   height: 54px;
   background: ${palette.solid.blue};
   color: ${palette.solid.white};
@@ -64,7 +64,6 @@ export const DisclaimerBanner = styled.div`
   a:hover,
   a:visited {
     color: ${palette.solid.white};
-    display: block;
   }
 
   @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {

--- a/publisher/src/components/primitives/index.tsx
+++ b/publisher/src/components/primitives/index.tsx
@@ -69,7 +69,7 @@ export const DisclaimerBanner = styled.div`
   @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
     flex-direction: column;
     height: fit-content;
-    padding: 16px 0;
+    padding: 16px;
   }
 `;
 


### PR DESCRIPTION
## Description of the change

Update Explore Data to only show Superagency data for superagencies and add a message with instructions on how to view child agency data.

Before:
<img width="1728" alt="Screenshot 2023-08-18 at 6 35 08 PM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/a477c91a-4469-46cd-b9fc-be3dd89bdcae">

After:
<img width="1728" alt="Screenshot 2023-08-18 at 6 35 20 PM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/bb7c3061-c7cb-4404-9ae7-db460f10431f">

## Related issues

Closes #875, #876

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
