### PR TITLE
[Agency Dashboards] Remove agency from deny list

### DIFF
--- a/agency-dashboard/src/utils/denylist.ts
+++ b/agency-dashboard/src/utils/denylist.ts
@@ -421,7 +421,6 @@ export const DENY_LIST = new Set([
   "perry township police department (franklin)",
   "pickerington police department",
   "pierce township police department",
-  "platte county prosecutor's office",
   "polk county attorney's office",
   "polk county district court",
   "port william police department",


### PR DESCRIPTION
## Description of the change

Removes Agency #544 from deny list. [I missed this request when it was originally made]

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
