### PR TITLE
[Agency Dashboard] Use same source of truth/calc for list of metrics between AgencyOverview and CategoryOverview

### DIFF
--- a/agency-dashboard/src/CategoryOverview/CategoryOverview.styled.tsx
+++ b/agency-dashboard/src/CategoryOverview/CategoryOverview.styled.tsx
@@ -118,12 +118,13 @@ export const MetricBox = styled.div`
   width: 50%;
   min-width: ${MIN_METRIC_BOX_WIDTH}px;
   padding-top: 16px;
+  padding-bottom: 100px;
   display: flex;
   flex-direction: column;
   align-items: start;
 
   &:not(:first-child) {
-    padding: 100px 96px 56px 0;
+    padding: 100px 96px 100px 0;
   }
 
   @media only screen and (max-width: 1220px) {

--- a/agency-dashboard/src/CategoryOverview/CategoryOverview.tsx
+++ b/agency-dashboard/src/CategoryOverview/CategoryOverview.tsx
@@ -146,7 +146,7 @@ export const CategoryOverview = observer(() => {
           <Styled.TopBlock>
             <Button
               label="<- Home"
-              onClick={() => navigate(-1)}
+              onClick={() => navigate("..", { relative: "path" })}
               labelColor="blue"
               noHover
               noSidePadding

--- a/agency-dashboard/src/Protected/Protected.tsx
+++ b/agency-dashboard/src/Protected/Protected.tsx
@@ -42,7 +42,7 @@ export const Protected: React.FC<PropsWithChildren> = observer(
       } catch (error) {
         navigate("/404");
         showToast({
-          message: `No agency found with slugline /${slug}.`,
+          message: `No agency found with path /${slug}.`,
           color: "red",
           timeout: 4000,
         });

--- a/agency-dashboard/src/Protected/Protected.tsx
+++ b/agency-dashboard/src/Protected/Protected.tsx
@@ -18,7 +18,7 @@
 import { showToast } from "@justice-counts/common/components/Toast";
 import { observer } from "mobx-react-lite";
 import React, { PropsWithChildren, useState } from "react";
-import { useParams } from "react-router-dom";
+import { useNavigate, useParams } from "react-router-dom";
 import useAsyncEffect from "use-async-effect";
 
 import { Loading } from "../Loading";
@@ -29,6 +29,7 @@ import { isAllowListed } from "../utils/allowlist";
 
 export const Protected: React.FC<PropsWithChildren> = observer(
   ({ children }) => {
+    const navigate = useNavigate();
     const { agencyDataStore, api } = useStore();
     const { slug } = useParams();
     const isProductionEnv = api.environment === environment.PRODUCTION;
@@ -39,8 +40,9 @@ export const Protected: React.FC<PropsWithChildren> = observer(
         await agencyDataStore.fetchAgencyData(slug as string);
         setLoading(false);
       } catch (error) {
+        navigate("/404");
         showToast({
-          message: "Error fetching data.",
+          message: `No agency found with slugline /${slug}.`,
           color: "red",
           timeout: 4000,
         });


### PR DESCRIPTION
## Description of the change

`AgencyOverview` used the following logic to render the list of metrics:
```
            const metricsByCategory =
              agencyDataStore.metricsByCategory[category] || [];
            const metricsByCategoryBySystem = metricsByCategory.filter(
              (metric) => metric.system.key === currentSystem
            );
            ...
            const metricsWithData = metricsByCategoryBySystem.filter(
              (metric) =>
                agencyDataStore.datapointsByMetric[metric.key].aggregate.filter(
                  (dp) => dp[DataVizAggregateName] !== null
                ).length > 0
            );
```

Whereas `CategoryOverview` used the following logic:
```
  const categoryMetrics = useMemo(
    () =>
      categoryData[category]?.key
        ? agencyDataStore.metricsByCategory?.[categoryData[category]?.key]
        : [],
    [agencyDataStore.metricsByCategory, category]
  );
```

This created situations where `AgencyOverview` and `CategoryOverview` were rendering a different set of metrics (not entirely different - one loaded 4 metrics and the other loaded 3 metrics). 

This is a temporary solution (duplicating the logic in AgencyOverview to CategoryOverview) - in a pending refactor, there will be one source of truth for the set of metrics to render.

https://github.com/Recidiviz/justice-counts/assets/59492998/bd8ece6b-dfc0-4ece-b49c-f8ff93afa704

## Related Issues
Ad-hoc, also Closes #897 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
