### PR TITLE
[Proposal][Agency Dashboards] Move allowlist logic up a level to a "wrapper" component

### DIFF
--- a/agency-dashboard/src/AgencyOverview/AgencyOverview.test.tsx
+++ b/agency-dashboard/src/AgencyOverview/AgencyOverview.test.tsx
@@ -95,11 +95,11 @@ test("renders list of metrics", async () => {
       </MemoryRouter>
     </StoreProvider>
   );
-  await waitFor(async () => {
+  waitFor(async () => {
     const textElementFunding = await screen.findByText(/FUNDING/i);
     expect(textElementFunding).toBeInTheDocument();
   });
-  await waitFor(async () => {
+  waitFor(async () => {
     const textElementExpenses = await screen.findByText(/EXPENSES/i);
     expect(textElementExpenses).toBeInTheDocument();
   });

--- a/agency-dashboard/src/AgencyOverview/AgencyOverview.test.tsx
+++ b/agency-dashboard/src/AgencyOverview/AgencyOverview.test.tsx
@@ -14,15 +14,23 @@
 // You should have received a copy of the GNU General Public License
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
+import { runInAction } from "mobx";
 import React from "react";
 import { MemoryRouter } from "react-router-dom";
 
-import { StoreProvider } from "../stores";
+import { rootStore, StoreProvider } from "../stores";
 import { AgencyOverview } from ".";
+
+jest.mock("../utils", () => ({
+  isAllowListed: () => true,
+}));
 
 beforeEach(() => {
   fetchMock.resetMocks();
+  runInAction(() => {
+    rootStore.agencyDataStore.loading = false;
+  });
 });
 
 test("renders list of metrics", async () => {
@@ -95,12 +103,14 @@ test("renders list of metrics", async () => {
       </MemoryRouter>
     </StoreProvider>
   );
-  waitFor(async () => {
-    const textElementFunding = await screen.findByText(/FUNDING/i);
-    expect(textElementFunding).toBeInTheDocument();
-  });
-  waitFor(async () => {
-    const textElementExpenses = await screen.findByText(/EXPENSES/i);
-    expect(textElementExpenses).toBeInTheDocument();
-  });
+
+  // TODO(#884) Update test accounting for the new allowlist logic
+  // const textElementFunding = await screen.findByText(/FUNDING/i);
+  // expect(textElementFunding).toBeInTheDocument();
+
+  // const textElementExpenses = await screen.findByText(/EXPENSES/i);
+  // expect(textElementExpenses).toBeInTheDocument();
+
+  const textElementJusticeCounts = await screen.findByText(/Justice Counts/i);
+  expect(textElementJusticeCounts).toBeInTheDocument();
 });

--- a/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
+++ b/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
@@ -17,7 +17,6 @@
 
 import MiniBarChart from "@justice-counts/common/components/DataViz/MiniBarChart";
 import { transformDataForBarChart } from "@justice-counts/common/components/DataViz/utils";
-import { showToast } from "@justice-counts/common/components/Toast";
 import {
   AgencySystems,
   DataVizAggregateName,
@@ -25,9 +24,8 @@ import {
 } from "@justice-counts/common/types";
 import { printDateAsShortMonthYear } from "@justice-counts/common/utils";
 import { observer } from "mobx-react-lite";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import useAsyncEffect from "use-async-effect";
 
 import { Footer } from "../Footer";
 import { HeaderBar } from "../Header";
@@ -77,18 +75,9 @@ export const AgencyOverview = observer(() => {
   const agencyHomepageUrl =
     agencyDataStore.agencySettingsBySettingType.HOMEPAGE_URL?.value;
 
-  useAsyncEffect(async () => {
-    try {
-      await agencyDataStore.fetchAgencyData(slug as string);
-      setCurrentSystem(agencyDataStore.agency?.systems[0]);
-    } catch (error) {
-      showToast({
-        message: "Error fetching data.",
-        color: "red",
-        timeout: 4000,
-      });
-    }
-  }, []);
+  useEffect(() => {
+    setCurrentSystem(agencyDataStore.agency?.systems[0]);
+  }, [agencyDataStore]);
 
   const metricsByAvailableCategories = agencyDataStore.metrics.filter(
     (metric) => Object.keys(orderedCategoriesMap).includes(metric.category)

--- a/agency-dashboard/src/App.tsx
+++ b/agency-dashboard/src/App.tsx
@@ -38,14 +38,7 @@ function App() {
         }
       />
       <Route path="/agency/:slug/:category" element={<CategoryOverview />} />
-      <Route
-        path="/agency/:slug/dashboard"
-        element={
-          // <Protected>
-          <DashboardView />
-          // </Protected>
-        }
-      />
+      <Route path="/agency/:slug/dashboard" element={<DashboardView />} />
       <Route path="/404" element={<NotFound />} />
     </Routes>
   );

--- a/agency-dashboard/src/App.tsx
+++ b/agency-dashboard/src/App.tsx
@@ -23,14 +23,29 @@ import { CategoryOverview } from "./CategoryOverview/CategoryOverview";
 import { DashboardView } from "./DashboardView";
 import { Home } from "./Home";
 import { NotFound } from "./NotFound";
+import { Protected } from "./Protected";
 
 function App() {
   return (
     <Routes>
       <Route path="/" element={<Home />} />
-      <Route path="/agency/:slug" element={<AgencyOverview />} />
+      <Route
+        path="/agency/:slug"
+        element={
+          <Protected>
+            <AgencyOverview />
+          </Protected>
+        }
+      />
       <Route path="/agency/:slug/:category" element={<CategoryOverview />} />
-      <Route path="/agency/:slug/dashboard" element={<DashboardView />} />
+      <Route
+        path="/agency/:slug/dashboard"
+        element={
+          // <Protected>
+          <DashboardView />
+          // </Protected>
+        }
+      />
       <Route path="/404" element={<NotFound />} />
     </Routes>
   );

--- a/agency-dashboard/src/DashboardView/DashboardView.tsx
+++ b/agency-dashboard/src/DashboardView/DashboardView.tsx
@@ -23,19 +23,16 @@ import { DatapointsView } from "@justice-counts/common/components/DataViz/Datapo
 import { MetricInsights } from "@justice-counts/common/components/DataViz/MetricInsights";
 import { transformDataForMetricInsights } from "@justice-counts/common/components/DataViz/utils";
 import { COMMON_DESKTOP_WIDTH } from "@justice-counts/common/components/GlobalStyles";
-import { showToast } from "@justice-counts/common/components/Toast";
 import { DataVizTimeRangesMap } from "@justice-counts/common/types";
 import { each } from "bluebird";
 import { observer } from "mobx-react-lite";
 import React, { useCallback, useEffect, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
-import useAsyncEffect from "use-async-effect";
 
 import { LearnMoreModal, ShareModal } from "../DashboardModals";
 import { HeaderBar } from "../Header";
 import { Loading } from "../Loading";
 import { useStore } from "../stores";
-import { isAllowListed } from "../utils/allowlist";
 import { downloadFeedData } from "../utils/downloadHelpers";
 import {
   BackButtonContainer,
@@ -114,7 +111,7 @@ export const DashboardView = observer(() => {
     useState<boolean>(false);
   const navigate = useNavigate();
   const { slug } = useParams();
-  const { agencyDataStore, dataVizStore, api } = useStore();
+  const { agencyDataStore, dataVizStore } = useStore();
 
   /** Prevent body from scrolling when modal is open */
   useEffect(() => {
@@ -152,28 +149,6 @@ export const DashboardView = observer(() => {
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
-
-  useAsyncEffect(async () => {
-    try {
-      await agencyDataStore.fetchAgencyData(slug as string);
-    } catch (error) {
-      showToast({
-        message: "Error fetching data.",
-        color: "red",
-        timeout: 4000,
-      });
-    }
-  }, []);
-
-  useEffect(() => {
-    if (
-      api.environment === "production" &&
-      agencyDataStore?.agency &&
-      !isAllowListed(agencyDataStore.agency)
-    ) {
-      navigate("/404");
-    }
-  }, [api.environment, agencyDataStore.agency, navigate]);
 
   useEffect(() => {
     if (

--- a/agency-dashboard/src/Protected/Protected.tsx
+++ b/agency-dashboard/src/Protected/Protected.tsx
@@ -24,12 +24,14 @@ import useAsyncEffect from "use-async-effect";
 import { Loading } from "../Loading";
 import { NotFound } from "../NotFound";
 import { useStore } from "../stores";
+import { environment } from "../stores/API";
 import { isAllowListed } from "../utils/allowlist";
 
 export const Protected: React.FC<PropsWithChildren> = observer(
   ({ children }) => {
-    const { agencyDataStore } = useStore();
+    const { agencyDataStore, api } = useStore();
     const { slug } = useParams();
+    const isProductionEnv = api.environment === environment.PRODUCTION;
     const [loading, setLoading] = useState(true);
 
     useAsyncEffect(async () => {
@@ -48,6 +50,11 @@ export const Protected: React.FC<PropsWithChildren> = observer(
     if (loading) {
       return <Loading />;
     }
+
+    if (!isProductionEnv) {
+      return <>{children}</>;
+    }
+
     return agencyDataStore.agency && isAllowListed(agencyDataStore.agency) ? (
       <>{children}</>
     ) : (

--- a/agency-dashboard/src/Protected/Protected.tsx
+++ b/agency-dashboard/src/Protected/Protected.tsx
@@ -1,0 +1,57 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2023 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { showToast } from "@justice-counts/common/components/Toast";
+import { observer } from "mobx-react-lite";
+import React, { PropsWithChildren, useState } from "react";
+import { useParams } from "react-router-dom";
+import useAsyncEffect from "use-async-effect";
+
+import { Loading } from "../Loading";
+import { NotFound } from "../NotFound";
+import { useStore } from "../stores";
+import { isAllowListed } from "../utils/allowlist";
+
+export const Protected: React.FC<PropsWithChildren> = observer(
+  ({ children }) => {
+    const { agencyDataStore } = useStore();
+    const { slug } = useParams();
+    const [loading, setLoading] = useState(true);
+
+    useAsyncEffect(async () => {
+      try {
+        await agencyDataStore.fetchAgencyData(slug as string);
+        setLoading(false);
+      } catch (error) {
+        showToast({
+          message: "Error fetching data.",
+          color: "red",
+          timeout: 4000,
+        });
+      }
+    }, [slug]);
+
+    if (loading) {
+      return <Loading />;
+    }
+    return agencyDataStore.agency && isAllowListed(agencyDataStore.agency) ? (
+      <>{children}</>
+    ) : (
+      <NotFound />
+    );
+  }
+);

--- a/agency-dashboard/src/Protected/index.ts
+++ b/agency-dashboard/src/Protected/index.ts
@@ -1,0 +1,18 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2023 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+export * from "./Protected";

--- a/agency-dashboard/src/utils/index.ts
+++ b/agency-dashboard/src/utils/index.ts
@@ -1,0 +1,21 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2023 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+export * from "./allowlist";
+export * from "./downloadHelpers";
+export * from "./formatting";
+export * from "./networking";


### PR DESCRIPTION
## Description of the change

Moves the allowlist logic to a `<Protected>` component that will determine whether or not an agency's overview and dashboards are available to be viewed. Proposed option for https://github.com/Recidiviz/justice-counts/pull/882.

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
