### PR TITLE
[Publisher] Remove duplicate state codes in agency name within the agency dropdown menu

### DIFF
--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -92,7 +92,9 @@ const Menu: React.FC = () => {
         .map((agency) => ({
           key: agency.id,
           label: `${agency.name} ${
-            agency.state_code && includeStateCodeInAgencyName
+            agency.state_code &&
+            includeStateCodeInAgencyName &&
+            !agency.name.includes(agency.state_code.split("_")[1].toUpperCase())
               ? `(${agency.state_code.split("_")[1].toUpperCase()})`
               : ""
           }`,

--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -91,7 +91,7 @@ const Menu: React.FC = () => {
         .sort((a, b) => a.name.localeCompare(b.name))
         .map((agency) => {
           const stateCodeDisplayName = agency.state_code
-            .split("_")[1]
+            ?.split("_")[1]
             .toUpperCase();
           const isStateCodeInAgencyName =
             agency.name.includes(stateCodeDisplayName);

--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -89,21 +89,28 @@ const Menu: React.FC = () => {
     ? userStore.userAgencies
         .slice()
         .sort((a, b) => a.name.localeCompare(b.name))
-        .map((agency) => ({
-          key: agency.id,
-          label: `${agency.name} ${
-            agency.state_code &&
-            includeStateCodeInAgencyName &&
-            !agency.name.includes(agency.state_code.split("_")[1].toUpperCase())
-              ? `(${agency.state_code.split("_")[1].toUpperCase()})`
-              : ""
-          }`,
-          onClick: () => {
-            navigate(`/agency/${agency.id}/${pathWithoutAgency}`);
-            handleCloseMobileMenu();
-          },
-          highlight: agency.id === currentAgency?.id,
-        }))
+        .map((agency) => {
+          const stateCodeDisplayName = agency.state_code
+            .split("_")[1]
+            .toUpperCase();
+          const isStateCodeInAgencyName =
+            agency.name.includes(stateCodeDisplayName);
+          return {
+            key: agency.id,
+            label: `${agency.name} ${
+              agency.state_code &&
+              includeStateCodeInAgencyName &&
+              !isStateCodeInAgencyName
+                ? `(${stateCodeDisplayName})`
+                : ""
+            }`,
+            onClick: () => {
+              navigate(`/agency/${agency.id}/${pathWithoutAgency}`);
+              handleCloseMobileMenu();
+            },
+            highlight: agency.id === currentAgency?.id,
+          };
+        })
     : [];
 
   const profileDropdownMetadata = [


### PR DESCRIPTION
## Description of the change

Removes duplicate state codes in agency's name within the agency dropdown menu. The current logic appends the state code to each agency in the dropdown menu - so if an agency's name is "Department of X (CA)" it will render as "Department of X (CA) (CA)" in the menu. This adjustment checks to see if the state code (in parenthesis) is already included in the agency's name - and if so, it will not append a state code.


Demo (the agency has the state code directly in its name):

https://github.com/Recidiviz/justice-counts/assets/59492998/b0b329a6-38ca-459c-b5e5-7068322d9b9a



## Related issues

Closes #1038

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
