### PR TITLE
[Bug] Agency Dashboards: Handle undefined disaggregations when getting line chart data from metrics

### DIFF
--- a/common/hooks/useLineChart.ts
+++ b/common/hooks/useLineChart.ts
@@ -49,7 +49,9 @@ export const useLineChart = ({
        */
       const { disaggregations } = datapointsByMetric[metric.key];
       const disaggregationKey = Object.keys(disaggregations)[0];
-      return Object.values(disaggregations[disaggregationKey]);
+      return disaggregations[disaggregationKey]
+        ? Object.values(disaggregations[disaggregationKey])
+        : [];
     }
     return [];
   };


### PR DESCRIPTION
## Description of the change

Stephanie from CSG reported a crash happening in https://dashboard-staging.justice-counts.org/agency/supervision-[demo]/capacity-and-costs

It seems that the `disaggregations[disaggregationKey]` came up as undefined - I'm still investigating why, but this will handle that case and prevent the page from crashing.

Tested this locally running staging as the backend. I tested a couple of other agencies to make sure things were working OK.

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
