### PR TITLE
[Agency Dashboards] Playtesting Followup - Hide individual breakdowns that have no value in Line Chart legend instead of showing "Not Recorded"

### DIFF
--- a/agency-dashboard/src/CategoryOverview/CategoryOverview.tsx
+++ b/agency-dashboard/src/CategoryOverview/CategoryOverview.tsx
@@ -175,7 +175,7 @@ export const CategoryOverview = observer(() => {
                         dimensions={getLineChartDimensionsFromMetric(metric)}
                         hoveredDate={hoveredDate[metric.key]}
                         setHoveredDate={setHoveredDate}
-                        metricKey={metric.key}
+                        metric={metric}
                       />
                     )}
                   </Styled.MetricDataVizContainer>

--- a/common/components/DataViz/CategoryOverviewBreakdown.styles.tsx
+++ b/common/components/DataViz/CategoryOverviewBreakdown.styles.tsx
@@ -33,11 +33,11 @@ export const LegendTitle = styled.p`
   line-height: 22px;
 `;
 
-export const LegendItem = styled.li<{ hasNoValue?: boolean }>`
+export const LegendItem = styled.li<{ hidden?: boolean }>`
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
-  ${({ hasNoValue }) => hasNoValue && `visibility: hidden;`}
+  ${({ hidden }) => hidden && `visibility: hidden;`}
 `;
 
 export const LegendBullet = styled.span<{ color: string }>`

--- a/common/components/DataViz/CategoryOverviewBreakdown.styles.tsx
+++ b/common/components/DataViz/CategoryOverviewBreakdown.styles.tsx
@@ -33,10 +33,11 @@ export const LegendTitle = styled.p`
   line-height: 22px;
 `;
 
-export const LegendItem = styled.li`
+export const LegendItem = styled.li<{ hasNoValue?: boolean }>`
   display: flex;
   flex-direction: row;
   justify-content: flex-start;
+  ${({ hasNoValue }) => hasNoValue && `visibility: hidden;`}
 `;
 
 export const LegendBullet = styled.span<{ color: string }>`

--- a/common/components/DataViz/CategoryOverviewBreakdown.tsx
+++ b/common/components/DataViz/CategoryOverviewBreakdown.tsx
@@ -61,17 +61,20 @@ export const CategoryOverviewBreakdown: FunctionComponent<
         const isDisabled = data[dimension]?.enabled !== true;
 
         return (
-          <LegendItem key={dimension} hidden={isDisabled}>
-            <LegendBullet color={data[dimension]?.fill}>▪</LegendBullet>
-            <LegendName color={palette.solid.black}>{dimension}</LegendName>
-            <LegendValue>
-              {renderPercentText(
-                data[dimension]?.value,
-                totalDimensionValues,
-                isFundingOrExpenses
-              )}
-            </LegendValue>
-          </LegendItem>
+          <>
+            {/* Dimensions are only hidden from UI when they are disabled, otherwise they will visible and display their value or "Not Recorded" when there is no value */}
+            <LegendItem key={dimension} hidden={isDisabled}>
+              <LegendBullet color={data[dimension]?.fill}>▪</LegendBullet>
+              <LegendName color={palette.solid.black}>{dimension}</LegendName>
+              <LegendValue>
+                {renderPercentText(
+                  data[dimension]?.value,
+                  totalDimensionValues,
+                  isFundingOrExpenses
+                )}
+              </LegendValue>
+            </LegendItem>
+          </>
         );
       })}
     </Container>

--- a/common/components/DataViz/CategoryOverviewBreakdown.tsx
+++ b/common/components/DataViz/CategoryOverviewBreakdown.tsx
@@ -55,19 +55,23 @@ export const CategoryOverviewBreakdown: FunctionComponent<
           (hoveredDate ? displayDate : `Recent (${displayDate})`)}
       </LegendTitle>
 
-      {sortedDimensions.map((dimension) => (
-        <LegendItem key={dimension}>
-          <LegendBullet color={data[dimension]?.fill}>▪</LegendBullet>
-          <LegendName color={palette.solid.black}>{dimension}</LegendName>
-          <LegendValue>
-            {renderPercentText(
-              data[dimension]?.value,
-              totalDimensionValues,
-              isFundingOrExpenses
-            )}
-          </LegendValue>
-        </LegendItem>
-      ))}
+      {sortedDimensions.map((dimension) => {
+        const hasNoValue = typeof data[dimension]?.value !== "number";
+
+        return (
+          <LegendItem key={dimension} hasNoValue={hasNoValue}>
+            <LegendBullet color={data[dimension]?.fill}>▪</LegendBullet>
+            <LegendName color={palette.solid.black}>{dimension}</LegendName>
+            <LegendValue>
+              {renderPercentText(
+                data[dimension]?.value,
+                totalDimensionValues,
+                isFundingOrExpenses
+              )}
+            </LegendValue>
+          </LegendItem>
+        );
+      })}
     </Container>
   );
 };

--- a/common/components/DataViz/CategoryOverviewBreakdown.tsx
+++ b/common/components/DataViz/CategoryOverviewBreakdown.tsx
@@ -42,11 +42,13 @@ export const CategoryOverviewBreakdown: FunctionComponent<
     }
     return acc;
   }, 0);
