### PR TITLE
[Bug] Fix link from Help Center to Agency Dashboards for production users

### DIFF
--- a/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
+++ b/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
@@ -16,14 +16,13 @@
 // =============================================================================
 
 import { slugify } from "@justice-counts/common/utils";
-import { observer } from "mobx-react-lite";
 import React, { PropsWithChildren } from "react";
 
 import { useStore } from "../../stores";
 
 export const LinkToPublisher: React.FC<
   PropsWithChildren & { publisherPath: string }
-> = observer(({ publisherPath, children }) => {
+> = ({ publisherPath, children }) => {
   const { userStore } = useStore();
   const agencyIdLocalStorage = localStorage.getItem("agencyId");
   const agencyId = agencyIdLocalStorage || userStore.getInitialAgencyId();
@@ -34,28 +33,26 @@ export const LinkToPublisher: React.FC<
       {children}
     </a>
   );
-});
+};
 
-export const LinkToDashboard: React.FC<PropsWithChildren> = observer(
-  ({ children }) => {
-    const { api, userStore } = useStore();
-    const agencyIdLocalStorage = localStorage.getItem("agencyId");
-    const agencyId =
-      agencyIdLocalStorage || userStore.getInitialAgencyId()?.toLocaleString();
-    const agencyName = agencyId && userStore.getAgency(agencyId)?.name;
-    // eslint-disable-next-line
-    console.log("api.environment::", api.environment);
-    if (!agencyName) return <>{children}</>;
+export const LinkToDashboard: React.FC<PropsWithChildren> = ({ children }) => {
+  const { api, userStore } = useStore();
+  const agencyIdLocalStorage = localStorage.getItem("agencyId");
+  const agencyId =
+    agencyIdLocalStorage || userStore.getInitialAgencyId()?.toLocaleString();
+  const agencyName = agencyId && userStore.getAgency(agencyId)?.name;
+  // eslint-disable-next-line
+  console.log("api.environment::", api.environment);
+  if (!agencyName) return <>{children}</>;
 
-    const url = generateDashboardURL(api.environment, agencyName);
+  const url = generateDashboardURL(api.environment, agencyName);
 
-    return (
-      <a href={url} target="_blank" rel="noreferrer noopener">
-        {children}
-      </a>
-    );
-  }
-);
+  return (
+    <a href={url} target="_blank" rel="noreferrer noopener">
+      {children}
+    </a>
+  );
+};
 
 export const generateDashboardURL = (
   env: string | undefined,

--- a/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
+++ b/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
@@ -16,13 +16,14 @@
 // =============================================================================
 
 import { slugify } from "@justice-counts/common/utils";
+import { observer } from "mobx-react-lite";
 import React, { PropsWithChildren } from "react";
 
 import { useStore } from "../../stores";
 
 export const LinkToPublisher: React.FC<
   PropsWithChildren & { publisherPath: string }
-> = ({ publisherPath, children }) => {
+> = observer(({ publisherPath, children }) => {
   const { userStore } = useStore();
   const agencyIdLocalStorage = localStorage.getItem("agencyId");
   const agencyId = agencyIdLocalStorage || userStore.getInitialAgencyId();
@@ -33,25 +34,27 @@ export const LinkToPublisher: React.FC<
       {children}
     </a>
   );
-};
+});
 
