### PR TITLE
[Publisher] Admin Panel: Agency Provisioning - Store Updates (2/n)

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -37,6 +37,7 @@ export type AgencySystems =
   | "SUPERAGENCY";
 
 export type AgencyTeamMember = {
+  user_account_id: number | null;
   auth0_user_id: string;
   name: string;
   email: string;

--- a/common/utils/helperUtils.ts
+++ b/common/utils/helperUtils.ts
@@ -274,3 +274,19 @@ export const validateEmail = (email: string) => {
     .toLowerCase()
     .match(/^([A-Z0-9_+-]\.?)*[A-Z0-9_+-]@([A-Z0-9][A-Z0-9-]*\.)+[A-Z]{2,}$/i);
 };
+
+/**
+ * Updates a set of selections by either adding or removing a specified item.
+ * @param prevSet - The previous set of selected items to update
+ * @param item - The item within the set to be added or removed depending on whether or not it already exists within the set
+ * @returns An updated set of selected items after the addition or removal operation.
+ */
+export const toggleAddRemoveSetItem = <T>(prevSet: Set<T>, item: T): Set<T> => {
+  const updatedSet = new Set(prevSet);
+  if (updatedSet.has(item)) {
+    updatedSet.delete(item);
+  } else {
+    updatedSet.add(item);
+  }
+  return updatedSet;
+};

--- a/publisher/src/components/AdminPanel/AdminPanel.test.tsx
+++ b/publisher/src/components/AdminPanel/AdminPanel.test.tsx
@@ -328,8 +328,9 @@ test("Adding an agency adds agency to user's agency list", async () => {
           state: "New York",
           state_code: "us_ny",
           super_agency_id: null,
+          child_agency_ids: [],
           systems: ["PRISONS", "SUPERVISION", "PAROLE", "PROBATION"],
-          team: [],
+          team: {},
         },
         {
           created_at: null,
@@ -342,8 +343,9 @@ test("Adding an agency adds agency to user's agency list", async () => {
           state: "New York",
           state_code: "us_ny",
           super_agency_id: null,
+          child_agency_ids: [],
           systems: ["PRISONS"],
-          team: [],
+          team: {},
         },
         {
           created_at: null,
@@ -356,8 +358,9 @@ test("Adding an agency adds agency to user's agency list", async () => {
           state: "Oregon",
           state_code: "us_or",
           super_agency_id: null,
+          child_agency_ids: [],
           systems: ["JAILS"],
-          team: [],
+          team: {},
         },
       ],
       (agency) => agency.id

--- a/publisher/src/components/AdminPanel/UserProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioning.tsx
@@ -79,7 +79,7 @@ export const UserProvisioning: React.FC<UserProvisioningProps> = observer(
 
     /** Available agencies to add from */
     const availableAgencies = agencies.filter(
-      (agency) => !selectedUserAgenciesIDsSet.has(agency.id)
+      (agency) => !selectedUserAgenciesIDsSet.has(+agency.id)
     );
     const availableAgenciesIDs = availableAgencies.map((agency) => +agency.id);
     const availableAgenciesIDsSet = new Set(availableAgenciesIDs);

--- a/publisher/src/components/Reports/CreateReport.test.tsx
+++ b/publisher/src/components/Reports/CreateReport.test.tsx
@@ -150,6 +150,7 @@ describe("test create report button", () => {
             systems: [],
             team: [
               {
+                user_account_id: 21,
                 name: "Test User",
                 auth0_user_id: "0",
                 email: "test@email.com",

--- a/publisher/src/stores/AdminPanelStore.test.tsx
+++ b/publisher/src/stores/AdminPanelStore.test.tsx
@@ -17,6 +17,7 @@
 
 import { AgencyResponse, UserResponse } from "../components/AdminPanel";
 import { groupBy } from "../utils";
+import { rootStore } from ".";
 import AdminPanelStore from "./AdminPanelStore";
 import API from "./API";
 
@@ -27,6 +28,7 @@ const MockAuthStore = jest.fn(() => {
 }) as jest.Mock;
 const api = new API(MockAuthStore());
 const adminPanelStore = new AdminPanelStore(api);
+rootStore.adminPanelStore = adminPanelStore;
 
 export const mockUsersResponse = {
   users: [
@@ -47,6 +49,7 @@ export const mockUsersResponse = {
           state: "New York",
           state_code: "us_ny",
           super_agency_id: null,
+          child_agency_ids: [],
           systems: ["PRISONS"],
           team: [],
         },
@@ -69,6 +72,7 @@ export const mockUsersResponse = {
           state: "New York",
           state_code: "us_ny",
           super_agency_id: null,
+          child_agency_ids: [],
           systems: ["PRISONS", "SUPERVISION", "PAROLE", "PROBATION"],
           team: [],
         },
@@ -83,6 +87,7 @@ export const mockUsersResponse = {
           state: "New York",
           state_code: "us_ny",
           super_agency_id: null,
+          child_agency_ids: [],
           systems: ["PRISONS"],
           team: [],
         },
@@ -97,6 +102,7 @@ export const mockUsersResponse = {
           state: "Oregon",
           state_code: "us_or",
           super_agency_id: null,
+          child_agency_ids: [],
           systems: ["JAILS"],
           team: [],
         },
@@ -119,6 +125,7 @@ export const mockUsersResponse = {
           state: "New York",
           state_code: "us_ny",
           super_agency_id: null,
+          child_agency_ids: [],
           systems: ["PRISONS", "SUPERVISION", "PAROLE", "PROBATION"],
           team: [],
         },
@@ -133,6 +140,7 @@ export const mockUsersResponse = {
           state: "New York",
           state_code: "us_ny",
           super_agency_id: null,
+          child_agency_ids: [],
           systems: ["PRISONS"],
           team: [],
         },
@@ -148,12 +156,13 @@ export const mockAgenciesResponse = {
       fips_county_code: null,
       id: 1011,
       is_dashboard_enabled: null,
-      is_superagency: null,
+      is_superagency: true,
       name: "Super Agency",
       settings: [],
       state: "Arizona",
       state_code: "us_az",
       super_agency_id: null,
+      child_agency_ids: [11],
       systems: ["LAW_ENFORCEMENT"],
       team: [
         {
@@ -162,6 +171,7 @@ export const mockAgenciesResponse = {
           invitation_status: null,
           name: "Anne Teak",
           role: "JUSTICE_COUNTS_ADMIN",
+          user_account_id: 1,
         },
       ],
     },
@@ -176,6 +186,7 @@ export const mockAgenciesResponse = {
       state: "California",
       state_code: "us_ca",
       super_agency_id: 10,
+      child_agency_ids: [],
       systems: ["SUPERVISION"],
       team: [
         {
@@ -184,6 +195,7 @@ export const mockAgenciesResponse = {
           invitation_status: null,
           name: "Liz Erd",
           role: "JUSTICE_COUNTS_ADMIN",
+          user_account_id: 2,
         },
       ],
     },
@@ -197,7 +209,8 @@ export const mockAgenciesResponse = {
       settings: [],
       state: "California",
       state_code: "us_ca",
-      super_agency_id: 10,
+      super_agency_id: 1011,
+      child_agency_ids: [],
       systems: ["LAW_ENFORCEMENT"],
       team: [
         {
@@ -206,6 +219,7 @@ export const mockAgenciesResponse = {
           invitation_status: null,
           name: "Liz Erd",
           role: "JUSTICE_COUNTS_ADMIN",
+          user_account_id: 2,
         },
       ],
     },

--- a/publisher/src/stores/AgencyStore.ts
+++ b/publisher/src/stores/AgencyStore.ts
@@ -326,6 +326,7 @@ class AgencyStore {
 
   inviteTeamMember = (name: string, email: string) => {
     const newTeamMember: AgencyTeamMember = {
+      user_account_id: null,
       auth0_user_id: "",
       name,
       email,


### PR DESCRIPTION
## Description of the change

Adds Agency Provisioning related methods and helpers in the `AdminPanelStore` and updates types. This is more/less the "backend" of the frontend - all of these methods will be plugged into the UI and used to update the changes made in the Agency Provisioning view to send off to the BE.

## Related issues

Contributes to #1051 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [x] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
