### PR TITLE
[Agency Dashboards] Small Fix & Clean Up

### DIFF
--- a/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
+++ b/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
@@ -186,11 +186,13 @@ export const AgencyOverview = observer(() => {
                       {metricsWithData.map((metric) => {
                         const { beginDate, endDate, transformedDataForChart } =
                           getMiniChartDateRangeAndTransformedData(metric);
+                        const metricDisplayName = metric.display_name
+                          .toUpperCase()
+                          .split("(")[0] // Removes system name parenthesis from display name (e.g. "Staff With Caseloads (Supervision)" becomes "Staff With Caseloads")
+                          .trim();
                         return (
                           <MetricBox key={metric.key}>
-                            <MetricBoxTitle>
-                              {metric.display_name.toUpperCase()}
-                            </MetricBoxTitle>
+                            <MetricBoxTitle>{metricDisplayName}</MetricBoxTitle>
                             <MetricBoxContentContainer>
                               <MetricBoxGraphContainer>
                                 <MiniChartContainer>

--- a/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
+++ b/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
@@ -53,12 +53,13 @@ import {
 } from ".";
 
 /** "Visible Categories" are the categories of metrics we are allowing users to view */
-const visibleCategoriesMetadata: VisibleCategoriesMetadata = {
-  "Capacity and Costs": {
-    label: "Understand the Finances",
-    description: "See how we’re funded and where we use those funds",
-  },
-};
+export const agencyOverviewVisibleCategoriesMetadata: VisibleCategoriesMetadata =
+  {
+    "Capacity and Costs": {
+      label: "Understand the Finances",
+      description: "See how we’re funded and where we use those funds",
+    },
+  };
 
 export const AgencyOverview = observer(() => {
   const navigate = useNavigate();
@@ -74,9 +75,13 @@ export const AgencyOverview = observer(() => {
     getMiniChartDateRangeAndTransformedData,
   } = agencyDataStore;
   const metricsByAvailableCategoriesWithData =
-    getMetricsByAvailableCategoriesWithData(visibleCategoriesMetadata);
+    getMetricsByAvailableCategoriesWithData(
+      agencyOverviewVisibleCategoriesMetadata
+    );
 
-  const availableSystems = agencySystemsWithData(visibleCategoriesMetadata);
+  const availableSystems = agencySystemsWithData(
+    agencyOverviewVisibleCategoriesMetadata
+  );
 
   const [currentSystem, setCurrentSystem] = useState<AgencySystems | undefined>(
     availableSystems[0]
@@ -133,76 +138,81 @@ export const AgencyOverview = observer(() => {
             </SystemChipsContainer>
 
             {/* Metric Categories (with data only) */}
-            {Object.keys(visibleCategoriesMetadata).map((category) => {
-              const metricsWithData =
-                getMetricsWithDataByCategoryByCurrentSystem(
-                  category,
-                  currentSystem
+            {Object.keys(agencyOverviewVisibleCategoriesMetadata).map(
+              (category) => {
+                const metricsWithData =
+                  getMetricsWithDataByCategoryByCurrentSystem(
+                    category,
+                    currentSystem
+                  );
+                if (metricsWithData.length === 0) return null;
+                const isCapacityAndCostCategory =
+                  category === "Capacity and Costs";
+
+                return (
+                  <CategorizedMetricsContainer key={category}>
+                    <CategoryTitle
+                      onClick={() =>
+                        handleCategoryClick(
+                          isCapacityAndCostCategory,
+                          category,
+                          currentSystem
+                        )
+                      }
+                      hasHover={isCapacityAndCostCategory}
+                    >
+                      {`${
+                        agencyOverviewVisibleCategoriesMetadata[category].label
+                      }${isCapacityAndCostCategory ? " ->" : ""}`}
+                    </CategoryTitle>
+                    <CategoryDescription>
+                      {
+                        agencyOverviewVisibleCategoriesMetadata[category]
+                          .description
+                      }
+                    </CategoryDescription>
+
+                    {/* Metrics Row (w/ mini charts) */}
+                    <MetricsContainer
+                      onClick={() =>
+                        handleCategoryClick(
+                          isCapacityAndCostCategory,
+                          category,
+                          currentSystem
+                        )
+                      }
+                      hasHover={isCapacityAndCostCategory}
+                    >
+                      {metricsWithData.map((metric) => {
+                        const { beginDate, endDate, transformedDataForChart } =
+                          getMiniChartDateRangeAndTransformedData(metric);
+                        return (
+                          <MetricBox key={metric.key}>
+                            <MetricBoxTitle>
+                              {metric.display_name.toUpperCase()}
+                            </MetricBoxTitle>
+                            <MetricBoxContentContainer>
+                              <MetricBoxGraphContainer>
+                                <MiniChartContainer>
+                                  <MiniBarChart
+                                    data={transformedDataForChart}
+                                    dimensionNames={[DataVizAggregateName]}
+                                  />
+                                </MiniChartContainer>
+                                <MetricBoxGraphRange>
+                                  <span>{beginDate}</span>
+                                  <span>{endDate}</span>
+                                </MetricBoxGraphRange>
+                              </MetricBoxGraphContainer>
+                            </MetricBoxContentContainer>
+                          </MetricBox>
+                        );
+                      })}
+                    </MetricsContainer>
+                  </CategorizedMetricsContainer>
                 );
-              if (metricsWithData.length === 0) return null;
-              const isCapacityAndCostCategory =
-                category === "Capacity and Costs";
-
-              return (
-                <CategorizedMetricsContainer key={category}>
-                  <CategoryTitle
-                    onClick={() =>
-                      handleCategoryClick(
-                        isCapacityAndCostCategory,
-                        category,
-                        currentSystem
-                      )
-                    }
-                    hasHover={isCapacityAndCostCategory}
-                  >
-                    {`${visibleCategoriesMetadata[category].label}${
-                      isCapacityAndCostCategory ? " ->" : ""
-                    }`}
-                  </CategoryTitle>
-                  <CategoryDescription>
-                    {visibleCategoriesMetadata[category].description}
-                  </CategoryDescription>
-
-                  {/* Metrics Row (w/ mini charts) */}
-                  <MetricsContainer
-                    onClick={() =>
-                      handleCategoryClick(
-                        isCapacityAndCostCategory,
-                        category,
-                        currentSystem
-                      )
-                    }
-                    hasHover={isCapacityAndCostCategory}
-                  >
-                    {metricsWithData.map((metric) => {
-                      const { beginDate, endDate, transformedDataForChart } =
-                        getMiniChartDateRangeAndTransformedData(metric);
-                      return (
-                        <MetricBox key={metric.key}>
-                          <MetricBoxTitle>
-                            {metric.display_name.toUpperCase()}
-                          </MetricBoxTitle>
-                          <MetricBoxContentContainer>
-                            <MetricBoxGraphContainer>
-                              <MiniChartContainer>
-                                <MiniBarChart
-                                  data={transformedDataForChart}
-                                  dimensionNames={[DataVizAggregateName]}
-                                />
-                              </MiniChartContainer>
-                              <MetricBoxGraphRange>
-                                <span>{beginDate}</span>
-                                <span>{endDate}</span>
-                              </MetricBoxGraphRange>
-                            </MetricBoxGraphContainer>
-                          </MetricBoxContentContainer>
-                        </MetricBox>
-                      );
-                    })}
-                  </MetricsContainer>
-                </CategorizedMetricsContainer>
-              );
-            })}
+              }
+            )}
           </MetricsViewContainer>
         )}
       </AgencyOverviewWrapper>

--- a/agency-dashboard/src/CategoryOverview/CategoryOverview.tsx
+++ b/agency-dashboard/src/CategoryOverview/CategoryOverview.tsx
@@ -29,6 +29,7 @@ import React, { useState } from "react";
 import { useLocation, useNavigate, useParams } from "react-router-dom";
 import { useCurrentPng } from "recharts-to-png";
 
+import { agencyOverviewVisibleCategoriesMetadata } from "../AgencyOverview";
 import { HeaderBar } from "../Header";
 import { Loading } from "../Loading";
 import { useStore } from "../stores";
@@ -36,7 +37,7 @@ import { copyCurrentUrlToClipboard } from "../utils";
 import * as Styled from "./CategoryOverview.styled";
 import { VisibleCategoriesMetadata } from "./types";
 
-const visibleCategoriesMetadata: VisibleCategoriesMetadata = {
+const categoryOverviewVisibleCategoriesMetadata: VisibleCategoriesMetadata = {
   "capacity-and-costs": {
     key: "Capacity and Costs",
     label: "Capacity and Costs",
@@ -58,7 +59,6 @@ export const CategoryOverview = observer(() => {
 
   const {
     agencyName,
-    agencySystems,
     datapointsByMetric,
     dimensionNamesByMetricAndDisaggregation,
     loading,
@@ -66,17 +66,20 @@ export const CategoryOverview = observer(() => {
     downloadMetricsData,
     getMetricsWithDataByCategory,
   } = agencyDataStore;
-  const categoryKey = visibleCategoriesMetadata[category]?.key;
+  const categoryKey = categoryOverviewVisibleCategoriesMetadata[category]?.key;
   const metricsWithData = categoryKey
     ? getMetricsWithDataByCategory(categoryKey)
     : undefined;
+  const systemsWithData = agencySystemsWithData(
+    agencyOverviewVisibleCategoriesMetadata
+  );
 
   const [dataRangeFilter, setDataRangeFilter] = useState<"recent" | "all">(
     "all"
   );
   const [hoveredDate, setHoveredDate] = useState<{ [key: string]: string }>({});
   const [currentSystem, setCurrentSystem] = useState(
-    state.currentSystem || agencySystems?.[0]
+    state?.currentSystem || systemsWithData?.[0]
   );
 
   const { getLineChartDataFromMetric, getLineChartDimensionsFromMetric } =
@@ -88,12 +91,6 @@ export const CategoryOverview = observer(() => {
     getDataVizTimeRange:
       getDataVizTimeRangeByFilterByMetricFrequency(dataRangeFilter),
     datapointsByMetric,
-  });
-  const systemsWithData = agencySystemsWithData({
-    "Capacity and Costs": {
-      label: "Understand the Finances",
-      description: "See how we’re funded and where we use those funds",
-    },
   });
 
   if (loading) {
@@ -117,10 +114,10 @@ export const CategoryOverview = observer(() => {
             />
             <Styled.AgencyTitle>{agencyName}</Styled.AgencyTitle>
             <Styled.CategoryTitle>
-              {visibleCategoriesMetadata[category]?.label}
+              {categoryOverviewVisibleCategoriesMetadata[category]?.label}
             </Styled.CategoryTitle>
             <Styled.CategoryDescription>
-              {visibleCategoriesMetadata[category]?.description}
+              {categoryOverviewVisibleCategoriesMetadata[category]?.description}
             </Styled.CategoryDescription>
 
             {/* Download/Share Buttons */}


### PR DESCRIPTION
## Description of the change

Small clean up and fixes a couple of things:
* A crash that happens when users go to the `.../agency/agency-name/capacity-and-cost/` directly (without clicking into the Category Overview page from the Agency Overview page)
* When an agency has multiple systems, there's a chance that the default system that shows in the Category Overview page will be a system without data - at which point no metrics, charts or breakdowns will render. 


https://github.com/Recidiviz/justice-counts/assets/59492998/79680f00-0951-4019-86c9-6a94814f847a


## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
