### PR TITLE
[Publisher] Styling Fix in Data Viz page

### DIFF
--- a/publisher/src/components/DataViz/MetricsDataChart.styled.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.styled.tsx
@@ -140,9 +140,10 @@ export const DisclaimerContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
+  padding-top: 15px;
   padding-bottom: 37px;
   width: ${INNER_PANEL_LEFT_CONTAINER_MAX_WIDTH}px;
-  height: 200px;
+  min-height: 200px;
 `;
 
 export const DisclaimerTitle = styled.div`


### PR DESCRIPTION
## Description of the change

Fixes the overlapping issue CSG pointed out in the Data Viz page where the list of systems and metrics on the left side was overlapping with the "Notes" section.

**Before**
<img width="1495" alt="Screenshot 2023-10-17 at 11 11 40 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/aadc5ccd-3748-4f43-b48e-2cfd59a43672">

**After**
<img width="1728" alt="Screenshot 2023-10-17 at 11 07 50 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/e1ae9492-a090-49c6-b768-0a7f48ea420e">


## Related issues

Closes #999

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
