### PR TITLE
[Bug] Fix out-of-sync behavior in agency dropdown menu 

### DIFF
--- a/common/components/Dropdown/Dropdown.tsx
+++ b/common/components/Dropdown/Dropdown.tsx
@@ -82,7 +82,7 @@ export function Dropdown({
 
   useEffect(() => {
     setFilteredOptions(options);
-    if (inputValue) setInputValue("");
+    setInputValue("");
   }, [options]);
 
   useEffect(() => {

--- a/common/components/Dropdown/Dropdown.tsx
+++ b/common/components/Dropdown/Dropdown.tsx
@@ -82,6 +82,7 @@ export function Dropdown({
 
   useEffect(() => {
     setFilteredOptions(options);
+    if (inputValue) setInputValue("");
   }, [options]);
 
   useEffect(() => {

--- a/common/components/Dropdown/Dropdown.tsx
+++ b/common/components/Dropdown/Dropdown.tsx
@@ -67,7 +67,7 @@ export function Dropdown({
   highlightIcon,
   typeaheadSearch,
 }: DropdownProps) {
-  const [filteredOptions, setFilteredOptions] = useState(options);
+  const [filteredOptions, setFilteredOptions] = useState<DropdownOption[]>();
   const [inputValue, setInputValue] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
 
@@ -79,6 +79,10 @@ export function Dropdown({
       )
     );
   };
+
+  useEffect(() => {
+    setFilteredOptions(options);
+  }, [options]);
 
   useEffect(() => {
     /** Helps maintain focus on input element as the dropdown list re-renders */
@@ -170,7 +174,7 @@ export function Dropdown({
             )
           )}
 
-          {typeaheadSearch && filteredOptions.length === 0 && (
+          {typeaheadSearch && filteredOptions?.length === 0 && (
             <Styled.NoResultsFoundWrapper>
               <Styled.OptionLabelWrapper>
                 No Results Found


### PR DESCRIPTION
## Description of the change

Matt (CSG) surfaced an issue with the agency dropdown causing weird behavior with navigation as described below:

"If you log in and then select a new agency from the drop down in the upper left menu, then navigate to any of the menu items using the upper left menu dropdown, it returns you to the agency you originally logged in as, rather than the agency that you've selected"

There was another issue with the agency dropdown where if you select an agency, the highlight icon doesn't update (e.g. you're in Agency 1 when you first login, then switch to Agency 2 - the dropdown highlight icon is still on Agency 1). These two issues are surprisingly related - and all to do with us not having a fresh copy of the dropdown `options` from the parent `Menu` component.

I made an incorrect assumption by initializing the below `useState` with the `options` that's passed into the `Dropdown` component from the parent `Menu` component.

```
...

const [filteredOptions, setFilteredOptions] = useState<DropdownOption[]>(options);

...

  { filteredOptions.map(...
```

The issue with this is that it persists the original `options` between re-renders which is not what we want when the parent component updates the `options` array (which it does for example when you click on another agency - the `highlight` boolean gets updated in the list and a freshly updated `options` list is passed to the `Dropdown` component). 

Instead of initializing the `useState` with `options`, we can create a `useEffect` that will update the `filteredOptions` appropriately when we get a new list of `options`. 

```
...

const [filteredOptions, setFilteredOptions] = useState<DropdownOption[]>();

...
  useEffect(() => {
    setFilteredOptions(options);
    setInputValue("");
  }, [options]);
...

  { filteredOptions.map(...
```

This way, when a user clicks on an item in the menu, the `Dropdown` component will always have the latest `options` list that will have the up-to-date navigation paths and highlight boolean.

Demo (please feel free to sanity check): https://mahmoudtest---justice-counts-web-qqec6jbn6a-uc.a.run.app

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
