### PR TITLE
Remove "report" word from `common` repo

### DIFF
--- a/agency-dashboard/src/utils/formatting.ts
+++ b/agency-dashboard/src/utils/formatting.ts
@@ -33,7 +33,7 @@ export const renderPercentText = (
   maxValue: number
 ) => {
   if (typeof val !== "number") {
-    return "Not Reported";
+    return "Not Recorded";
   }
 
   let percentText = `${val !== 0 ? Math.round((val / maxValue) * 100) : 0}%`;

--- a/common/components/DataViz/BarChart.tsx
+++ b/common/components/DataViz/BarChart.tsx
@@ -56,7 +56,7 @@ const NoReportedData = styled.div`
   padding: 8px;
 
   &::after {
-    content: "No reported data for this metric.";
+    content: "No recorded data for this metric.";
   }
 `;
 

--- a/common/components/DataViz/MetricsCategoryBarChart.tsx
+++ b/common/components/DataViz/MetricsCategoryBarChart.tsx
@@ -41,7 +41,7 @@ const NoReportedData = styled.div`
   padding: 0 0 0 53px;
 
   &::after {
-    content: "No reported data for this metric.";
+    content: "No recorded data for this metric.";
   }
 `;
 

--- a/common/components/DataViz/Tooltip.tsx
+++ b/common/components/DataViz/Tooltip.tsx
@@ -74,7 +74,7 @@ const Tooltip: React.FC<TooltipProps> = ({
 
     const renderText = (val: string | number | null, maxValue: number) => {
       if (typeof val !== "number") {
-        return "Not Reported";
+        return "Not Recorded";
       }
 
       let percentText = `${
@@ -99,7 +99,7 @@ const Tooltip: React.FC<TooltipProps> = ({
       if (datapoint.dataVizMissingData !== 0) {
         return (
           <TooltipItemContainer>
-            <TooltipName>Not reported</TooltipName>
+            <TooltipName>Not Recorded</TooltipName>
           </TooltipItemContainer>
         );
       }


### PR DESCRIPTION
## Description of the change

Removes all instances of the word "reported". We don't export the `REPORT` constants from Publisher into the `common` repo. 

We could move it to the `common` repo and update all our imports in Publisher, but I think it's OK for now for us to manually write `record` in these few spots in `common` repo since the usage of the word has been pretty stable so far. Happy to work on this if anyone disagrees - just didn't seem worthwhile to do at the moment.

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