-export const LinkToDashboard: React.FC<PropsWithChildren> = ({ children }) => {
-  const { api, userStore } = useStore();
-  const agencyIdLocalStorage = localStorage.getItem("agencyId");
-  const agencyId =
-    agencyIdLocalStorage || userStore.getInitialAgencyId()?.toLocaleString();
-  const agencyName = agencyId && userStore.getAgency(agencyId)?.name;
+export const LinkToDashboard: React.FC<PropsWithChildren> = observer(
+  ({ children }) => {
+    const { api, userStore } = useStore();
+    const agencyIdLocalStorage = localStorage.getItem("agencyId");
+    const agencyId =
+      agencyIdLocalStorage || userStore.getInitialAgencyId()?.toLocaleString();
+    const agencyName = agencyId && userStore.getAgency(agencyId)?.name;
 
-  if (!agencyName) return <>{children}</>;
+    if (!agencyName) return <>{children}</>;
 
-  const url = generateDashboardURL(api.environment, agencyName);
+    const url = generateDashboardURL(api.environment, agencyName);
 
-  return (
-    <a href={url} target="_blank" rel="noreferrer noopener">
-      {children}
-    </a>
-  );
-};
+    return (
+      <a href={url} target="_blank" rel="noreferrer noopener">
+        {children}
+      </a>
+    );
+  }
+);
 
 export const generateDashboardURL = (
   env: string | undefined,

--- a/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
+++ b/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
@@ -43,8 +43,7 @@ export const LinkToDashboard: React.FC<PropsWithChildren> = observer(
     const agencyId =
       agencyIdLocalStorage || userStore.getInitialAgencyId()?.toLocaleString();
     const agencyName = agencyId && userStore.getAgency(agencyId)?.name;
-    // eslint-disable-next-line
-    console.log("api.environment::", api.environment);
+
     if (!agencyName) return <>{children}</>;
 
     const url = generateDashboardURL(api.environment, agencyName);

--- a/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
+++ b/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
@@ -16,13 +16,14 @@
 // =============================================================================
 
 import { slugify } from "@justice-counts/common/utils";
+import { observer } from "mobx-react-lite";
 import React, { PropsWithChildren } from "react";
 
 import { useStore } from "../../stores";
 
 export const LinkToPublisher: React.FC<
   PropsWithChildren & { publisherPath: string }
-> = ({ publisherPath, children }) => {
+> = observer(({ publisherPath, children }) => {
   const { userStore } = useStore();
   const agencyIdLocalStorage = localStorage.getItem("agencyId");
   const agencyId = agencyIdLocalStorage || userStore.getInitialAgencyId();
@@ -33,26 +34,28 @@ export const LinkToPublisher: React.FC<
       {children}
     </a>
   );
-};
+});
 
-export const LinkToDashboard: React.FC<PropsWithChildren> = ({ children }) => {
-  const { api, userStore } = useStore();
-  const agencyIdLocalStorage = localStorage.getItem("agencyId");
-  const agencyId =
-    agencyIdLocalStorage || userStore.getInitialAgencyId()?.toLocaleString();
-  const agencyName = agencyId && userStore.getAgency(agencyId)?.name;
-  // eslint-disable-next-line
-  console.log("api.environment::", api.environment);
-  if (!agencyName) return <>{children}</>;
+export const LinkToDashboard: React.FC<PropsWithChildren> = observer(
+  ({ children }) => {
+    const { api, userStore } = useStore();
+    const agencyIdLocalStorage = localStorage.getItem("agencyId");
+    const agencyId =
+      agencyIdLocalStorage || userStore.getInitialAgencyId()?.toLocaleString();
+    const agencyName = agencyId && userStore.getAgency(agencyId)?.name;
+    // eslint-disable-next-line
+    console.log("api.environment::", api.environment);
+    if (!agencyName) return <>{children}</>;
 
-  const url = generateDashboardURL(api.environment, agencyName);
+    const url = generateDashboardURL(api.environment, agencyName);
 
-  return (
-    <a href={url} target="_blank" rel="noreferrer noopener">
-      {children}
-    </a>
-  );
-};
+    return (
+      <a href={url} target="_blank" rel="noreferrer noopener">
+        {children}
+      </a>
+    );
+  }
+);
 
 export const generateDashboardURL = (
   env: string | undefined,

--- a/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
+++ b/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
@@ -43,7 +43,8 @@ export const LinkToDashboard: React.FC<PropsWithChildren> = observer(
     const agencyId =
       agencyIdLocalStorage || userStore.getInitialAgencyId()?.toLocaleString();
     const agencyName = agencyId && userStore.getAgency(agencyId)?.name;
-
+    // eslint-disable-next-line
+    console.log("api.environment::", api.environment);
     if (!agencyName) return <>{children}</>;
 
     const url = generateDashboardURL(api.environment, agencyName);


### PR DESCRIPTION
## Description of the change

I noticed a bug when I was playing around with the Help Center in production specifically in the link to Agency Dashboards. I was taken to the staging URL which resulted in an error - instead of the production URL. For some reason the piece of logic that creates the URL based on the environment isn't picking up on the right environment. I suspect it is because when this component is mounted, the `api.environment` is first `undefined` until it is set - and since these components aren't `observer`s they might not have been re-rendering when `api.environment` is set and have thus defaulted to the staging URL.

I tried to log the `api.environment` and deploy to playtesting with and without the `observer` and it logged `staging` for both - so my hunch might be off. But regardless, both components should be wrapped in an `observer` - so this change is necessary. I am curious to see when we deploy to prod if this fixes it. If not, I'll keep digging into this.

<img width="1728" alt="Screenshot 2023-11-20 at 11 28 27 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/089822e8-0ff0-4953-81c4-72d2a7400dd0">

## Related issues

Closes #1067

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
