### PR TITLE
get csv for agency data from protected endpoint

### DIFF
--- a/agency-dashboard/src/stores/AgencyDataStore.ts
+++ b/agency-dashboard/src/stores/AgencyDataStore.ts
@@ -255,7 +255,7 @@ class AgencyDataStore {
       if (metric && this.agency) {
         const agencyId = this.agency.id;
         metric.filenames.forEach((filename) =>
-          downloadFeedData(metric.system.key, agencyId, filename)
+          downloadFeedData(metric.system.key, agencyId, filename, true)
         );
       }
     });

--- a/common/utils/downloadHelpers.ts
+++ b/common/utils/downloadHelpers.ts
@@ -20,10 +20,21 @@ import { Metric } from "@justice-counts/common/types";
 export const downloadFeedData = async (
   system: string,
   agencyId: number | string,
-  filename: string
+  filename: string,
+  isPublic: boolean
 ) => {
   const a = document.createElement("a");
-  a.href = `/feed/${agencyId}?system=${system}&metric=${filename}`;
+  let url = `/feed/${agencyId}?system=${system}&metric=${filename}`;
+  if (isPublic === false) {
+    // the isPublic determines where we fetch the an agency's data.
+    // If the information WILL NOT be shared publicly (i.e isPublic === false),
+    // data is requested from a protected endpoint that will return
+    // all uploaded data for an agency. If the data WILL be shared
+    // publicly, data is fetched from a public endpoint that will
+    // only return published data.
+    url = `/api${url}`;
+  }
+  a.href = url;
   a.setAttribute("download", `${filename}.csv`);
   a.click();
   a.remove();
@@ -31,11 +42,12 @@ export const downloadFeedData = async (
 
 export const downloadMetricData = (
   metric: Metric,
-  agencyId: number | string
+  agencyId: number | string,
+  isPublic: boolean
 ) => {
   if (metric) {
     metric.filenames.forEach((fileName) => {
-      downloadFeedData(metric.system.key, agencyId, fileName);
+      downloadFeedData(metric.system.key, agencyId, fileName, isPublic);
     });
   }
 };

--- a/publisher/src/components/DataViz/MetricsDataChart.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.tsx
@@ -365,7 +365,7 @@ export const MetricsDataChart: React.FC = observer(() => {
               onClick={() =>
                 dataView === ChartView.Chart
                   ? handleChartDownload(currentSystem, currentMetric.key)
-                  : downloadMetricData(currentMetric, agencyId)
+                  : downloadMetricData(currentMetric, agencyId, false)
               }
             >
               <DownloadChartIcon />


### PR DESCRIPTION
## Description of the change

Updates where we fetch the agencies uploaded data to confirm that only logged-in users can access CSVs containing all uploaded data. 


## Related issues

[Companion BE PR](https://github.com/Recidiviz/recidiviz-data/pull/24903)

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
