### PR TITLE
[Agency Dashboards] Playtesting Followup - Filter out datapoints with no aggregate values when rendering the line chart 

### DIFF
--- a/common/components/DataViz/CategoryOverviewBreakdown.tsx
+++ b/common/components/DataViz/CategoryOverviewBreakdown.tsx
@@ -61,21 +61,19 @@ export const CategoryOverviewBreakdown: FunctionComponent<
       {sortedDimensions.map((dimension) => {
         const isDisabled = data[dimension]?.enabled !== true;
 
+        /* Dimensions are only hidden from UI when they are disabled, otherwise they will visible and display their value or "Not Recorded" when there is no value */
         return (
-          <>
-            {/* Dimensions are only hidden from UI when they are disabled, otherwise they will visible and display their value or "Not Recorded" when there is no value */}
-            <LegendItem key={dimension} hidden={isDisabled}>
-              <LegendBullet color={data[dimension]?.fill}>▪</LegendBullet>
-              <LegendName color={palette.solid.black}>{dimension}</LegendName>
-              <LegendValue>
-                {renderPercentText(
-                  data[dimension]?.value,
-                  totalDimensionValues,
-                  isFundingOrExpenses
-                )}
-              </LegendValue>
-            </LegendItem>
-          </>
+          <LegendItem key={dimension} hidden={isDisabled}>
+            <LegendBullet color={data[dimension]?.fill}>▪</LegendBullet>
+            <LegendName color={palette.solid.black}>{dimension}</LegendName>
+            <LegendValue>
+              {renderPercentText(
+                data[dimension]?.value,
+                totalDimensionValues,
+                isFundingOrExpenses
+              )}
+            </LegendValue>
+          </LegendItem>
         );
       })}
     </Container>

