### PR TITLE
Add typeahead search in agency dropdown menu

### DIFF
--- a/common/components/Dropdown/Dropdown.styled.tsx
+++ b/common/components/Dropdown/Dropdown.styled.tsx
@@ -22,7 +22,7 @@ import {
   DropdownToggle,
 } from "@recidiviz/design-system";
 // eslint-disable-next-line no-restricted-imports
-import styled from "styled-components";
+import styled, { css } from "styled-components";
 
 import { palette, typography } from "../GlobalStyles";
 import { ToggleHover, ToggleSize } from "./types";
@@ -94,12 +94,7 @@ export const CustomDropdownMenu = styled(DropdownMenu)<{
     menuFullWidth ? "width: 100%;" : "min-width: 293px;"}
 `;
 
-export const CustomDropdownMenuItem = styled(DropdownMenuItem)<{
-  color?: "green" | "red";
-  disabled?: boolean;
-  highlight?: boolean;
-  noHover?: boolean;
-}>`
+const customDropdownMenuItemBaseCSS = css`
   margin: 0 !important;
   width: 100%;
   min-width: 100%;
@@ -111,6 +106,15 @@ export const CustomDropdownMenuItem = styled(DropdownMenuItem)<{
   border-radius: 3px;
   text-transform: capitalize;
   ${typography.sizeCSS.normal};
+`;
+
+export const CustomDropdownMenuItem = styled(DropdownMenuItem)<{
+  color?: "green" | "red";
+  disabled?: boolean;
+  highlight?: boolean;
+  noHover?: boolean;
+}>`
+  ${customDropdownMenuItemBaseCSS}
   color: ${({ color, highlight }) => {
     if (color === "green") {
       return palette.solid.green;
@@ -173,4 +177,32 @@ export const OptionLabelWrapper = styled.div<{
   gap: 16px;
   color: inherit !important;
   ${({ highlightIcon }) => highlightIcon && "padding-left: 8px;"}
+`;
+
+export const CustomInputWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding: 20px 16px 8px 16px;
+`;
+
+export const CustomInput = styled.input`
+  ${typography.sizeCSS.normal}
+  width: 100%;
+  padding: 4px 8px 4px 8px;
+  border: 1px solid ${palette.solid.lightgrey3};
+  color: ${palette.highlight.grey9};
+  background: ${palette.solid.lightgrey2};
+  border-radius: 2px;
+
+  &::placeholder {
+    color: ${palette.highlight.grey5};
+  }
+`;
+
+export const NoResultsFoundWrapper = styled.div`
+  ${customDropdownMenuItemBaseCSS}
+  color: ${palette.solid.darkgrey};
+  padding-left: 24px;
 `;

--- a/common/components/Dropdown/Dropdown.tsx
+++ b/common/components/Dropdown/Dropdown.tsx
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React from "react";
+import React, { useState } from "react";
 
 import dropdownCaret from "../../assets/dropdown-caret.svg";
 import * as Styled from "./Dropdown.styled";
@@ -29,7 +29,7 @@ import {
 
 type DropdownProps = {
   label: string | React.ReactNode;
-  options?: DropdownOption[];
+  options: DropdownOption[];
   size?: ToggleSize;
   disabled?: boolean;
   hover?: ToggleHover;
@@ -37,6 +37,7 @@ type DropdownProps = {
   alignment?: DropdownMenuAlignment;
   fullWidth?: boolean;
   highlightIcon?: React.ReactNode;
+  withTypeaheadSearch?: boolean;
 };
 
 /**
@@ -61,7 +62,19 @@ export function Dropdown({
   alignment,
   fullWidth,
   highlightIcon,
+  withTypeaheadSearch,
 }: DropdownProps) {
+  const [filteredOptions, setFilteredOptions] = useState(options);
+  const [inputValue, setInputValue] = useState("");
+  const optionsToRender =
+    withTypeaheadSearch && inputValue !== "" ? filteredOptions : options;
+  const handleFilteredOptions = (val: string) => {
+    const regex = new RegExp(`${val}`, `im`);
+    setFilteredOptions(() =>
+      options.filter((option) => regex.test(option.label as string))
+    );
+  };
+
   return (
     <Styled.CustomDropdown>
       <Styled.CustomDropdownToggle
@@ -92,41 +105,65 @@ export function Dropdown({
         alignment={alignment}
         menuFullWidth={fullWidth}
       >
-        {options && options.length > 1
-          ? options.map(
-              ({
-                key,
-                label: optionLabel,
-                onClick,
-                color,
-                disabled: optionDisabled,
-                highlight,
-                noHover,
-                icon,
-              }) => (
-                <Styled.CustomDropdownMenuItem
-                  key={key}
-                  onClick={onClick}
-                  color={color}
-                  disabled={optionDisabled}
-                  noHover={noHover}
-                  highlight={highlight && !highlightIcon}
+        <>
+          {withTypeaheadSearch && (
+            <Styled.CustomInputWrapper>
+              <Styled.CustomInput
+                id="dropdown-typeahead"
+                name="dropdown-typeahead"
+                type="text"
+                placeholder="Search for Agency"
+                value={inputValue}
+                onChange={(e) => {
+                  setInputValue(e.target.value);
+                  handleFilteredOptions(e.target.value);
+                }}
+              />
+            </Styled.CustomInputWrapper>
+          )}
+
+          {optionsToRender?.map(
+            ({
+              key,
+              label: optionLabel,
+              onClick,
+              color,
+              disabled: optionDisabled,
+              highlight,
+              noHover,
+              icon,
+            }) => (
+              <Styled.CustomDropdownMenuItem
+                key={key}
+                onClick={onClick}
+                color={color}
+                disabled={optionDisabled}
+                noHover={noHover}
+                highlight={highlight && !highlightIcon}
+              >
+                <Styled.OptionLabelWrapper
+                  highlightIcon={Boolean(highlightIcon)}
                 >
-                  <Styled.OptionLabelWrapper
-                    highlightIcon={Boolean(highlightIcon)}
-                  >
-                    {/**
-                     * icon: a label icon that's always visible in the dropdown menu
-                     * highlightIcon: an icon that indicates (and is only visible on) the menu option that is currently active
-                     */}
-                    {icon}
-                    {optionLabel}
-                    {highlight && highlightIcon}
-                  </Styled.OptionLabelWrapper>
-                </Styled.CustomDropdownMenuItem>
-              )
+                  {/**
+                   * icon: a label icon that's always visible in the dropdown menu
+                   * highlightIcon: an icon that indicates (and is only visible on) the menu option that is currently active
+                   */}
+                  {icon}
+                  {optionLabel}
+                  {highlight && highlightIcon}
+                </Styled.OptionLabelWrapper>
+              </Styled.CustomDropdownMenuItem>
             )
-          : undefined}
+          )}
+
+          {withTypeaheadSearch && filteredOptions.length === 0 && (
+            <Styled.NoResultsFoundWrapper>
+              <Styled.OptionLabelWrapper>
+                No Results Found
+              </Styled.OptionLabelWrapper>
+            </Styled.NoResultsFoundWrapper>
+          )}
+        </>
       </Styled.CustomDropdownMenu>
     </Styled.CustomDropdown>
   );

--- a/common/components/Dropdown/Dropdown.tsx
+++ b/common/components/Dropdown/Dropdown.tsx
@@ -37,7 +37,7 @@ type DropdownProps = {
   alignment?: DropdownMenuAlignment;
   fullWidth?: boolean;
   highlightIcon?: React.ReactNode;
-  withTypeaheadSearch?: boolean;
+  typeaheadSearch?: { placeholder: string };
 };
 
 /**
@@ -51,6 +51,8 @@ type DropdownProps = {
  * @param [Props.caretPosition] - left or right (if undefined caret is not displayed)
  * @param [Props.alignment] - alignment of the menu (right or left) if not provided then it is left by default
  * @param [Props.fullWidth] - defines if the menu width will be equal to dropdown toggle width (default is fit-content)
+ * @param [Props.highlightIcon] - icon used when an element is highlighted
+ * @param [Props.typeaheadSearch] - `true` when set, accepts custom placeholder string, and renders a typeahead search feature for the current list
  * */
 export function Dropdown({
   label,
@@ -62,7 +64,7 @@ export function Dropdown({
   alignment,
   fullWidth,
   highlightIcon,
-  withTypeaheadSearch,
+  typeaheadSearch,
 }: DropdownProps) {
   const [filteredOptions, setFilteredOptions] = useState(options);
   const [inputValue, setInputValue] = useState("");
@@ -116,14 +118,14 @@ export function Dropdown({
         menuFullWidth={fullWidth}
       >
         <>
-          {withTypeaheadSearch && (
+          {typeaheadSearch && (
             <Styled.CustomInputWrapper>
               <Styled.CustomInput
                 ref={inputRef}
                 id="dropdown-typeahead"
                 name="dropdown-typeahead"
                 type="search"
-                placeholder="Search for Agency"
+                placeholder={typeaheadSearch.placeholder}
                 value={inputValue}
                 onChange={(e) => {
                   setInputValue(e.target.value);
@@ -167,7 +169,7 @@ export function Dropdown({
             )
           )}
 
-          {withTypeaheadSearch && filteredOptions.length === 0 && (
+          {typeaheadSearch && filteredOptions.length === 0 && (
             <Styled.NoResultsFoundWrapper>
               <Styled.OptionLabelWrapper>
                 No Results Found

--- a/common/components/Dropdown/Dropdown.tsx
+++ b/common/components/Dropdown/Dropdown.tsx
@@ -52,7 +52,8 @@ type DropdownProps = {
  * @param [Props.alignment] - alignment of the menu (right or left) if not provided then it is left by default
  * @param [Props.fullWidth] - defines if the menu width will be equal to dropdown toggle width (default is fit-content)
  * @param [Props.highlightIcon] - icon used when an element is highlighted
- * @param [Props.typeaheadSearch] - `true` when set, accepts custom placeholder string, and renders a typeahead search feature for the current list
+ * @param [Props.typeaheadSearch] - { placeholder: string } - an object with customizable options - renders a typeahead search feature for
+ *                                                            the current list when set.
  * */
 export function Dropdown({
   label,

--- a/common/components/Dropdown/Dropdown.tsx
+++ b/common/components/Dropdown/Dropdown.tsx
@@ -71,11 +71,14 @@ export function Dropdown({
   const updateFilteredOptions = (val: string) => {
     const regex = new RegExp(`${val}`, `i`);
     setFilteredOptions(() =>
-      options.filter((option) => regex.test(option.label as string))
+      options.filter(
+        (option) => typeof option.label === "string" && regex.test(option.label)
+      )
     );
   };
 
   useEffect(() => {
+    /** Helps maintain focus on input element as the dropdown list re-renders */
     const timeout = setTimeout(() => inputRef.current?.focus(), 0);
     return () => clearTimeout(timeout);
   }, [inputValue]);

--- a/common/components/Dropdown/Dropdown.tsx
+++ b/common/components/Dropdown/Dropdown.tsx
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import React, { useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 
 import dropdownCaret from "../../assets/dropdown-caret.svg";
 import * as Styled from "./Dropdown.styled";
@@ -66,14 +66,19 @@ export function Dropdown({
 }: DropdownProps) {
   const [filteredOptions, setFilteredOptions] = useState(options);
   const [inputValue, setInputValue] = useState("");
-  const optionsToRender =
-    withTypeaheadSearch && inputValue !== "" ? filteredOptions : options;
-  const handleFilteredOptions = (val: string) => {
-    const regex = new RegExp(`${val}`, `im`);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const updateFilteredOptions = (val: string) => {
+    const regex = new RegExp(`${val}`, `i`);
     setFilteredOptions(() =>
       options.filter((option) => regex.test(option.label as string))
     );
   };
+
+  useEffect(() => {
+    const timeout = setTimeout(() => inputRef.current?.focus(), 0);
+    return () => clearTimeout(timeout);
+  }, [inputValue]);
 
   return (
     <Styled.CustomDropdown>
@@ -109,20 +114,21 @@ export function Dropdown({
           {withTypeaheadSearch && (
             <Styled.CustomInputWrapper>
               <Styled.CustomInput
+                ref={inputRef}
                 id="dropdown-typeahead"
                 name="dropdown-typeahead"
-                type="text"
+                type="search"
                 placeholder="Search for Agency"
                 value={inputValue}
                 onChange={(e) => {
                   setInputValue(e.target.value);
-                  handleFilteredOptions(e.target.value);
+                  updateFilteredOptions(e.target.value);
                 }}
               />
             </Styled.CustomInputWrapper>
           )}
 
-          {optionsToRender?.map(
+          {filteredOptions?.map(
             ({
               key,
               label: optionLabel,

--- a/common/components/Dropdown/Dropdown.tsx
+++ b/common/components/Dropdown/Dropdown.tsx
@@ -79,8 +79,10 @@ export function Dropdown({
 
   useEffect(() => {
     /** Helps maintain focus on input element as the dropdown list re-renders */
-    const timeout = setTimeout(() => inputRef.current?.focus(), 0);
-    return () => clearTimeout(timeout);
+    const timeout = setTimeout(() => {
+      inputRef.current?.focus();
+      clearTimeout(timeout);
+    }, 0);
   }, [inputValue]);
 
   return (

--- a/common/components/GlobalStyles/Palette.ts
+++ b/common/components/GlobalStyles/Palette.ts
@@ -28,6 +28,8 @@ export const palette = {
     grey2: `rgb(222, 222, 222)`, // solid color version of `highlight.grey3`
     darkgrey: `rgba(0, 17, 51, 1)`,
     lightgrey: `rgb(217, 219, 224)`,
+    lightgrey2: `rgba(248, 248, 248, 1)`,
+    lightgrey3: `rgba(220, 220, 220, 1)`,
     white: `rgba(255,255,255, 1)`,
     offwhite: `rgba(239, 244, 245, 1)`,
     black: `rgba(14, 17, 26, 1)`,

--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -180,7 +180,7 @@ const Menu: React.FC = () => {
                 alignment="left"
                 caretPosition="right"
                 highlightIcon={<Styled.TargetIcon />}
-                withTypeaheadSearch
+                typeaheadSearch={{ placeholder: "Search for Agency" }}
               />
             </Styled.MenuItem>
           </Styled.AgencyDropdownWrapper>

--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -180,6 +180,7 @@ const Menu: React.FC = () => {
                 alignment="left"
                 caretPosition="right"
                 highlightIcon={<Styled.TargetIcon />}
+                withTypeaheadSearch
               />
             </Styled.MenuItem>
           </Styled.AgencyDropdownWrapper>


### PR DESCRIPTION
## Description of the change

Adds a typeahead search input in the agency dropdown menu to help filter agency options.

https://github.com/Recidiviz/justice-counts/assets/59492998/17ec0d07-9d94-4afa-980b-538329526908

Playtesting Link: https://mahmoudtest---justice-counts-web-qqec6jbn6a-uc.a.run.app/agency/161/

## Related issues

Closes #877

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
