### PR TITLE
[Publisher] Correct REPORTING_PERIOD_CAPITALIZED constant to say "Recording Period" instead of "Reporting Period"

### DIFF
--- a/publisher/src/components/Global/constants.ts
+++ b/publisher/src/components/Global/constants.ts
@@ -22,7 +22,7 @@ export const REPORT_CAPITALIZED = "Record";
 export const REPORTS_CAPITALIZED = "Records";
 export const REPORTING_CAPITALIZED = "Data Sharing";
 export const REPORTED_CAPITALIZED = "Shared";
-export const REPORT_PERIOD_CAPITALIZED = "Reporting Period";
+export const REPORTING_PERIOD_CAPITALIZED = "Recording Period";
 
 export const REPORT_LOWERCASE = "record";
 export const REPORTS_LOWERCASE = "records";

--- a/publisher/src/pages/Reports.tsx
+++ b/publisher/src/pages/Reports.tsx
@@ -43,7 +43,7 @@ import { useNavigate, useParams } from "react-router-dom";
 
 import {
   REPORT_LOWERCASE,
-  REPORT_PERIOD_CAPITALIZED,
+  REPORTING_PERIOD_CAPITALIZED,
   REPORTS_CAPITALIZED,
   REPORTS_LOWERCASE,
 } from "../components/Global/constants";
@@ -97,7 +97,7 @@ const ReportStatusFilterOptionObject: { [key: string]: string } = {
 };
 
 const reportListColumnTitles = [
-  REPORT_PERIOD_CAPITALIZED,
+  REPORTING_PERIOD_CAPITALIZED,
   "Status",
   "Frequency",
   "Editors",


### PR DESCRIPTION
## Description of the change

Corrects `REPORTING_PERIOD_CAPITALIZED` constant to say "Recording Period" instead of "Reporting Period". [We totally missed this one in our reviews during the Records page refresh ~6 months ago]

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
