### PR TITLE
[Agency Dashboards] Playtesting Followup - Filter charts by system in Category Overview page

### DIFF
--- a/agency-dashboard/src/CategoryOverview/CategoryOverview.styled.tsx
+++ b/agency-dashboard/src/CategoryOverview/CategoryOverview.styled.tsx
@@ -22,6 +22,11 @@ import {
 } from "@justice-counts/common/components/GlobalStyles";
 import styled from "styled-components/macro";
 
+import {
+  SystemChip,
+  SystemChipsContainer,
+} from "../AgencyOverview/AgencyOverview.styles";
+
 const MIN_METRIC_BOX_WIDTH = 507;
 
 export const Wrapper = styled.div`
@@ -174,3 +179,13 @@ export const BreakdownsTitle = styled.h3`
   ${typography.sizeCSS.medium};
   margin-left: 50px;
 `;
+
+export const CustomSystemChipsContainer = styled(SystemChipsContainer)`
+  width: 100%;
+  max-width: 93%;
+  margin-bottom: 0;
+  padding-bottom: 24px;
+  border-bottom: 1px solid ${palette.highlight.grey4};
+`;
+
+export const CustomSystemChip = styled(SystemChip)``;

--- a/agency-dashboard/src/CategoryOverview/CategoryOverview.tsx
+++ b/agency-dashboard/src/CategoryOverview/CategoryOverview.tsx
@@ -23,6 +23,7 @@ import MetricsCategoryBarChart from "@justice-counts/common/components/DataViz/M
 import { getDataVizTimeRangeByFilterByMetricFrequency } from "@justice-counts/common/components/DataViz/utils";
 import { useBarChart, useLineChart } from "@justice-counts/common/hooks";
 import { DataVizAggregateName, Metric } from "@justice-counts/common/types";
+import { removeSnakeCase } from "@justice-counts/common/utils";
 import { observer } from "mobx-react-lite";
 import React, { useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
@@ -56,9 +57,11 @@ export const CategoryOverview = observer(() => {
 
   const {
     agencyName,
+    agencySystems,
     datapointsByMetric,
     dimensionNamesByMetricAndDisaggregation,
     loading,
+    agencySystemsWithData,
     downloadMetricsData,
     getMetricsWithDataByCategory,
   } = agencyDataStore;
@@ -71,6 +74,7 @@ export const CategoryOverview = observer(() => {
     "all"
   );
   const [hoveredDate, setHoveredDate] = useState<{ [key: string]: string }>({});
+  const [currentSystem, setCurrentSystem] = useState(agencySystems?.[0]);
 
   const { getLineChartDataFromMetric, getLineChartDimensionsFromMetric } =
     useLineChart({
@@ -82,6 +86,7 @@ export const CategoryOverview = observer(() => {
       getDataVizTimeRangeByFilterByMetricFrequency(dataRangeFilter),
     datapointsByMetric,
   });
+  const systemsWithData = agencySystemsWithData();
 
   if (loading) {
     return <Loading />;
@@ -121,6 +126,23 @@ export const CategoryOverview = observer(() => {
             </Styled.TopBlockControls>
           </Styled.TopBlock>
 
+          {/* System Selector */}
+          {systemsWithData.length > 1 && (
+            <Styled.CustomSystemChipsContainer>
+              {agencySystemsWithData().map((system) => {
+                return (
+                  <Styled.CustomSystemChip
+                    key={system}
+                    onClick={() => setCurrentSystem(system)}
+                    active={system === currentSystem}
+                  >
+                    {removeSnakeCase(system).toLocaleLowerCase()}
+                  </Styled.CustomSystemChip>
+                );
+              })}
+            </Styled.CustomSystemChipsContainer>
+          )}
+
           {/* Metrics + Data Visualizations */}
           <Styled.MetricsBlock>
             {/* Time Range Filters */}
@@ -141,50 +163,52 @@ export const CategoryOverview = observer(() => {
 
             {/* Metric Information & Data Visualization */}
             <Styled.MetricsWrapper>
-              {metricsWithData?.map((metric: Metric) => (
-                <Styled.MetricBox key={metric.key}>
-                  <Styled.MetricName>{metric.display_name}</Styled.MetricName>
-                  <Styled.MetricDataVizContainer>
-                    <Styled.MetricDescriptionBarChartWrapper>
-                      <Styled.MetricDescription>
-                        {metric.description}
-                      </Styled.MetricDescription>
+              {metricsWithData
+                ?.filter((metric) => metric.system.key === currentSystem)
+                .map((metric: Metric) => (
+                  <Styled.MetricBox key={metric.key}>
+                    <Styled.MetricName>{metric.display_name}</Styled.MetricName>
+                    <Styled.MetricDataVizContainer>
+                      <Styled.MetricDescriptionBarChartWrapper>
+                        <Styled.MetricDescription>
+                          {metric.description}
+                        </Styled.MetricDescription>
 
-                      {/* Bar Chart */}
-                      <MetricsCategoryBarChart
-                        width={620}
-                        data={getBarChartData(metric)}
-                        onHoverBar={(payload) => {
-                          setHoveredDate((prev) => ({
-                            ...prev,
-                            [metric.key]: payload.start_date,
-                          }));
-                        }}
-                        dimensionNames={[DataVizAggregateName]}
-                        metric={metric.display_name}
-                        ref={ref}
-                      />
-                    </Styled.MetricDescriptionBarChartWrapper>
+                        {/* Bar Chart */}
+                        <MetricsCategoryBarChart
+                          width={620}
+                          data={getBarChartData(metric)}
+                          onHoverBar={(payload) => {
+                            setHoveredDate((prev) => ({
+                              ...prev,
+                              [metric.key]: payload.start_date,
+                            }));
+                          }}
+                          dimensionNames={[DataVizAggregateName]}
+                          metric={metric.display_name}
+                          ref={ref}
+                        />
+                      </Styled.MetricDescriptionBarChartWrapper>
 
-                    {/* Breakdown/Disaggregation Line Chart */}
-                    {/* NOTE: CategoryOverviewLineChart will not appear if all metrics are disabled or the metric itself has no breakdowns */}
-                    {/* TODO(#978) Refactor to handle multiple breakdowns */}
-                    {getLineChartDataFromMetric(metric).length > 0 && (
-                      <CategoryOverviewLineChart
-                        data={getLineChartDataFromMetric(metric)}
-                        isFundingOrExpenses={
-                          metric.display_name === "Funding" ||
-                          metric.display_name === "Expenses"
-                        }
-                        dimensions={getLineChartDimensionsFromMetric(metric)}
-                        hoveredDate={hoveredDate[metric.key]}
-                        setHoveredDate={setHoveredDate}
-                        metric={metric}
-                      />
-                    )}
-                  </Styled.MetricDataVizContainer>
-                </Styled.MetricBox>
-              ))}
+                      {/* Breakdown/Disaggregation Line Chart */}
+                      {/* NOTE: CategoryOverviewLineChart will not appear if all metrics are disabled or the metric itself has no breakdowns */}
+                      {/* TODO(#978) Refactor to handle multiple breakdowns */}
+                      {getLineChartDataFromMetric(metric).length > 0 && (
+                        <CategoryOverviewLineChart
+                          data={getLineChartDataFromMetric(metric)}
+                          isFundingOrExpenses={
+                            metric.display_name === "Funding" ||
+                            metric.display_name === "Expenses"
+                          }
+                          dimensions={getLineChartDimensionsFromMetric(metric)}
+                          hoveredDate={hoveredDate[metric.key]}
+                          setHoveredDate={setHoveredDate}
+                          metric={metric}
+                        />
+                      )}
+                    </Styled.MetricDataVizContainer>
+                  </Styled.MetricBox>
+                ))}
             </Styled.MetricsWrapper>
           </Styled.MetricsBlock>
         </Styled.Container>

--- a/agency-dashboard/src/CategoryOverview/CategoryOverview.tsx
+++ b/agency-dashboard/src/CategoryOverview/CategoryOverview.tsx
@@ -129,7 +129,7 @@ export const CategoryOverview = observer(() => {
           {/* System Selector */}
           {systemsWithData.length > 1 && (
             <Styled.CustomSystemChipsContainer>
-              {agencySystemsWithData().map((system) => {
+              {systemsWithData.map((system) => {
                 return (
                   <Styled.CustomSystemChip
                     key={system}


### PR DESCRIPTION
## Description of the change

For multi-system agencies - instead of displaying all of the metric charts for each system in one page (in the Category Overview page), this will allow you to filter the metric charts by system (via system chips  - similar to the Agency Overview page). This will only appear for agencies with multiple systems.

https://github.com/Recidiviz/justice-counts/assets/59492998/243e1ac3-0265-4b50-9a65-ce23e5705a7f


## Related issues

Closes #959

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
