### PR TITLE
[Bug][Publisher] Fix Explore Data crash when agency has no enabled metrics

### DIFF
--- a/publisher/src/components/DataViz/MetricsDataChart.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.tsx
@@ -70,7 +70,7 @@ export const MetricsDataChart: React.FC = observer(() => {
   const currentSystem = systemSearchParam || currentAgency?.systems[0];
   const currentMetric = currentSystem
     ? metricsBySystem[currentSystem]?.find(
-        (m) => m.key === (metricSearchParam || enabledMetrics[0].key)
+        (m) => m.key === (metricSearchParam || enabledMetrics[0]?.key)
       ) || metricsBySystem[currentSystem]?.[0]
     : undefined;
   const metricName = currentMetric?.display_name || "";


### PR DESCRIPTION
## Description of the change

Issue:
If an agency has no enabled metrics and go to the Explore Data page, Publisher crashes because it is not properly handling the no-metrics case.

Solution:
Add a check to `enabledMetrics[0]` incase it is undefined before accessing the key.

[Huge thank you to Jessica for catching this bug!]

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
