### PR TITLE
[Test] Add FormStore test to cover buggy line addition in DataEntryReview

### DIFF
--- a/publisher/src/components/Reports/DataEntryForm.tsx
+++ b/publisher/src/components/Reports/DataEntryForm.tsx
@@ -335,6 +335,7 @@ const DataEntryForm: React.FC<{
                         key={metric.key}
                         id={metric.key}
                         ref={(e: HTMLDivElement) => metricsRef.current?.push(e)}
+                        data-testid="hello"
                       >
                         <MetricSectionTitleWrapper>
                           <MetricSectionTitle>

--- a/publisher/src/components/Reports/DataEntryForm.tsx
+++ b/publisher/src/components/Reports/DataEntryForm.tsx
@@ -335,7 +335,6 @@ const DataEntryForm: React.FC<{
                         key={metric.key}
                         id={metric.key}
                         ref={(e: HTMLDivElement) => metricsRef.current?.push(e)}
-                        data-testid="hello"
                       >
                         <MetricSectionTitleWrapper>
                           <MetricSectionTitle>

--- a/publisher/src/stores/FormStore.test.tsx
+++ b/publisher/src/stores/FormStore.test.tsx
@@ -194,40 +194,10 @@ test("updatedReportValues maps all updated (and not updated) input values into r
   );
 });
 
