### PR TITLE
[Agency Dashboards] Playtesting Followup - Right align y-axis in bar chart

### DIFF
--- a/common/components/DataViz/BarChartComponents.tsx
+++ b/common/components/DataViz/BarChartComponents.tsx
@@ -31,7 +31,7 @@ export const CustomYAxisTick = (props: CustomYAxisTickProps) => {
   return (
     <g transform={`translate(${0},${y})`}>
       <text
-        x={rightAligned ? 60 : 0}
+        x={rightAligned ? 50 : 0}
         y={0}
         textAnchor={rightAligned ? "end" : "start"}
         fill={palette.solid.darkgrey}

--- a/common/components/DataViz/BarChartComponents.tsx
+++ b/common/components/DataViz/BarChartComponents.tsx
@@ -22,7 +22,7 @@ import { CustomYAxisTickProps } from "./types";
 import { abbreviateNumber } from "./utils";
 
 export const CustomYAxisTick = (props: CustomYAxisTickProps) => {
-  const { y, payload, percentageView, styles, metric } = props;
+  const { y, payload, percentageView, styles, metric, rightAligned } = props;
   const str = percentageView
     ? `${payload.value * 100}%`
     : abbreviateNumber(payload.value);
@@ -31,9 +31,9 @@ export const CustomYAxisTick = (props: CustomYAxisTickProps) => {
   return (
     <g transform={`translate(${0},${y})`}>
       <text
-        x={0}
+        x={rightAligned ? 60 : 0}
         y={0}
-        textAnchor="start"
+        textAnchor={rightAligned ? "end" : "start"}
         fill={palette.solid.darkgrey}
         style={styles}
       >

--- a/common/components/DataViz/BarChartComponents.tsx
+++ b/common/components/DataViz/BarChartComponents.tsx
@@ -31,7 +31,7 @@ export const CustomYAxisTick = (props: CustomYAxisTickProps) => {
   return (
     <g transform={`translate(${0},${y})`}>
       <text
-        x={rightAligned ? 50 : 0}
+        x={rightAligned ? 55 : 0}
         y={0}
         textAnchor={rightAligned ? "end" : "start"}
         fill={palette.solid.darkgrey}

--- a/common/components/DataViz/MetricsCategoryBarChart.tsx
+++ b/common/components/DataViz/MetricsCategoryBarChart.tsx
@@ -112,7 +112,7 @@ const MetricsCategoryBarChart = forwardRef<never, ResponsiveBarChartProps>(
             margin={{
               top: 20,
               right: 0,
-              left: 0,
+              left: 15,
               bottom: 16,
             }}
             ref={ref}

--- a/common/components/DataViz/MetricsCategoryBarChart.tsx
+++ b/common/components/DataViz/MetricsCategoryBarChart.tsx
@@ -150,6 +150,7 @@ const MetricsCategoryBarChart = forwardRef<never, ResponsiveBarChartProps>(
                     percentageView={false}
                     styles={tickStyle}
                     metric={metric}
+                    rightAligned
                   />
                 )}
                 tickLine={false}

--- a/common/components/DataViz/types.ts
+++ b/common/components/DataViz/types.ts
@@ -32,6 +32,7 @@ export interface CustomYAxisTickProps extends TickProps {
   percentageView: boolean;
   styles: React.CSSProperties;
   metric?: string;
+  rightAligned?: boolean;
 }
 
 export type ResponsiveBarChartProps = {


### PR DESCRIPTION
## Description of the change

Right-aligns the y-axis tick values in the bar chart.

Before:
<img width="728" alt="Screenshot 2023-09-26 at 10 47 59 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/b1bb0cf1-57c3-426a-bf61-0372d6a4cf15">


After:
<img width="728" alt="Screenshot 2023-09-26 at 10 46 44 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/07cf1c4d-0385-4f66-bc44-94b2de2cd893">


## Related issues

Contributes to #948 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
