### PR TITLE
[Bug] Fix issue where reports publish old values

### DIFF
--- a/publisher/src/components/Reports/DataEntryReview.tsx
+++ b/publisher/src/components/Reports/DataEntryReview.tsx
@@ -86,7 +86,6 @@ const DataEntryReview = () => {
 
   useEffect(() => {
     const initialize = async () => {
-      formStore.validatePreviouslySavedInputs(reportID);
       const reviewProps = await reportStore.getPublishReviewPropsFromDatapoints(
         [reportID],
         String(agencyId)


### PR DESCRIPTION
## Description of the change

**Issue:**
CSG noticed that when they update a value in the data entry form and go to publish, the previous value is what is actually saved and published.

**Resolution:**
Remove running the`formStore.validatePreviouslySavedInputs(reportID)` method in the DataEntryReview because this will load the FormStore with the previously saved inputs. This caused an issue because the FormStore which normally has the latest values, gets reset by this method (which I naively thought would be safe to use to get the metric validation when you go from Task Card -> DataEntryReview). 

Will work on a better solution and write up a task, but this should resolve the current issue at hand.

## Related issues

Closes #XXXX

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