-  /** Dimensions sorted in descending order based on value */
-  const sortedDimensions = dimensions.sort(
-    (dimA: string, dimB: string) =>
-      Number(data[dimB]?.value) - Number(data[dimA]?.value)
-  );
+  /** Dimensions sorted in descending order based on value, and enabled status (disabled dimensions go to bottom of list) */
+  const sortedDimensions = dimensions
+    .sort(
+      (dimA: string, dimB: string) =>
+        Number(data[dimB]?.value) - Number(data[dimA]?.value)
+    )
+    .sort((_: string, dimB: string) => (data[dimB]?.enabled ? 1 : -1));
 
   return (
     <Container>
@@ -56,10 +58,10 @@ export const CategoryOverviewBreakdown: FunctionComponent<
       </LegendTitle>
 
       {sortedDimensions.map((dimension) => {
-        const hasNoValue = typeof data[dimension]?.value !== "number";
+        const isDisabled = data[dimension]?.enabled !== true;
 
         return (
-          <LegendItem key={dimension} hasNoValue={hasNoValue}>
+          <LegendItem key={dimension} hidden={isDisabled}>
             <LegendBullet color={data[dimension]?.fill}>▪</LegendBullet>
             <LegendName color={palette.solid.black}>{dimension}</LegendName>
             <LegendValue>

--- a/common/components/DataViz/CategoryOverviewLineChart.tsx
+++ b/common/components/DataViz/CategoryOverviewLineChart.tsx
@@ -32,7 +32,7 @@ import {
 } from "recharts";
 
 import { useLineChartLegend } from "../../hooks";
-import { Datapoint } from "../../types";
+import { Datapoint, Metric } from "../../types";
 import { convertShortDateToUTCDateString } from "../../utils";
 import { formatNumberForChart } from "../../utils/helperUtils";
 import { palette } from "../GlobalStyles";
@@ -49,7 +49,7 @@ export type LineChartProps = {
       [key: string]: string;
     }>
   >;
-  metricKey: string;
+  metric: Metric;
 };
 
 export type CustomXAxisTickProps = {
@@ -104,7 +104,7 @@ export function CategoryOverviewLineChart({
   dimensions,
   hoveredDate,
   setHoveredDate,
-  metricKey,
+  metric,
 }: LineChartProps) {
   /** Creates a { [dimension]: colorFromDataVizPalette } map */
   const [dimensionsToColorMap] = useState<Record<string, string>>(() => {
@@ -118,6 +118,7 @@ export function CategoryOverviewLineChart({
     data,
     dimensions,
     hoveredDate,
+    metric,
     dimensionsToColorMap
   );
 
@@ -146,7 +147,7 @@ export function CategoryOverviewLineChart({
             const { activeLabel } = e;
             setHoveredDate((prev) => ({
               ...prev,
-              [metricKey]: convertShortDateToUTCDateString(activeLabel),
+              [metric.key]: convertShortDateToUTCDateString(activeLabel),
             }));
           }
         }}

--- a/common/components/DataViz/types.ts
+++ b/common/components/DataViz/types.ts
@@ -75,8 +75,9 @@ export type ResponsiveBarData = Datapoint &
   };
 
 export type LineChartBreakdownValue = {
-  value?: number | string | null;
   fill: string;
+  value?: number | string | null;
+  enabled?: boolean;
 };
 
 export type LineChartBreakdownNumericValue = {

--- a/common/hooks/useLineChartLegend.ts
+++ b/common/hooks/useLineChartLegend.ts
@@ -16,26 +16,35 @@
 // =============================================================================
 
 import { LegendData } from "../components/DataViz/types";
-import { Datapoint } from "../types";
+import { Datapoint, Metric } from "../types";
+import { groupBy } from "../utils";
 
 export const useLineChartLegend = (
   datapoints: Datapoint[],
   dimensions: string[],
   hoveredDate: string | null,
+  metric: Metric,
   dimensionsToColorMap: Record<string, string>
 ) => {
+  /** For now, only groups dimensions by label for the first disaggregation. We'll have to adjust this to handle multiple disaggregations. */
+  const dimensionsByLabel = groupBy(
+    metric.disaggregations[0].dimensions,
+    (dim) => dim.label
+  );
+
   const transformDataForLegend = (datapoint: Datapoint): LegendData => {
-    const dimensionsValueFill = dimensions.reduce((acc, dim) => {
+    const dimensionsValueFillEnabled = dimensions.reduce((acc, dim) => {
       if (datapoint) {
         acc[dim] = {
           value: datapoint[dim],
           fill: dimensionsToColorMap[dim],
+          enabled: dimensionsByLabel[dim][0].enabled,
         };
       }
       return acc;
     }, {} as LegendData);
 
-    return { ...datapoint, ...dimensionsValueFill } as LegendData;
+    return { ...datapoint, ...dimensionsValueFillEnabled } as LegendData;
   };
 
   const getLastDatapoint = (dps: Datapoint[]): Datapoint => dps[dps.length - 1];


### PR DESCRIPTION
## Description of the change

Hides individual breakdowns in the line chart legend instead of showing "Not Recorded".


https://github.com/Recidiviz/justice-counts/assets/59492998/ab9facab-b364-4058-b975-678a6cfaa7d1



## Related issues

Closes #963 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
