### PR TITLE
[Publisher] Enable CSV download from Explore Data table view

### DIFF
--- a/agency-dashboard/src/DashboardView/DashboardView.tsx
+++ b/agency-dashboard/src/DashboardView/DashboardView.tsx
@@ -33,7 +33,7 @@ import { LearnMoreModal, ShareModal } from "../DashboardModals";
 import { HeaderBar } from "../Header";
 import { Loading } from "../Loading";
 import { useStore } from "../stores";
-import { downloadFeedData } from "../utils/downloadHelpers";
+
 import {
   BackButtonContainer,
   Container,
@@ -49,6 +49,7 @@ import {
   RightPanelMetricOverviewContent,
   RightPanelMetricTitle,
 } from ".";
+import { downloadFeedData } from "@justice-counts/common/utils";
 
 const getScreenWidth = () =>
   window.innerWidth ||
@@ -227,10 +228,14 @@ export const DashboardView = observer(() => {
     ) {
       const metric = agencyDataStore.metricsByKey[metricKeyParam];
       if (metric) {
-        each(
-          metric.filenames,
-          downloadFeedData(metric.system.key, agencyDataStore.agency.id)
-        );
+        metric.filenames.forEach((filename) => {
+          if (agencyDataStore.agency)
+            downloadFeedData(
+              metric.system.key,
+              agencyDataStore.agency.id,
+              filename
+            );
+        });
       }
     }
   }, [agencyDataStore, metricKeyParam]);

--- a/agency-dashboard/src/DashboardView/DashboardView.tsx
+++ b/agency-dashboard/src/DashboardView/DashboardView.tsx
@@ -24,7 +24,7 @@ import { MetricInsights } from "@justice-counts/common/components/DataViz/Metric
 import { transformDataForMetricInsights } from "@justice-counts/common/components/DataViz/utils";
 import { COMMON_DESKTOP_WIDTH } from "@justice-counts/common/components/GlobalStyles";
 import { DataVizTimeRangesMap } from "@justice-counts/common/types";
-import { each } from "bluebird";
+import { downloadFeedData } from "@justice-counts/common/utils";
 import { observer } from "mobx-react-lite";
 import React, { useCallback, useEffect, useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
@@ -33,7 +33,6 @@ import { LearnMoreModal, ShareModal } from "../DashboardModals";
 import { HeaderBar } from "../Header";
 import { Loading } from "../Loading";
 import { useStore } from "../stores";
-
 import {
   BackButtonContainer,
   Container,
@@ -49,7 +48,6 @@ import {
   RightPanelMetricOverviewContent,
   RightPanelMetricTitle,
 } from ".";
-import { downloadFeedData } from "@justice-counts/common/utils";
 
 const getScreenWidth = () =>
   window.innerWidth ||

--- a/agency-dashboard/src/stores/AgencyDataStore.ts
+++ b/agency-dashboard/src/stores/AgencyDataStore.ts
@@ -30,6 +30,7 @@ import {
   UserAgency,
 } from "@justice-counts/common/types";
 import {
+  downloadFeedData,
   isPositiveNumber,
   printDateAsMonthYear,
   shortMonthsToNumbers,
@@ -38,7 +39,7 @@ import { makeAutoObservable, runInAction } from "mobx";
 
 import { VisibleCategoriesMetadata } from "../CategoryOverview/types";
 import { AgenciesList } from "../Home";
-import { downloadFeedData } from "../utils";
+
 import API from "./API";
 
 class AgencyDataStore {
@@ -255,7 +256,7 @@ class AgencyDataStore {
       if (metric && this.agency) {
         const agencyId = this.agency.id;
         metric.filenames.forEach((filename) =>
-          downloadFeedData(metric.system.key, agencyId)(filename)
+          downloadFeedData(metric.system.key, agencyId, filename)
         );
       }
     });

--- a/agency-dashboard/src/stores/AgencyDataStore.ts
+++ b/agency-dashboard/src/stores/AgencyDataStore.ts
@@ -39,7 +39,6 @@ import { makeAutoObservable, runInAction } from "mobx";
 
 import { VisibleCategoriesMetadata } from "../CategoryOverview/types";
 import { AgenciesList } from "../Home";
-
 import API from "./API";
 
 class AgencyDataStore {

--- a/agency-dashboard/src/utils/index.ts
+++ b/agency-dashboard/src/utils/index.ts
@@ -16,6 +16,5 @@
 // =============================================================================
 
 export * from "./denylist";
-export * from "./downloadHelpers";
 export * from "./formatting";
 export * from "./helpers";

--- a/agency-dashboard/tsconfig.json
+++ b/agency-dashboard/tsconfig.json
@@ -20,5 +20,7 @@
     "noEmit": true,
     "jsx": "react"
   },
-  "include": ["src"]
+  "include": [
+    "src"
+  ]
 }

--- a/agency-dashboard/tsconfig.json
+++ b/agency-dashboard/tsconfig.json
@@ -22,5 +22,5 @@
   },
   "include": [
     "src"
-  ]
+, "../common/utils/downloadHelpers.ts"  ]
 }

