### PR TITLE
[#22950] [Agency Dashboard] breakdown chart updates

### DIFF
--- a/agency-dashboard/src/CategoryOverview/CategoryOverview.styled.tsx
+++ b/agency-dashboard/src/CategoryOverview/CategoryOverview.styled.tsx
@@ -36,7 +36,7 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   align-items: start;
-  gap: 50px;
+  gap: 32px;
   width: 100%;
   padding: 0 96px;
 `;
@@ -46,7 +46,7 @@ export const TopBlock = styled.div`
   flex-direction: column;
   align-items: start;
   width: ${MIN_METRIC_BOX_WIDTH}px;
-  padding-top: 40px;
+  padding-top: 16px;
 
   & > div > div {
     min-width: unset;
@@ -60,7 +60,7 @@ export const CategoryTitle = styled.div`
 
 export const CategoryDescription = styled.div`
   ${typography.sizeCSS.normal};
-  margin-bottom: 40px;
+  margin-bottom: 16px;
 `;
 
 export const TopBlockControls = styled.div`
@@ -98,7 +98,7 @@ export const MetricsFilters = styled.div`
 export const MetricsFilterButton = styled.div<{ active: boolean }>`
   ${typography.sizeCSS.normal};
   color: ${({ active }) =>
-    active ? palette.solid.blue : palette.solid.darkgrey};
+    active ? palette.solid.blue : palette.highlight.grey9};
   cursor: pointer;
 `;
 
@@ -117,10 +117,14 @@ export const MetricsWrapper = styled.div`
 export const MetricBox = styled.div`
   width: 50%;
   min-width: ${MIN_METRIC_BOX_WIDTH}px;
-  padding: 56px 96px 56px 0;
+  padding-top: 16px;
   display: flex;
   flex-direction: column;
   align-items: start;
+
+  &:not(:first-child) {
+    padding: 100px 96px 56px 0;
+  }
 
   @media only screen and (max-width: 1220px) {
     width: 100%;
@@ -137,15 +141,13 @@ export const MetricName = styled.div`
 
 export const MetricDescription = styled.div`
   ${typography.sizeCSS.normal};
-  margin-bottom: 40px;
+  margin-bottom: 24px;
 `;
 
 export const MetricDataVizContainer = styled.div`
   display: flex;
-  align-items: center;
   justify-content: space-around;
   flex-direction: row;
-  width: 90vw;
   height: 647px;
 
   .recharts-bar-rectangle {
@@ -153,9 +155,14 @@ export const MetricDataVizContainer = styled.div`
   }
 `;
 
+export const MetricDescriptionBarChartWrapper = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+`;
+
 export const BreakdownsTitle = styled.h3`
-  font-size: 18px;
-  line-height: 24px;
-  font-weight: 500;
+  ${typography.sizeCSS.medium};
   margin-left: 50px;
 `;

