### PR TITLE
Fix metrics list validation in Publish Review page when coming from a publish task card in the Home page

### DIFF
--- a/publisher/src/components/Home/TaskCard.tsx
+++ b/publisher/src/components/Home/TaskCard.tsx
@@ -48,7 +48,7 @@ export const TaskCard: React.FC<{
       {actionLinks && (
         <Styled.TaskCardActionLinksWrapper>
           {actionLinks.map((action) => {
-            // Exclude "Upload Data" action link from Superagency data entry metric task cards
+            /** Exclude "Upload Data" action link from Superagency data entry metric task cards */
             if (
               isSuperagency &&
               action.label === taskCardLabelsActionLinks.uploadData.label
@@ -95,7 +95,7 @@ export const TaskCard: React.FC<{
                        * If there are no values loaded in the FormStore for metrics and breakdowns, then we can
                        * assume the user has not gone through the DataEntryForm and made updates, and is going directly
                        * from the Task Card to the Publish Review page. If that is the case, the previously saved values
-                       * will be the latest values - and we will neecd to load and validate them in the FormStore in order
+                       * will be the latest values - and we will need to load and validate them in the FormStore in order
                        * to render the validation checkmarks in the metrics list in the review page.
                        */
                       formStore.validatePreviouslySavedInputs(recordID);

--- a/publisher/src/components/Home/TaskCard.tsx
+++ b/publisher/src/components/Home/TaskCard.tsx
@@ -16,14 +16,14 @@
 // =============================================================================
 
 import { Tooltip } from "@justice-counts/common/components/Tooltip";
+import { observer } from "mobx-react-lite";
 import React from "react";
 import { useNavigate } from "react-router-dom";
 
+import { useStore } from "../../stores";
 import HomeStore from "../../stores/HomeStore";
 import { taskCardLabelsActionLinks, TaskCardMetadata } from ".";
 import * as Styled from "./Home.styled";
-import { useStore } from "../../stores";
-import { observer } from "mobx-react-lite";
 
 export const TaskCard: React.FC<{
   metadata: TaskCardMetadata;

--- a/publisher/src/components/Home/TaskCard.tsx
+++ b/publisher/src/components/Home/TaskCard.tsx
@@ -22,11 +22,14 @@ import { useNavigate } from "react-router-dom";
 import HomeStore from "../../stores/HomeStore";
 import { taskCardLabelsActionLinks, TaskCardMetadata } from ".";
 import * as Styled from "./Home.styled";
+import { useStore } from "../../stores";
+import { observer } from "mobx-react-lite";
 
 export const TaskCard: React.FC<{
   metadata: TaskCardMetadata;
   isSuperagency?: boolean;
-}> = ({ metadata, isSuperagency }) => {
+}> = observer(({ metadata, isSuperagency }) => {
+  const { formStore } = useStore();
   const navigate = useNavigate();
   const {
     key,
@@ -86,7 +89,17 @@ export const TaskCard: React.FC<{
                       }
                     );
                   }
-                  if (isPublishAction) {
+                  if (isPublishAction && recordID) {
+                    if (!formStore.hasFormStoreValuesLoaded(recordID)) {
+                      /**
+                       * If there are no values loaded in the FormStore for metrics and breakdowns, then we can
+                       * assume the user has not gone through the DataEntryForm and made updates, and is going directly
+                       * from the Task Card to the Publish Review page. If that is the case, the previously saved values
+                       * will be the latest values - and we will neecd to load and validate them in the FormStore in order
+                       * to render the validation checkmarks in the metrics list in the review page.
+                       */
+                      formStore.validatePreviouslySavedInputs(recordID);
+                    }
                     return navigate(
                       `./${action.path + recordID + reviewPagePath}`
                     );
@@ -110,4 +123,4 @@ export const TaskCard: React.FC<{
       )}
     </Styled.TaskCardContainer>
   );
-};
+});

--- a/publisher/src/stores/FormStore.ts
+++ b/publisher/src/stores/FormStore.ts
@@ -51,6 +51,10 @@ class FormStore {
     this.disaggregations = {};
   }
 
+  hasFormStoreValuesLoaded(recordID: number) {
+    return this.metricsValues[recordID] && this.disaggregations[recordID];
+  }
+
   validatePreviouslySavedInputs(reportID: number) {
     /** Runs validation of previously saved inputs on load */
     this.reportStore.reportMetrics[reportID].forEach((metric) => {


### PR DESCRIPTION
## Description of the change

Implements an alternative solution to validating metrics when going from a publish task card in the Home page directly to the Publish Review page. 

When a user goes to the `ReportDataEntry` > `DataEntryForm` component via opening a record, the previously saved values are loaded and validated in the FormStore so that they appear in the form, and thus, the review page will have validated values it can check to show the appropriate checkmark for each metric. 

Currently, if a user is going directly to the `DataEntryReview` page without having opened up the record in question, the FormStore will have no values loaded for that record - thus, the validation checkmark logic in the review page will have nothing to validate. 

This solution updates the logic in the publish task card and checks to see if the FormStore has loaded & validated values for the record:
* if so, no action needed - loading the review page should be no problem and the validation checkmarks will appear as usual
* if not, we can assume the user has not opened the report or made any changes and we can safely load, validate and reference the previously saved values in the review page

Demo (also sanity checks manual entry to review page is not buggy):

https://github.com/Recidiviz/justice-counts/assets/59492998/4332f978-74f9-4e16-baaa-b8ebc7fb2a5c

As an additional sanity check, I locally rebased this on top of the test added in #912 and tests passed.

## Related issues

Closes #896 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
