### PR TITLE
Superagency: Playtesting Followup - UI adjustment for monthly records for superagencies with no configured metrics and only default annual metrics

### DIFF
--- a/publisher/src/components/Forms/Form.styles.tsx
+++ b/publisher/src/components/Forms/Form.styles.tsx
@@ -58,6 +58,7 @@ export const PageWrapper = styled.div`
 
 export const FormWrapper = styled.div`
   flex: 0 1 ${DATA_ENTRY_WIDTH}px;
+  width: ${DATA_ENTRY_WIDTH}px;
   max-width: ${DATA_ENTRY_WIDTH}px;
   display: flex;
   flex-direction: column;

--- a/publisher/src/components/Reports/DataEntryForm.tsx
+++ b/publisher/src/components/Reports/DataEntryForm.tsx
@@ -389,7 +389,7 @@ const DataEntryForm: React.FC<{
             )}
             {isSuperagency && reportMetrics.length === 0 && (
               <DisabledMetricsInfoWrapper>
-                No metrics have been configured yet that match this record's
+                No metrics have been configured yet that match this {`record's`}
                 frequency. Please go to{" "}
                 <DisabledMetricsInfoLink
                   onClick={() => navigate(`/agency/${agencyId}/metric-config`)}

--- a/publisher/src/components/Reports/DataEntryForm.tsx
+++ b/publisher/src/components/Reports/DataEntryForm.tsx
@@ -86,6 +86,7 @@ const DataEntryForm: React.FC<{
   const metricsRef = useRef<HTMLDivElement[]>([]);
 
   const currentAgency = userStore.getAgency(agencyId);
+  const isSuperagency = userStore.isAgencySuperagency(agencyId);
   const isPublished =
     reportStore.reportOverviews[reportID].status === "PUBLISHED";
 
@@ -376,7 +377,7 @@ const DataEntryForm: React.FC<{
                             navigate(`/agency/${agencyId}/metric-config`)
                           }
                         >
-                          Metric Configuration
+                          Set Up Metrics
                         </DisabledMetricsInfoLink>{" "}
                         to re-enable{" "}
                         {disabledMetricsNames.length > 1 ? "them" : "it"}.
@@ -385,6 +386,18 @@ const DataEntryForm: React.FC<{
                   </Fragment>
                 );
               }
+            )}
+            {isSuperagency && reportMetrics.length === 0 && (
+              <DisabledMetricsInfoWrapper>
+                No metrics have been configured yet that match this record's
+                frequency. Please go to{" "}
+                <DisabledMetricsInfoLink
+                  onClick={() => navigate(`/agency/${agencyId}/metric-config`)}
+                >
+                  Set Up Metrics
+                </DisabledMetricsInfoLink>{" "}
+                to configure your metrics.
+              </DisabledMetricsInfoWrapper>
             )}
           </FormFieldSet>
         </Form>

--- a/publisher/src/components/Reports/DataEntryForm.tsx
+++ b/publisher/src/components/Reports/DataEntryForm.tsx
@@ -389,14 +389,15 @@ const DataEntryForm: React.FC<{
             )}
             {isSuperagency && reportMetrics.length === 0 && (
               <DisabledMetricsInfoWrapper>
-                No metrics have been configured yet that match this {`record's`}
-                frequency. Please go to{" "}
+                There are no metrics that match this {`record's`} frequency (
+                {reportOverview.frequency}). If you believe this is incorrect,
+                go to{" "}
                 <DisabledMetricsInfoLink
                   onClick={() => navigate(`/agency/${agencyId}/metric-config`)}
                 >
                   Set Up Metrics
                 </DisabledMetricsInfoLink>{" "}
-                to configure your metrics.
+                to adjust each {`metric's`} frequency.
               </DisabledMetricsInfoWrapper>
             )}
           </FormFieldSet>


### PR DESCRIPTION
## Description of the change

During playtesting, Michelle noticed something strange with the monthly records for superagencies that did not have their metrics configured. The record would display the following:

![image](https://github.com/Recidiviz/justice-counts/assets/59492998/fcd2b4fb-a404-4ced-98d9-a664265b7c4d)

The reason why this is happening is because all of the current superagency metrics have a default **ANNUAL** frequency and no metrics with a default **MONTHLY** frequency. So in a situation where the superagency has no metrics configured, opening up a monthly record will result in the above screenshot.

This change handles these cases by adding copy within monthly records that nudge the user to go to the Metric Settings page to configure their metrics.

<img width="1728" alt="Screenshot 2023-09-08 at 5 58 59 PM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/08ff9c62-184c-4efd-a3cb-e351964604fb">



## Related issues

Closes #928 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