-test("Hmm", async () => {
+test("The form store has the same updated value between data entry form and data entry review and does not revert to previously saved values", async () => {
   runInAction(() => {
     reportStore.loadingReportData = false;
-    reportStore.getMultipleReportsWithDatapoints = jest.fn(
-      (reportIDs: number[], currentAgencyId: string) =>
-        Promise.resolve([
-          {
-            id: 0,
-            agency_id: mockAgencyID,
-            frequency: "ANNUAL",
-            metrics: [mockProsecutionMetric],
-            datapoints: [mockProsecutionDatapoint],
-            year: 2022,
-            month: 1,
-            last_modified_at: "April 12 2022",
-            last_modified_at_timestamp: null,
-            editors: [
-              { name: "Editor #1", role: AgencyTeamMemberRole.AGENCY_ADMIN },
-              { name: "Editor #2", role: AgencyTeamMemberRole.CONTRIBUTOR },
-            ],
-            status: "DRAFT",
-          },
-        ])
-    );
   });
-  /**
-   * Load the data entry form
-   * Change value
-   * Go to Publish Review
-   * Check that the value has not changed in the form store
-   * Publish
-   * Check that the value has not changed
-   */
-
   const { rerender } = render(
     <BrowserRouter>
       <StoreProvider>
@@ -250,23 +220,15 @@ test("Hmm", async () => {
     formStore.metricsValues[mockReportID]["PROSECUTION_STAFF"].value
   );
 
-  const reviewButtonNode = screen.getByText("Review");
-
-  fireEvent.click(reviewButtonNode);
-
-  // rerender(
-  //   <BrowserRouter>
-  //     <StoreProvider>
-  //       <DataEntryReview />
-  //     </StoreProvider>
-  //   </BrowserRouter>
-  // );
-
-  console.log(
-    "hi",
-    formStore.metricsValues[mockReportID]["PROSECUTION_STAFF"].value
+  render(
+    <BrowserRouter>
+      <StoreProvider>
+        <DataEntryReview />
+      </StoreProvider>
+    </BrowserRouter>
   );
-  await waitFor(() => screen.getByText("Review & Publish"));
-  await waitFor(() => screen.getAllByText("Staff"));
-  // const x = screen.getByText("Review & Publish");
+
+  expect(formStore.metricsValues[mockReportID]["PROSECUTION_STAFF"].value).toBe(
+    updatedValue
+  );
 });

--- a/publisher/src/stores/FormStore.test.tsx
+++ b/publisher/src/stores/FormStore.test.tsx
@@ -198,7 +198,7 @@ test("The form store has the same updated value between data entry form and data
   runInAction(() => {
     reportStore.loadingReportData = false;
   });
-  const { rerender } = render(
+  render(
     <BrowserRouter>
       <StoreProvider>
         <ReportDataEntry />

--- a/publisher/src/stores/FormStore.test.tsx
+++ b/publisher/src/stores/FormStore.test.tsx
@@ -15,20 +15,15 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import {
-  AgencyTeamMemberRole,
-  Datapoint,
-  Metric,
-} from "@justice-counts/common/types";
+import { AgencyTeamMemberRole, Metric } from "@justice-counts/common/types";
+import { fireEvent, render, screen } from "@testing-library/react";
 import { runInAction } from "mobx";
-
-import { StoreProvider, rootStore } from ".";
-import { BrowserRouter } from "react-router-dom";
-import DataEntryForm from "../components/Reports/DataEntryForm";
 import React from "react";
-import { screen, render, fireEvent, waitFor } from "@testing-library/react";
-import ReportDataEntry from "../components/Reports/ReportDataEntry";
+import { BrowserRouter } from "react-router-dom";
+
 import DataEntryReview from "../components/Reports/DataEntryReview";
+import ReportDataEntry from "../components/Reports/ReportDataEntry";
+import { rootStore, StoreProvider } from ".";
 
 jest.mock("react-router-dom", () => ({
   ...jest.requireActual("react-router-dom"),
@@ -91,22 +86,6 @@ const mockProsecutionMetric: Metric = {
       should_sum_to_total: false,
     },
   ],
-};
-const mockProsecutionDatapoint: Datapoint = {
-  agency_name: "Prosecution",
-  dimension_display_name: null,
-  disaggregation_display_name: null,
-  end_date: "Sun, 01 Jan 2023 00:00:00 GMT",
-  frequency: "ANNUAL",
-  id: 0,
-  // is_published: false,
-  dataVizMissingData: 0,
-  metric_definition_key: "PROSECUTION_TOTAL_STAFF",
-  metric_display_name: "Staff",
-  old_value: null,
-  report_id: 3854,
-  start_date: "Sat, 01 Jan 2022 00:00:00 GMT",
-  value: 1000,
 };
 
 beforeEach(() => {
@@ -217,7 +196,7 @@ test("The form store has the same updated value between data entry form and data
   expect(totalStaffInputNode).toBeInTheDocument();
   expect(totalStaffInputNode.value).toBe("123,777");
   expect(totalStaffInputNode.value.replace(",", "")).toBe(
-    formStore.metricsValues[mockReportID]["PROSECUTION_STAFF"].value
+    formStore.metricsValues[mockReportID].PROSECUTION_STAFF.value
   );
 
   render(
@@ -228,7 +207,7 @@ test("The form store has the same updated value between data entry form and data
     </BrowserRouter>
   );
 
-  expect(formStore.metricsValues[mockReportID]["PROSECUTION_STAFF"].value).toBe(
+  expect(formStore.metricsValues[mockReportID].PROSECUTION_STAFF.value).toBe(
     updatedValue
   );
 });

--- a/publisher/src/stores/FormStore.test.tsx
+++ b/publisher/src/stores/FormStore.test.tsx
@@ -185,18 +185,20 @@ test("The form store has the same updated value between data entry form and data
     </BrowserRouter>
   );
 
+  // Confirm existing Total Staff value is 1,000
   const totalStaffInputNode: HTMLInputElement =
     screen.getByLabelText("Total Staff");
-  const updatedValue = "123777";
-
+  expect(totalStaffInputNode).toBeInTheDocument();
   expect(totalStaffInputNode.value).toBe("1,000");
 
+  // Update Total Staff value to be 123,777
+  const updatedValue = "123,777";
   fireEvent.change(totalStaffInputNode, { target: { value: updatedValue } });
 
-  expect(totalStaffInputNode).toBeInTheDocument();
-  expect(totalStaffInputNode.value).toBe("123,777");
-  expect(totalStaffInputNode.value.replace(",", "")).toBe(
-    formStore.metricsValues[mockReportID].PROSECUTION_STAFF.value
+  // Check that the updated value is 123,777 and it matches the value in the FormStore
+  expect(totalStaffInputNode.value).toBe(updatedValue);
+  expect(formStore.metricsValues[mockReportID].PROSECUTION_STAFF.value).toBe(
+    updatedValue
   );
 
   render(
@@ -207,6 +209,8 @@ test("The form store has the same updated value between data entry form and data
     </BrowserRouter>
   );
 
+  // Check after rendering the DataEntryReview page that the updated value did not change
+  // in the FormStore and that the FormStore reflects the updated value
   expect(formStore.metricsValues[mockReportID].PROSECUTION_STAFF.value).toBe(
     updatedValue
   );


### PR DESCRIPTION
## Description of the change

As a follow up to the buggy line that was introduced that caused previously saved report values to overwrite recently updated values - this test should provide coverage to ensure that between the DataEntryForm and DataEntryReview components that the data in the FormStore (which is what ultimately gets sent to the BE to be saved) remains consistent. 

In the case where the bug was introduced, the values in the FormStore between DataEntryForm and DataEntryReview were different, and Publishing is what officially saved the values.

Test in action (without and with the buggy line):

https://github.com/Recidiviz/justice-counts/assets/59492998/c076b02c-ee62-4b6a-9454-97c663d84ced


## Related issues

Closes #895 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [x] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