--- a/agency-dashboard/tsconfig.json
+++ b/agency-dashboard/tsconfig.json
@@ -20,7 +20,5 @@
     "noEmit": true,
     "jsx": "react"
   },
-  "include": [
-    "src"
-, "../common/utils/downloadHelpers.ts"  ]
+  "include": ["src"]
 }

--- a/common/utils/downloadHelpers.ts
+++ b/common/utils/downloadHelpers.ts
@@ -15,11 +15,27 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-export const downloadFeedData =
-  (system: string, agencyId: number) => async (filename: string) => {
-    const a = document.createElement("a");
-    a.href = `/feed/${agencyId}?system=${system}&metric=${filename}`;
-    a.setAttribute("download", `${filename}.csv`);
-    a.click();
-    a.remove();
-  };
+import { Metric } from "@justice-counts/common/types";
+
+export const downloadFeedData = async (
+  system: string,
+  agencyId: number | string,
+  filename: string
+) => {
+  const a = document.createElement("a");
+  a.href = `/feed/${agencyId}?system=${system}&metric=${filename}`;
+  a.setAttribute("download", `${filename}.csv`);
+  a.click();
+  a.remove();
+};
+
+export const downloadMetricData = (
+  metric: Metric,
+  agencyId: number | string
+) => {
+  if (metric) {
+    metric.filenames.forEach((fileName) => {
+      downloadFeedData(metric.system.key, agencyId, fileName);
+    });
+  }
+};

--- a/common/utils/index.ts
+++ b/common/utils/index.ts
@@ -17,4 +17,5 @@
 
 export * from "./conversionUtils";
 export * from "./dateUtils";
+export * from "./downloadHelpers";
 export * from "./helperUtils";

--- a/publisher/src/components/DataViz/MetricsDataChart.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.tsx
@@ -29,6 +29,7 @@ import {
 import { MIN_DESKTOP_WIDTH } from "@justice-counts/common/components/GlobalStyles";
 import { useWindowWidth } from "@justice-counts/common/hooks";
 import { AgencySystems, ReportFrequency } from "@justice-counts/common/types";
+import { downloadMetricData } from "@justice-counts/common/utils";
 import { frequencyString } from "@justice-counts/common/utils/helperUtils";
 import FileSaver from "file-saver";
 import { observer } from "mobx-react-lite";
@@ -348,7 +349,9 @@ export const MetricsDataChart: React.FC = observer(() => {
             </Styled.PanelRightTopButton>
             <Styled.PanelRightTopButton
               onClick={() =>
-                handleChartDownload(currentSystem, currentMetric.key)
+                dataView === ChartView.Chart
+                  ? handleChartDownload(currentSystem, currentMetric.key)
+                  : downloadMetricData(currentMetric, agencyId)
               }
             >
               <DownloadChartIcon />

--- a/publisher/src/setupProxy.js
+++ b/publisher/src/setupProxy.js
@@ -19,7 +19,7 @@ const { createProxyMiddleware } = require("http-proxy-middleware");
 
 module.exports = function (app) {
   app.use(
-    ["/auth", "/api", "/app_public_config.js"],
+    ["/auth", "/api", "/feed", "/app_public_config.js"],
     createProxyMiddleware({
       target: process.env.REACT_APP_PROXY_HOST,
       changeOrigin: true,


### PR DESCRIPTION
## Description of the change

Enables CSV download from Explore Data table view download button (which was only implemented in Agency Dashboards). Currently, the button does nothing in table view.


https://github.com/Recidiviz/justice-counts/assets/59492998/058fb138-536b-4fef-9cb4-16be31d84c78



## Related issues

Closes #923 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
