### PR TITLE
Data Viz: Change "Year-to-Year" text to "Percent Change"

### DIFF
--- a/common/components/DataViz/MetricInsights.tsx
+++ b/common/components/DataViz/MetricInsights.tsx
@@ -55,9 +55,10 @@ export const MetricInsights: React.FC<{
       selfWidth={insightsWidth}
       enableHideByWidth={enableHideByWidth}
     >
-      <MetricInsight title="Year-to-Year" value={percentChange} />
+      <MetricInsight title="Percent Change" value={percentChange} />
       <MetricInsight title="Avg. Total Value" value={avgValue} />
       <MetricInsight title="Most Recent" value={mostRecentValue} />
     </MetricInsightsContainer>
   );
 };
+``;

--- a/common/components/DataViz/MetricInsights.tsx
+++ b/common/components/DataViz/MetricInsights.tsx
@@ -55,7 +55,7 @@ export const MetricInsights: React.FC<{
       selfWidth={insightsWidth}
       enableHideByWidth={enableHideByWidth}
     >
-      <MetricInsight title="Year-to-Year" value={percentChange} />
+      <MetricInsight title="Percent Change" value={percentChange} />
       <MetricInsight title="Avg. Total Value" value={avgValue} />
       <MetricInsight title="Most Recent" value={mostRecentValue} />
     </MetricInsightsContainer>

--- a/common/components/DataViz/MetricInsights.tsx
+++ b/common/components/DataViz/MetricInsights.tsx
@@ -55,10 +55,9 @@ export const MetricInsights: React.FC<{
       selfWidth={insightsWidth}
       enableHideByWidth={enableHideByWidth}
     >
-      <MetricInsight title="Percent Change" value={percentChange} />
+      <MetricInsight title="Year-to-Year" value={percentChange} />
       <MetricInsight title="Avg. Total Value" value={avgValue} />
       <MetricInsight title="Most Recent" value={mostRecentValue} />
     </MetricInsightsContainer>
   );
 };
-``;


### PR DESCRIPTION
## Description of the change

Changes "Year-to-Year" text in the Data Viz charts to "Percent Change".

<img width="1728" alt="Screenshot 2023-09-06 at 10 00 02 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/fa4b2483-6dae-4395-a6db-b9461c08fa20">


## Related issues

Closes #920

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
