### PR TITLE
[Agency Dashboards] Playtesting Followup - Add demo label under agency name and add agency name to category page

### DIFF
--- a/agency-dashboard/src/AgencyOverview/AgencyOverview.styles.tsx
+++ b/agency-dashboard/src/AgencyOverview/AgencyOverview.styles.tsx
@@ -44,6 +44,7 @@ export const AgencyOverviewHeader = styled.div`
   padding-bottom: 96px;
   border-bottom: 1px solid ${palette.highlight.grey3};
   margin-bottom: 24px;
+  position: relative;
 `;
 
 export const AgencyTitle = styled.div`
@@ -202,4 +203,15 @@ export const MetricBoxGraphRange = styled.div`
   flex-direction: row;
   justify-content: space-between;
   width: 100%;
+`;
+
+export const DemoLabel = styled.div`
+  ${typography.sizeCSS.medium};
+  width: fit-content;
+  position: absolute;
+  bottom: 0px;
+  color: ${palette.solid.white};
+  background: ${palette.solid.blue};
+  padding: 8px 16px;
+  margin-bottom: 28px;
 `;

--- a/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
+++ b/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
@@ -39,6 +39,7 @@ import {
   CategorizedMetricsContainer,
   CategoryDescription,
   CategoryTitle,
+  DemoLabel,
   MetricBox,
   MetricBoxContentContainer,
   MetricBoxGraphContainer,
@@ -101,6 +102,7 @@ export const AgencyOverview = observer(() => {
               </AgencyHomepage>
             )}
           </AgencyDescription>
+          <DemoLabel>Demo</DemoLabel>
         </AgencyOverviewHeader>
 
         {metricsByAvailableCategoriesWithData.length === 0 ? (

--- a/agency-dashboard/src/CategoryOverview/CategoryOverview.styled.tsx
+++ b/agency-dashboard/src/CategoryOverview/CategoryOverview.styled.tsx
@@ -45,12 +45,17 @@ export const TopBlock = styled.div`
   display: flex;
   flex-direction: column;
   align-items: start;
-  width: ${MIN_METRIC_BOX_WIDTH}px;
   padding-top: 16px;
 
   & > div > div {
     min-width: unset;
   }
+`;
+
+export const AgencyTitle = styled.div`
+  width: 70%;
+  ${typography.sizeCSS.headline};
+  margin-bottom: 50px;
 `;
 
 export const CategoryTitle = styled.div`
@@ -60,6 +65,7 @@ export const CategoryTitle = styled.div`
 
 export const CategoryDescription = styled.div`
   ${typography.sizeCSS.normal};
+  width: ${MIN_METRIC_BOX_WIDTH}px;
   margin-bottom: 16px;
 `;
 

--- a/agency-dashboard/src/CategoryOverview/CategoryOverview.styled.tsx
+++ b/agency-dashboard/src/CategoryOverview/CategoryOverview.styled.tsx
@@ -42,6 +42,7 @@ export const Container = styled.div`
 `;
 
 export const TopBlock = styled.div`
+  width: 100%;
   display: flex;
   flex-direction: column;
   align-items: start;
@@ -53,7 +54,7 @@ export const TopBlock = styled.div`
 `;
 
 export const AgencyTitle = styled.div`
-  width: 70%;
+  max-width: 70%;
   ${typography.sizeCSS.headline};
   margin-bottom: 50px;
 `;

--- a/agency-dashboard/src/CategoryOverview/CategoryOverview.tsx
+++ b/agency-dashboard/src/CategoryOverview/CategoryOverview.tsx
@@ -55,6 +55,7 @@ export const CategoryOverview = observer(() => {
   });
 
   const {
+    agencyName,
     datapointsByMetric,
     dimensionNamesByMetricAndDisaggregation,
     loading,
@@ -101,6 +102,7 @@ export const CategoryOverview = observer(() => {
               noSidePadding
               size="medium"
             />
+            <Styled.AgencyTitle>{agencyName}</Styled.AgencyTitle>
             <Styled.CategoryTitle>
               {visibleCategoriesMetadata[category]?.label}
             </Styled.CategoryTitle>


### PR DESCRIPTION
## Description of the change

Addresses the following playtesting follow-up items:
* Adds visible demo label under agency name in Agency Overview page
* Adds the agency title above the metric category title in the Category Overview page


https://github.com/Recidiviz/justice-counts/assets/59492998/94096d2e-e191-4fed-b570-c20869bf4d14



## Related issues

Closes #942 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