--- a/agency-dashboard/src/CategoryOverview/CategoryOverview.tsx
+++ b/agency-dashboard/src/CategoryOverview/CategoryOverview.tsx
@@ -160,6 +160,7 @@ export const CategoryOverview = observer(() => {
               labelColor="blue"
               noHover
               noSidePadding
+              size="medium"
             />
             <Styled.CategoryTitle>
               {categoryData[category].label}
@@ -195,20 +196,23 @@ export const CategoryOverview = observer(() => {
               {categoryMetrics.map((metric: Metric) => (
                 <Styled.MetricBox key={metric.key}>
                   <Styled.MetricName>{metric.display_name}</Styled.MetricName>
-                  <Styled.MetricDescription>
-                    {metric.description}
-                  </Styled.MetricDescription>
+
                   <Styled.MetricDataVizContainer>
-                    <MetricsCategoryBarChart
-                      width={620}
-                      data={getBarChartData(metric)}
-                      onHoverBar={(payload) => {
-                        setHoveredDate(payload.start_date);
-                      }}
-                      dimensionNames={[DataVizAggregateName]}
-                      metric={metric.display_name}
-                      ref={ref}
-                    />
+                    <Styled.MetricDescriptionBarChartWrapper>
+                      <Styled.MetricDescription>
+                        {metric.description}
+                      </Styled.MetricDescription>
+                      <MetricsCategoryBarChart
+                        width={620}
+                        data={getBarChartData(metric)}
+                        onHoverBar={(payload) => {
+                          setHoveredDate(payload.start_date);
+                        }}
+                        dimensionNames={[DataVizAggregateName]}
+                        metric={metric.display_name}
+                        ref={ref}
+                      />
+                    </Styled.MetricDescriptionBarChartWrapper>
                     <CategoryOverviewLineChart
                       data={getLineChartData(metric)}
                       isFundingOrExpenses={

--- a/agency-dashboard/src/CategoryOverview/CategoryOverview.tsx
+++ b/agency-dashboard/src/CategoryOverview/CategoryOverview.tsx
@@ -211,6 +211,10 @@ export const CategoryOverview = observer(() => {
                     />
                     <CategoryOverviewLineChart
                       data={getLineChartData(metric)}
+                      isFundingOrExpenses={
+                        metric.display_name === "Funding" ||
+                        metric.display_name === "Expenses"
+                      }
                       dimensions={getLineChartDimensions(metric)}
                       hoveredDate={hoveredDate}
                       setHoveredDate={setHoveredDate}

--- a/agency-dashboard/src/Header/HeaderBar.styles.tsx
+++ b/agency-dashboard/src/Header/HeaderBar.styles.tsx
@@ -77,7 +77,7 @@ export const LinksBlock = styled.div`
   flex-direction: row;
   justify-content: end;
   gap: 32px;
-  padding-right: 16px;
+  padding-right: 40px;
 `;
 
 export const Link = styled.a`

--- a/agency-dashboard/src/utils/formatting.ts
+++ b/agency-dashboard/src/utils/formatting.ts
@@ -30,7 +30,8 @@ export const getDatapointYear = (datapoint: Datapoint) => {
 
 export const renderPercentText = (
   val: number | string | null,
-  maxValue: number
+  maxValue: number,
+  isCurrency = false
 ) => {
   if (typeof val !== "number") {
     return "Not Recorded";
@@ -41,5 +42,7 @@ export const renderPercentText = (
   if (percentText === "0%" && val !== 0) {
     percentText = "<1%";
   }
-  return `${formatNumberInput(val.toString())} (${percentText})`;
+  return `${isCurrency ? "$" : ""}${formatNumberInput(
+    val.toString()
+  )} (${percentText})`;
 };

--- a/common/components/DataViz/CategoryOverviewBreakdown.styles.tsx
+++ b/common/components/DataViz/CategoryOverviewBreakdown.styles.tsx
@@ -24,7 +24,7 @@ export const Container = styled.ul`
   flex-direction: column;
   list-style-type: square;
   margin-top: 32px;
-  width: 520px;
+  width: 620px;
   margin-left: 40px;
 `;
 

--- a/common/components/DataViz/CategoryOverviewBreakdown.tsx
+++ b/common/components/DataViz/CategoryOverviewBreakdown.tsx
@@ -31,7 +31,7 @@ import React, { FunctionComponent } from "react";
 
 // eslint-disable-next-line no-restricted-imports
 import { Datapoint } from "../../types";
-import { printDateAsYear } from "../../utils";
+import { printDateAsShortMonthYear } from "../../utils";
 import { palette } from "../GlobalStyles";
 import {
   Container,
@@ -53,8 +53,14 @@ export const CategoryOverviewBreakdown: FunctionComponent<
   <Container>
     <LegendTitle>
       {hoveredDate
-        ? printDateAsYear(String(data.start_date?.value))
-        : `Recent (${printDateAsYear(String(data.start_date?.value))})`}
+        ? printDateAsShortMonthYear(
+            new Date(data.start_date?.value as string).getUTCMonth(),
+            new Date(data.start_date?.value as string).getUTCFullYear()
+          )
+        : `Recent (${printDateAsShortMonthYear(
+            new Date(data.start_date?.value as string).getUTCMonth(),
+            new Date(data.start_date?.value as string).getUTCFullYear()
+          )})`}
     </LegendTitle>
     {pipe(
       sort(

--- a/common/components/DataViz/CategoryOverviewBreakdown.tsx
+++ b/common/components/DataViz/CategoryOverviewBreakdown.tsx
@@ -54,11 +54,11 @@ export const CategoryOverviewBreakdown: FunctionComponent<
     <LegendTitle>
       {hoveredDate
         ? printDateAsShortMonthYear(
-            new Date(data.start_date?.value as string).getUTCMonth(),
+            new Date(data.start_date?.value as string).getUTCMonth() + 1,
             new Date(data.start_date?.value as string).getUTCFullYear()
           )
         : `Recent (${printDateAsShortMonthYear(
-            new Date(data.start_date?.value as string).getUTCMonth(),
+            new Date(data.start_date?.value as string).getUTCMonth() + 1,
             new Date(data.start_date?.value as string).getUTCFullYear()
           )})`}
     </LegendTitle>

--- a/common/components/DataViz/CategoryOverviewBreakdown.tsx
+++ b/common/components/DataViz/CategoryOverviewBreakdown.tsx
@@ -16,7 +16,17 @@
 // =============================================================================
 
 import { renderPercentText } from "@justice-counts/agency-dashboard/src/utils/formatting";
-import { filter, is, pipe, reduce, values } from "ramda";
+import {
+  Ord,
+  descend,
+  filter,
+  is,
+  map,
+  pipe,
+  reduce,
+  sort,
+  values,
+} from "ramda";
 import React, { FunctionComponent } from "react";
 
 // eslint-disable-next-line no-restricted-imports
@@ -39,38 +49,46 @@ import {
 
 export const CategoryOverviewBreakdown: FunctionComponent<
   LineChartBreakdownProps
-> = ({ data, dimensions, hoveredDate }) => (
+> = ({ data, isFundingOrExpenses, dimensions, hoveredDate }) => (
   <Container>
     <LegendTitle>
       {hoveredDate
         ? printDateAsYear(String(data.start_date?.value))
         : `Recent (${printDateAsYear(String(data.start_date?.value))})`}
     </LegendTitle>
-    {dimensions.map((dimension) => (
-      <LegendItem>
-        <LegendBullet color={data[dimension]?.fill}>▪</LegendBullet>
-        <LegendName color={palette.solid.black}>{dimension}</LegendName>
-        <LegendValue>
-          {renderPercentText(
-            data[dimension]?.value,
-            pipe(
-              values as unknown as (
-                obj: Record<keyof Datapoint, LineChartBreakdownValue>
-              ) => LineChartBreakdownValue,
-              filter(({ value }: LineChartBreakdownValue) =>
-                is(Number, value)
-              ) as (
-                pred: LineChartBreakdownValue
-              ) => LineChartBreakdownNumericValue[],
-              reduce<LineChartBreakdownNumericValue, number>(
-                (acc: number, { value }: LineChartBreakdownNumericValue) =>
-                  acc + value,
-                0
-              )
-            )(data) as number
-          )}
-        </LegendValue>
-      </LegendItem>
-    ))}
+    {pipe(
+      sort(
+        descend(
+          (dimension: keyof Datapoint) => Number(data[dimension]?.value) as Ord
+        )
+      ),
+      map((dimension: keyof Datapoint) => (
+        <LegendItem>
+          <LegendBullet color={data[dimension]?.fill}>▪</LegendBullet>
+          <LegendName color={palette.solid.black}>{dimension}</LegendName>
+          <LegendValue>
+            {renderPercentText(
+              data[dimension]?.value,
+              pipe(
+                values as unknown as (
+                  obj: Record<keyof Datapoint, LineChartBreakdownValue>
+                ) => LineChartBreakdownValue,
+                filter(({ value }: LineChartBreakdownValue) =>
+                  is(Number, value)
+                ) as (
+                  pred: LineChartBreakdownValue
+                ) => LineChartBreakdownNumericValue[],
+                reduce<LineChartBreakdownNumericValue, number>(
+                  (acc: number, { value }: LineChartBreakdownNumericValue) =>
+                    acc + value,
+                  0
+                )
+              )(data) as number,
+              isFundingOrExpenses
+            )}
+          </LegendValue>
+        </LegendItem>
+      ))
+    )(dimensions)}
   </Container>
 );

--- a/common/components/DataViz/CategoryOverviewBreakdown.tsx
+++ b/common/components/DataViz/CategoryOverviewBreakdown.tsx
@@ -17,11 +17,11 @@
 
 import { renderPercentText } from "@justice-counts/agency-dashboard/src/utils/formatting";
 import {
-  Ord,
   descend,
   filter,
   is,
   map,
+  Ord,
   pipe,
   reduce,
   sort,

--- a/common/components/DataViz/CategoryOverviewLineChart.tsx
+++ b/common/components/DataViz/CategoryOverviewLineChart.tsx
@@ -19,7 +19,7 @@ import {
   BreakdownsTitle,
   Container,
 } from "@justice-counts/agency-dashboard/src/CategoryOverview/CategoryOverview.styled";
-import { invertObj, map, mapObjIndexed, pipe, reverse, tail } from "ramda";
+import { invertObj, map, mapObjIndexed, pipe } from "ramda";
 import React, { CSSProperties, useMemo } from "react";
 import {
   CartesianGrid,
@@ -38,6 +38,7 @@ import { printDateAsShortMonthYear } from "../../utils";
 import { formatNumberForChart } from "../../utils/helperUtils";
 import { palette } from "../GlobalStyles";
 import { CategoryOverviewBreakdown } from "./CategoryOverviewBreakdown";
+import { trimArrayEnds } from "./utils";
 
 export type LineChartProps = {
   data: Datapoint[];
@@ -147,10 +148,7 @@ export function CategoryOverviewLineChart({
         <CartesianGrid horizontal={false} />
         <ReferenceLine y={referenceLineHeight} />
         {pipe(
-          tail,
-          reverse<Datapoint>,
-          tail,
-          reverse<Datapoint>,
+          trimArrayEnds<Datapoint>,
           map(
             (datapoint: Datapoint): JSX.Element => (
               <ReferenceLine

--- a/common/components/DataViz/CategoryOverviewLineChart.tsx
+++ b/common/components/DataViz/CategoryOverviewLineChart.tsx
@@ -34,7 +34,7 @@ import {
 
 import { useLineChartLegend } from "../../hooks";
 import { Datapoint } from "../../types";
-import { printDateAsYear } from "../../utils";
+import { printDateAsMonthYear, printDateAsYear } from "../../utils";
 import { formatNumberForChart } from "../../utils/helperUtils";
 import { palette } from "../GlobalStyles";
 import { CategoryOverviewBreakdown } from "./CategoryOverviewBreakdown";
@@ -130,8 +130,14 @@ export function CategoryOverviewLineChart({
           style={axisTickStyle}
           tickLine
           ticks={[
-            printDateAsYear(data[0].start_date),
-            printDateAsYear(data[data.length - 1].start_date),
+            printDateAsMonthYear(
+              new Date(data[0].start_date).getUTCMonth(),
+              new Date(data[0].start_date).getUTCFullYear()
+            ),
+            printDateAsMonthYear(
+              new Date(data[data.length - 1].start_date).getUTCMonth(),
+              new Date(data[data.length - 1].start_date).getUTCFullYear()
+            ),
           ]}
           interval="preserveStartEnd"
         />

--- a/common/components/DataViz/CategoryOverviewLineChart.tsx
+++ b/common/components/DataViz/CategoryOverviewLineChart.tsx
@@ -41,6 +41,7 @@ import { CategoryOverviewBreakdown } from "./CategoryOverviewBreakdown";
 
 export type LineChartProps = {
   data: Datapoint[];
+  isFundingOrExpenses: boolean;
   dimensions: string[];
   hoveredDate: string | null;
   setHoveredDate: (date: string | null) => void;
@@ -48,6 +49,7 @@ export type LineChartProps = {
 
 export function CategoryOverviewLineChart({
   data,
+  isFundingOrExpenses,
   dimensions,
   hoveredDate,
   setHoveredDate,
@@ -64,7 +66,6 @@ export function CategoryOverviewLineChart({
       )(palette.dataViz),
     [dimensions]
   );
-
   const renderLines = () => {
     // each Recharts Bar component defines a category type in the stacked bar chart
     let lineDefinitions: JSX.Element[] = [];
@@ -152,6 +153,7 @@ export function CategoryOverviewLineChart({
             content={
               <CategoryOverviewBreakdown
                 data={legendData}
+                isFundingOrExpenses={isFundingOrExpenses}
                 dimensions={dimensions}
                 hoveredDate={hoveredDate}
               />

--- a/common/components/DataViz/CategoryOverviewLineChart.tsx
+++ b/common/components/DataViz/CategoryOverviewLineChart.tsx
@@ -34,7 +34,10 @@ import {
 
 import { useLineChartLegend } from "../../hooks";
 import { Datapoint } from "../../types";
-import { printDateAsShortMonthYear } from "../../utils";
+import {
+  convertShortDateToUTCDateString,
+  printDateAsShortMonthYear,
+} from "../../utils";
 import { formatNumberForChart } from "../../utils/helperUtils";
 import { palette } from "../GlobalStyles";
 import { CategoryOverviewBreakdown } from "./CategoryOverviewBreakdown";
@@ -135,15 +138,22 @@ export function CategoryOverviewLineChart({
     hoveredDate,
     colorDict
   );
+
   return (
     <Container>
       <BreakdownsTitle>Breakdowns</BreakdownsTitle>
       <LineChart
-        width={600}
-        height={500}
+        width={680}
+        height={550}
         data={data}
+        style={{ paddingLeft: 11 }}
         margin={{ top: 5, right: 30, left: 20, bottom: 5 }}
         onClick={() => setHoveredDate(null)}
+        onMouseMove={(e) => {
+          if (e.activeLabel) {
+            setHoveredDate(convertShortDateToUTCDateString(e.activeLabel));
+          }
+        }}
       >
         <CartesianGrid horizontal={false} />
         <ReferenceLine y={referenceLineHeight} />
@@ -153,10 +163,9 @@ export function CategoryOverviewLineChart({
             (datapoint: Datapoint): JSX.Element => (
               <ReferenceLine
                 x={printDateAsShortMonthYear(
-                  new Date(datapoint.start_date).getUTCMonth(),
+                  new Date(datapoint.start_date).getUTCMonth() + 1,
                   new Date(datapoint.start_date).getUTCFullYear()
                 )}
-                onMouseEnter={() => setHoveredDate(datapoint.start_date)}
               />
             )
           )
@@ -164,7 +173,7 @@ export function CategoryOverviewLineChart({
         <XAxis
           dataKey={(datapoint) =>
             printDateAsShortMonthYear(
-              new Date(datapoint.start_date).getUTCMonth(),
+              new Date(datapoint.start_date).getUTCMonth() + 1,
               new Date(datapoint.start_date).getUTCFullYear()
             )
           }

--- a/common/components/DataViz/CategoryOverviewLineChart.tsx
+++ b/common/components/DataViz/CategoryOverviewLineChart.tsx
@@ -50,7 +50,6 @@ export type LineChartProps = {
 export type CustomXAxisTickProps = {
   x?: number;
   y?: number;
-  stroke?: string;
   length: number;
   payload?: {
     coordinate: number;
@@ -77,7 +76,7 @@ const CustomizedAxisTick = ({
   payload,
   length,
 }: CustomXAxisTickProps) => {
-  return payload.index === length - 1 || payload.index === 0 ? (
+  return payload?.index === length - 1 || payload?.index === 0 ? (
     <g transform={`translate(${x},${y})`}>
       <text
         style={axisTickStyle}
@@ -86,7 +85,7 @@ const CustomizedAxisTick = ({
         dy={16}
         textAnchor="end"
         fill="#666"
-        transform={"translate(25, 0)"}
+        transform="translate(25, 0)"
       >
         {payload.value}
       </text>

--- a/common/components/DataViz/CategoryOverviewLineChart.tsx
+++ b/common/components/DataViz/CategoryOverviewLineChart.tsx
@@ -34,7 +34,7 @@ import {
 
 import { useLineChartLegend } from "../../hooks";
 import { Datapoint } from "../../types";
-import { printDateAsMonthYear, printDateAsYear } from "../../utils";
+import { printDateAsShortMonthYear } from "../../utils";
 import { formatNumberForChart } from "../../utils/helperUtils";
 import { palette } from "../GlobalStyles";
 import { CategoryOverviewBreakdown } from "./CategoryOverviewBreakdown";
@@ -45,6 +45,53 @@ export type LineChartProps = {
   dimensions: string[];
   hoveredDate: string | null;
   setHoveredDate: (date: string | null) => void;
+};
+
+export type CustomXAxisTickProps = {
+  x?: number;
+  y?: number;
+  stroke?: string;
+  length: number;
+  payload?: {
+    coordinate: number;
+    index: number;
+    isShow: boolean;
+    offset: number;
+    tickCoord: number;
+    value: string;
+  };
+};
+
+const axisTickStyle: CSSProperties = {
+  fontFamily: "Inter",
+  fontSize: 12,
+  fontWeight: 600,
+  letterSpacing: "0em",
+  textAlign: "right",
+  fill: "rgba(0, 17, 51, 0.5)",
+};
+
+const CustomizedAxisTick = ({
+  x,
+  y,
+  payload,
+  length,
+}: CustomXAxisTickProps) => {
+  return payload.index === length - 1 || payload.index === 0 ? (
+    <g transform={`translate(${x},${y})`}>
+      <text
+        style={axisTickStyle}
+        x={0}
+        y={0}
+        dy={16}
+        textAnchor="end"
+        fill="#666"
+        transform={"translate(25, 0)"}
+      >
+        {payload.value}
+      </text>
+    </g>
+  ) : null;
 };
 
 export function CategoryOverviewLineChart({
@@ -88,17 +135,6 @@ export function CategoryOverviewLineChart({
     hoveredDate,
     colorDict
   );
-  const axisTickStyle: CSSProperties = useMemo(
-    () => ({
-      fontFamily: "Inter",
-      fontSize: 12,
-      fontWeight: 600,
-      letterSpacing: "0em",
-      textAlign: "right",
-      fill: "rgba(0, 17, 51, 0.5)",
-    }),
-    []
-  );
   return (
     <Container>
       <BreakdownsTitle>Breakdowns</BreakdownsTitle>
@@ -119,26 +155,25 @@ export function CategoryOverviewLineChart({
           map(
             (datapoint: Datapoint): JSX.Element => (
               <ReferenceLine
-                x={printDateAsYear(datapoint.start_date)}
+                x={printDateAsShortMonthYear(
+                  new Date(datapoint.start_date).getUTCMonth(),
+                  new Date(datapoint.start_date).getUTCFullYear()
+                )}
                 onMouseEnter={() => setHoveredDate(datapoint.start_date)}
               />
             )
           )
         )(data)}
         <XAxis
-          dataKey={(datapoint) => printDateAsYear(datapoint.start_date)}
+          dataKey={(datapoint) =>
+            printDateAsShortMonthYear(
+              new Date(datapoint.start_date).getUTCMonth(),
+              new Date(datapoint.start_date).getUTCFullYear()
+            )
+          }
           style={axisTickStyle}
           tickLine
-          ticks={[
-            printDateAsMonthYear(
-              new Date(data[0].start_date).getUTCMonth(),
-              new Date(data[0].start_date).getUTCFullYear()
-            ),
-            printDateAsMonthYear(
-              new Date(data[data.length - 1].start_date).getUTCMonth(),
-              new Date(data[data.length - 1].start_date).getUTCFullYear()
-            ),
-          ]}
+          tick={<CustomizedAxisTick length={data.length} />}
           interval="preserveStartEnd"
         />
         <YAxis

--- a/common/components/DataViz/types.ts
+++ b/common/components/DataViz/types.ts
@@ -86,6 +86,7 @@ export type LineChartBreakdownNumericValue = {
 
 export type LineChartBreakdownProps = {
   data: Record<keyof Datapoint, LineChartBreakdownValue>;
+  isFundingOrExpenses: boolean;
   dimensions: string[];
   hoveredDate: string | null;
 };

--- a/common/components/DataViz/utils.ts
+++ b/common/components/DataViz/utils.ts
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import { mapValues, pickBy } from "lodash";
-import { pipe, prop, values } from "ramda";
+import { pipe, prop, reverse, tail, values } from "ramda";
 
 import {
   Datapoint,
@@ -466,3 +466,7 @@ export const generateDummyDataForChart = () => {
   }
   return dummyData;
 };
+
+// Removes first and last elements in the given array
+export const trimArrayEnds: <T>(arr: T[]) => T[] = <T>(arr: T[]) =>
+  pipe(tail, reverse<T>, tail, reverse<T>)(arr);

--- a/common/utils/dateUtils.ts
+++ b/common/utils/dateUtils.ts
@@ -154,6 +154,12 @@ export const printDateRangeFromMonthYear = (
   }`;
 };
 
+/**
+ * Converts a short date string to UTC date string
+ * @param shortDate string
+ * @returns UTC date string
+ * @example "Jan 2023" will become "Sun, 01 Jan 2023 00:00:00 GMT"
+ */
 export const convertShortDateToUTCDateString = (shortDate: string) => {
   const splitDate = shortDate.split(" ");
   const monthName = splitDate[0];
@@ -174,5 +180,6 @@ export const convertShortDateToUTCDateString = (shortDate: string) => {
   };
   const month = shortMonthMap[monthName];
 
+  console.log(shortDate, new Date(Date.UTC(year, month)).toUTCString());
   return new Date(Date.UTC(year, month)).toUTCString();
 };

--- a/common/utils/dateUtils.ts
+++ b/common/utils/dateUtils.ts
@@ -153,3 +153,26 @@ export const printDateRangeFromMonthYear = (
     month === 1 ? year : year + 1
   }`;
 };
+
+export const convertShortDateToUTCDateString = (shortDate: string) => {
+  const splitDate = shortDate.split(" ");
+  const monthName = splitDate[0];
+  const year = Number(splitDate[1]);
+  const shortMonthMap: Record<string, number> = {
+    Jan: 0,
+    Feb: 1,
+    Mar: 2,
+    Apr: 3,
+    May: 4,
+    Jun: 5,
+    Jul: 6,
+    Aug: 7,
+    Sep: 8,
+    Oct: 9,
+    Nov: 10,
+    Dec: 11,
+  };
+  const month = shortMonthMap[monthName];
+
+  return new Date(Date.UTC(year, month)).toUTCString();
+};

--- a/common/utils/dateUtils.ts
+++ b/common/utils/dateUtils.ts
@@ -180,6 +180,5 @@ export const convertShortDateToUTCDateString = (shortDate: string) => {
   };
   const month = shortMonthMap[monthName];
 
-  console.log(shortDate, new Date(Date.UTC(year, month)).toUTCString());
   return new Date(Date.UTC(year, month)).toUTCString();
 };


### PR DESCRIPTION
## Description of the change

- [x] Order of breakdown legend should be highest to lowest based on most recent observation (e.g. State Appropriations, Contract Beds, Grants, etc.)
- [x] Order of breakdown within the hover tooltip should be highest to lowest based on most recent observation (e.g. State Appropriations, Contract Beds, Grants, etc.)
- [x] Hover tooltip breakdown values should be comma-separated and have a dollar sign for funding and expenses
- [x] Tooltip for breakdown line chart has only year whereas tooltip for bar chart has start month/year - end month/year. Add the start month/year - end month/year to the tooltip on the breakdown line chart to match the tooltip for the bar chart.

## Type of change

Feature

## Test Plan

Navigate to https://alfonsotest---agency-dashboard-web-b47yvyxs3q-uc.a.run.app/agency/department-of-corrections/capacity-and-costs

Observe the breakdown values in order matching the magnitudes in the chart. 
Observe the updated formatting of values

## Related issues

Closes #22950

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