--- a/common/components/DataViz/CategoryOverviewLineChart.tsx
+++ b/common/components/DataViz/CategoryOverviewLineChart.tsx
@@ -131,7 +131,7 @@ export function CategoryOverviewLineChart({
 
     return dimensions.map((dimension) => (
       <Line
-        hide={!dimensionsByLabel[dimension]?.[0]?.enabled}
+        hide={!dimensionsByLabel[dimension]?.[0]?.enabled} // Don't show lines for disabled dimensions
         key={dimension}
         dataKey={dimension}
         stroke={dimensionsToColorMap[dimension]}

--- a/common/components/DataViz/CategoryOverviewLineChart.tsx
+++ b/common/components/DataViz/CategoryOverviewLineChart.tsx
@@ -34,7 +34,7 @@ import {
 import { useLineChartLegend } from "../../hooks";
 import { Datapoint, Metric } from "../../types";
 import { convertShortDateToUTCDateString } from "../../utils";
-import { formatNumberForChart } from "../../utils/helperUtils";
+import { formatNumberForChart, groupBy } from "../../utils/helperUtils";
 import { palette } from "../GlobalStyles";
 import { CategoryOverviewBreakdown } from "./CategoryOverviewBreakdown";
 import { splitUtcString } from "./utils";
@@ -124,8 +124,14 @@ export function CategoryOverviewLineChart({
   );
 
   const breakdownLines = useMemo(() => {
+    const dimensionsByLabel = groupBy(
+      metric.disaggregations[0].dimensions,
+      (dim) => dim.label
+    );
+
     return dimensions.map((dimension) => (
       <Line
+        hide={!dimensionsByLabel[dimension]?.[0]?.enabled}
         key={dimension}
         dataKey={dimension}
         stroke={dimensionsToColorMap[dimension]}
@@ -138,7 +144,7 @@ export function CategoryOverviewLineChart({
         }}
       />
     ));
-  }, [dimensions, dimensionsToColorMap]);
+  }, [metric, dimensions, dimensionsToColorMap]);
 
   return (
     <Container>

--- a/common/components/DataViz/CategoryOverviewLineChart.tsx
+++ b/common/components/DataViz/CategoryOverviewLineChart.tsx
@@ -124,23 +124,21 @@ export function CategoryOverviewLineChart({
   );
 
   const breakdownLines = useMemo(() => {
-    return dimensions
-      .filter((dimension) => legendData[dimension]?.enabled) // Filter out disabled dimensions
-      .map((dimension) => (
-        <Line
-          key={dimension}
-          dataKey={dimension}
-          stroke={dimensionsToColorMap[dimension]}
-          type="monotone"
-          dot={{ r: 4 }}
-          activeDot={{
-            stroke: dimensionsToColorMap[dimension],
-            strokeWidth: 2,
-            r: 4,
-          }}
-        />
-      ));
-  }, [dimensions, dimensionsToColorMap, legendData]);
+    return dimensions.map((dimension) => (
+      <Line
+        key={dimension}
+        dataKey={dimension}
+        stroke={dimensionsToColorMap[dimension]}
+        type="monotone"
+        dot={{ r: 4 }}
+        activeDot={{
+          stroke: dimensionsToColorMap[dimension],
+          strokeWidth: 2,
+          r: 4,
+        }}
+      />
+    ));
+  }, [dimensions, dimensionsToColorMap]);
 
   return (
     <Container>

--- a/common/hooks/useLineChart.ts
+++ b/common/hooks/useLineChart.ts
@@ -67,12 +67,14 @@ export const useLineChart = ({
         .filter((dp) => dp.Total === null)
         .map((dp) => dp.start_date);
       const disaggregationDisplayName = Object.keys(disaggregations)[0];
-      const disaggregationWithDimensionValues = Object.values(
-        disaggregations[disaggregationDisplayName]
-      ).filter(
-        (dp) =>
-          !startDatesOfNullTotalAggregateDatapoints.includes(dp.start_date)
-      );
+      const disaggregationWithDimensionValues = disaggregations[
+        disaggregationDisplayName
+      ]
+        ? Object.values(disaggregations[disaggregationDisplayName]).filter(
+            (dp) =>
+              !startDatesOfNullTotalAggregateDatapoints.includes(dp.start_date)
+          )
+        : [];
       const hasAllDisabledDimensions =
         disaggregationsByDisplayName[
           disaggregationDisplayName

--- a/common/hooks/useLineChart.ts
+++ b/common/hooks/useLineChart.ts
@@ -75,14 +75,19 @@ export const useLineChart = ({
 
   const getLineChartDimensionsFromMetric = (metric: Metric) => {
     if (dimensionNamesByMetricAndDisaggregation) {
+      const dimensionsByLabel = groupBy(
+        metric.disaggregations[0].dimensions,
+        (dim) => dim.label
+      );
+
       /**
-       * Gets an array of dimension keys.
+       * Gets an array of dimension keys (filtering out disabled dimensions).
        * NOTE: This assumes there's just one breakdown per metric. We will need to adjust this
        *       based on how we want to handle displaying metrics w/ multiple breakdowns.
        */
       return Object.values(
         dimensionNamesByMetricAndDisaggregation[metric.key]
-      )[0];
+      )[0].filter((dimension) => dimensionsByLabel[dimension]?.[0]?.enabled);
     }
     return [];
   };

--- a/common/hooks/useLineChart.ts
+++ b/common/hooks/useLineChart.ts
@@ -75,11 +75,6 @@ export const useLineChart = ({
 
   const getLineChartDimensionsFromMetric = (metric: Metric) => {
     if (dimensionNamesByMetricAndDisaggregation) {
-      const dimensionsByLabel = groupBy(
-        metric.disaggregations[0].dimensions,
-        (dim) => dim.label
-      );
-
       /**
        * Gets an array of dimension keys (filtering out disabled dimensions).
        * NOTE: This assumes there's just one breakdown per metric. We will need to adjust this
@@ -87,7 +82,7 @@ export const useLineChart = ({
        */
       return Object.values(
         dimensionNamesByMetricAndDisaggregation[metric.key]
-      )[0].filter((dimension) => dimensionsByLabel[dimension]?.[0]?.enabled);
+      )[0];
     }
     return [];
   };

--- a/common/hooks/useLineChart.ts
+++ b/common/hooks/useLineChart.ts
@@ -56,9 +56,22 @@ export const useLineChart = ({
        *       based on how we want to handle displaying metrics w/ multiple breakdowns.
        */
       const { disaggregations } = datapointsByMetric[metric.key];
+      /**
+       * Get start dates of aggregate datapoints that have a `null` value for the `Total` property
+       * so we can filter those datapoints out of the disaggregations to match the date ranges
+       * rendered in the bar charts.
+       */
+      const startDatesOfNullTotalAggregateDatapoints = datapointsByMetric[
+        metric.key
+      ].aggregate
+        .filter((dp) => dp.Total === null)
+        .map((dp) => dp.start_date);
       const disaggregationDisplayName = Object.keys(disaggregations)[0];
       const disaggregationWithDimensionValues = Object.values(
         disaggregations[disaggregationDisplayName]
+      ).filter(
+        (dp) =>
+          !startDatesOfNullTotalAggregateDatapoints.includes(dp.start_date)
       );
       const hasAllDisabledDimensions =
         disaggregationsByDisplayName[


### PR DESCRIPTION
## Description of the change

Filters out datapoints in the line chart with `null` aggregate total value (similar to how the bar chart filters null datapoints). This handles the edge case where an agency publishes an empty record - currently, the empty record will not appear on the bar charts (because the aggregate `Total` will be `null` and its filtering those out), but does appear on the line charts (which is not filtering for `null` aggregate totals).


https://github.com/Recidiviz/justice-counts/assets/59492998/63626345-6f73-42b7-84ff-dbdc4884372a



## Related issues

Closes #946 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
