### PR TITLE
[Agency Dashboards][Bug] Intermittent crash when hovering on charts 

### DIFF
--- a/agency-dashboard/src/utils/formatting.ts
+++ b/agency-dashboard/src/utils/formatting.ts
@@ -29,7 +29,7 @@ export const getDatapointYear = (datapoint: Datapoint) => {
 };
 
 export const renderPercentText = (
-  val: number | string | null,
+  val: number | string | null | undefined,
   maxValue: number,
   isCurrency = false
 ) => {

--- a/common/components/DataViz/CategoryOverviewBreakdown.tsx
+++ b/common/components/DataViz/CategoryOverviewBreakdown.tsx
@@ -36,13 +36,16 @@ export const CategoryOverviewBreakdown: FunctionComponent<
   const { month, year } = splitUtcString(String(data.start_date));
   const displayDate = `${month} ${year}`;
   const totalDimensionValues = dimensions.reduce((acc, dim) => {
-    const sum = acc + Number(data[dim].value);
-    return sum;
+    if (data[dim]?.value) {
+      const sum = acc + Number(data[dim].value);
+      return sum;
+    }
+    return acc;
   }, 0);
   /** Dimensions sorted in descending order based on value */
   const sortedDimensions = dimensions.sort(
     (dimA: string, dimB: string) =>
-      Number(data[dimB].value) - Number(data[dimA].value)
+      Number(data[dimB]?.value) - Number(data[dimA]?.value)
   );
 
   return (

--- a/common/components/DataViz/types.ts
+++ b/common/components/DataViz/types.ts
@@ -75,7 +75,7 @@ export type ResponsiveBarData = Datapoint &
   };
 
 export type LineChartBreakdownValue = {
-  value: number | string;
+  value?: number | string | null;
   fill: string;
 };
 
@@ -93,5 +93,5 @@ export type LineChartBreakdownProps = {
 
 export type LegendData = Record<
   keyof Datapoint,
-  LineChartBreakdownNumericValue
+  LineChartBreakdownNumericValue | LineChartBreakdownValue
 >;

--- a/common/hooks/useLineChartLegend.ts
+++ b/common/hooks/useLineChartLegend.ts
@@ -40,9 +40,8 @@ export const useLineChartLegend = (
 
   const getLastDatapoint = (dps: Datapoint[]): Datapoint => dps[dps.length - 1];
 
-  const getHoveredDatapoint = (dps: Datapoint[]): Datapoint => {
-    return dps.filter((dp) => dp.start_date === hoveredDate)[0];
-  };
+  const getHoveredDatapoint = (dps: Datapoint[]): Datapoint =>
+    dps.filter((dp) => dp.start_date === hoveredDate)[0];
 
   const legendData = transformDataForLegend(
     hoveredDate ? getHoveredDatapoint(datapoints) : getLastDatapoint(datapoints)

--- a/common/hooks/useLineChartLegend.ts
+++ b/common/hooks/useLineChartLegend.ts
@@ -26,10 +26,12 @@ export const useLineChartLegend = (
 ) => {
   const transformDataForLegend = (datapoint: Datapoint): LegendData => {
     const dimensionsValueFill = dimensions.reduce((acc, dim) => {
-      acc[dim] = {
-        value: datapoint[dim] as number,
-        fill: dimensionsToColorMap[dim],
-      };
+      if (datapoint) {
+        acc[dim] = {
+          value: datapoint[dim],
+          fill: dimensionsToColorMap[dim],
+        };
+      }
       return acc;
     }, {} as LegendData);
 
@@ -38,8 +40,9 @@ export const useLineChartLegend = (
 
   const getLastDatapoint = (dps: Datapoint[]): Datapoint => dps[dps.length - 1];
 
-  const getHoveredDatapoint = (dps: Datapoint[]): Datapoint =>
-    dps.filter((dp) => dp.start_date === hoveredDate)[0];
+  const getHoveredDatapoint = (dps: Datapoint[]): Datapoint => {
+    return dps.filter((dp) => dp.start_date === hoveredDate)[0];
+  };
 
   const legendData = transformDataForLegend(
     hoveredDate ? getHoveredDatapoint(datapoints) : getLastDatapoint(datapoints)


### PR DESCRIPTION
## Description of the change

During a playtesting of Agency 496's dashboard in production, there were times when hovering over a chart crashed the app. This is not easy to reproduce since the charts re-render so often based on mouse movement, but there are times during the transition between Recent and All, where hovering back on a chart after switching the `datapoint` returned by `getHoveredDatapoint` comes back as `undefined`. This happens when there are no datapoints w/ a date that matches the `hoveredDate` - and this in turn causes a crash within the `transformDataForLegend` logic when we set the value for `dimensionsValueFill`. This at the very least handles the `undefined` cases (and hopefully prevents similar crashes).

I'm still trying to figure out why there's a brief mismatch sometimes and it's a bit of a challenge logging this because it's intermittent and the amount of natural re-renders that happen from moving your mouse over the charts spits out a ton of log info. I was able to see that before the crash, the `hoveredDate` that's causing issues is `Wed, 01 Jan 2020 00:00:00 GMT` in the Funding chart - normally, the `onHoverBar` logic in the charts doesn't pick up on hovers over bars that have no datapoints (the ones that show up in a faint red color w/ `Not Recorded` on the tooltip) - and this one shouldn't have triggered anything because there is no Jan 2020 record. But, for some reason when you switch from All to Recent and hover over the chart quickly (almost like you're doing it in the middle of the transition), it picks up on the `Wed, 01 Jan 2020 00:00:00 GMT` bar and that starts returning undefined throughout. I'm a bit stumped for now but will keep digging into this (time-boxing because I sank a few hours into it and am still coming up puzzled). My latest hunch so far is something funny going on with the `onHoverBar` logic, or something funny going on between hovering while the chart is transitioning (or both). Either way, I think the changes here are still important to handle the potential `undefined` cases.

Demo (env is set to prod):

https://github.com/Recidiviz/justice-counts/assets/59492998/3fa5e09b-c0bc-4c7e-9ab0-0345c0cbdb7c

Please feel free to sanity check by running locally and pointing to production in your env file.

## Related issues

Closes #944

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
