### PR TITLE
[Publisher] Admin Panel: Agency Provisioning - Team Members (5/n)

### DIFF
--- a/publisher/src/components/AdminPanel/AdminPanel.styles.tsx
+++ b/publisher/src/components/AdminPanel/AdminPanel.styles.tsx
@@ -279,6 +279,7 @@ export const ButtonWrapper = styled.div`
 export const TeamMembersContainer = styled.div`
   display: flex;
   flex-wrap: wrap;
+  margin-top: 12px;
 `;
 
 export const TeamMemberCard = styled.div<{

--- a/publisher/src/components/AdminPanel/AdminPanel.test.tsx
+++ b/publisher/src/components/AdminPanel/AdminPanel.test.tsx
@@ -720,3 +720,129 @@ test("Clicking on an existing agency card opens the edit agency modal", () => {
   const teamMember = screen.getAllByText("Anne Teak")[0];
   expect(teamMember).toBeInTheDocument();
 });
+
+test("Team members tab renders with add/remove buttons and users who are connected to the agency", () => {
+  runInAction(() => {
+    adminPanelStore.usersByID = usersByID;
+    adminPanelStore.agenciesByID = agenciesByID;
+  });
+
+  render(
+    <BrowserRouter>
+      <StoreProvider>
+        <AdminPanel />
+      </StoreProvider>
+    </BrowserRouter>
+  );
+
+  const agencyProvisioningTab = screen.getByText("Agency Provisioning");
+  fireEvent.click(agencyProvisioningTab);
+
+  const agency1Card = screen.getByText("Super Agency");
+  fireEvent.click(agency1Card);
+
+  const teamMemberRolesTab = screen.getByText("Team Members & Roles");
+  fireEvent.click(teamMemberRolesTab);
+
+  const addUsersButton = screen.getByText("Add Users");
+  const deleteUsersButton = screen.getByText("Delete Users");
+  const teamMember = screen.getByText("user1@email.org");
+
+  expect(teamMember).toBeInTheDocument();
+  expect(addUsersButton).toBeInTheDocument();
+  expect(deleteUsersButton).toBeInTheDocument();
+});
+
+test("Adding a user adds a card to the list of team members", () => {
+  runInAction(() => {
+    adminPanelStore.usersByID = usersByID;
+    adminPanelStore.agenciesByID = agenciesByID;
+  });
+
+  render(
+    <BrowserRouter>
+      <StoreProvider>
+        <AdminPanel />
+      </StoreProvider>
+    </BrowserRouter>
+  );
+
+  const agencyProvisioningTab = screen.getByText("Agency Provisioning");
+  fireEvent.click(agencyProvisioningTab);
+
+  const agency1Card = screen.getByText("Super Agency");
+  fireEvent.click(agency1Card);
+
+  const teamMemberRolesTab = screen.getByText("Team Members & Roles");
+  fireEvent.click(teamMemberRolesTab);
+
+  const addUsersButton = screen.getByText("Add Users");
+  fireEvent.click(addUsersButton);
+
+  const selectTeamMembersToAddLabel = screen.getByText(
+    "Select team members to add"
+  );
+  const existingTeamMember1 = screen.getByText("user1@email.org");
+  const teamMember2 = screen.getAllByText("Liz Erd")[2];
+  const teamMember3 = screen.getByText("Percy Vere");
+
+  expect(selectTeamMembersToAddLabel).toBeInTheDocument();
+  expect(existingTeamMember1).toBeInTheDocument();
+  expect(teamMember2).toBeInTheDocument();
+  expect(teamMember3).toBeInTheDocument();
+  expect(addUsersButton).toBeInTheDocument();
+
+  fireEvent.click(teamMember2);
+  /** Expect Liz Erd (user2@email.org) to be added to the team members list  */
+  const teamMember2Email = screen.getByText("user2@email.org");
+  expect(teamMember2Email).toBeInTheDocument();
+});
+
+test("Deleting a user deletes a card to the list of team members", () => {
+  runInAction(() => {
+    adminPanelStore.usersByID = usersByID;
+    adminPanelStore.agenciesByID = agenciesByID;
+  });
+
+  render(
+    <BrowserRouter>
+      <StoreProvider>
+        <AdminPanel />
+      </StoreProvider>
+    </BrowserRouter>
+  );
+
+  const agencyProvisioningTab = screen.getByText("Agency Provisioning");
+  fireEvent.click(agencyProvisioningTab);
+
+  const agency1Card = screen.getByText("Super Agency");
+  fireEvent.click(agency1Card);
+
+  const teamMemberRolesTab = screen.getByText("Team Members & Roles");
+  fireEvent.click(teamMemberRolesTab);
+
+  const deleteUsersButton = screen.getByText("Delete Users");
+  fireEvent.click(deleteUsersButton);
+
+  const selectTeamMembersToAddLabel = screen.getByText(
+    "Select team members to delete"
+  );
+  const existingTeamMember1 = screen.getByText("user1@email.org");
+  const existingTeamMember1ChipToDelete = screen.queryAllByText("Anne Teak")[1];
+  const teamMember2 = screen.queryAllByText("Liz Erd")[2];
+  const teamMember3 = screen.queryByText("Percy Vere");
+
+  expect(selectTeamMembersToAddLabel).toBeInTheDocument();
+  expect(existingTeamMember1).toBeInTheDocument();
+  expect(teamMember2).toBeUndefined();
+  expect(teamMember3).toBeNull();
+  expect(deleteUsersButton).toBeInTheDocument();
+
+  /** Expect the role input to be disabled after clicking on Anne Teak to delete  */
+  const existingTeamMember1Role = screen.getByDisplayValue(
+    "JUSTICE COUNTS ADMIN"
+  );
+  expect(existingTeamMember1Role).not.toBeDisabled();
+  fireEvent.click(existingTeamMember1ChipToDelete);
+  expect(existingTeamMember1Role).toBeDisabled();
+});

--- a/publisher/src/components/AdminPanel/types.ts
+++ b/publisher/src/components/AdminPanel/types.ts
@@ -15,7 +15,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { AgencySystems, AgencyTeamMember } from "@justice-counts/common/types";
+import {
+  AgencySystems,
+  AgencyTeamMember,
+  AgencyTeamMemberRole,
+} from "@justice-counts/common/types";
 
 export enum Environment {
   LOCAL = "local",
@@ -108,7 +112,7 @@ export type AgencyProvisioningUpdates = {
 
 export type AgencyTeamUpdates = {
   user_account_id: number | null;
-  role: UserRole;
+  role: AgencyTeamMemberRole;
 };
 
 /** User Types */
@@ -127,13 +131,6 @@ export type UserWithAgenciesByID = Omit<User, "agencies"> & {
 
 export type UserResponse = { users: User[] };
 
-export enum UserRoles {
-  AGENCY_ADMIN = "AGENCY_ADMIN",
-  JUSTICE_COUNTS_ADMIN = "JUSTICE_COUNTS_ADMIN",
-  CONTRIBUTOR = "CONTRIBUTOR",
-  READ_ONLY = "READ_ONLY",
-}
-
 export const userRoles = [
   "AGENCY_ADMIN",
   "JUSTICE_COUNTS_ADMIN",
@@ -141,7 +138,7 @@ export const userRoles = [
   "READ_ONLY",
 ] as const;
 
-export type UserRole = (typeof userRoles)[number];
+// export type AgencyTeamMemberRole = (typeof userRoles)[number];
 
 export type UserProvisioningUpdates = {
   name: string;
@@ -150,7 +147,7 @@ export type UserProvisioningUpdates = {
 };
 
 export type UserRoleUpdates = {
-  [id: number]: UserRole;
+  [id: number]: AgencyTeamMemberRole;
 };
 
 /** Search Feature Types */
@@ -169,7 +166,7 @@ export type InteractiveSearchListUpdateSelections = (
     name: string;
     action?: InteractiveSearchListAction;
     email?: string;
-    role?: UserRole;
+    role?: AgencyTeamMemberRole;
   },
   action: InteractiveSearchListAction
 ) => void;
@@ -179,7 +176,7 @@ export type SearchableListItem = {
   name: string;
   action?: InteractiveSearchListAction;
   email?: string;
-  role?: UserRole;
+  role?: AgencyTeamMemberRole;
 };
 
 export type SearchableSetKeys = Set<number | string>;

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -15,7 +15,11 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { AgencySystems, AgencyTeamMember } from "@justice-counts/common/types";
+import {
+  AgencySystems,
+  AgencyTeamMember,
+  AgencyTeamMemberRole,
+} from "@justice-counts/common/types";
 import { removeSnakeCase } from "@justice-counts/common/utils";
 import { makeAutoObservable, runInAction } from "mobx";
 
@@ -25,6 +29,7 @@ import {
   AgencyResponse,
   AgencyTeamUpdates,
   AgencyWithTeamByID,
+  Environment,
   FipsCountyCodeKey,
   FipsCountyCodes,
   SearchableEntity,
@@ -34,6 +39,7 @@ import {
   User,
   UserProvisioningUpdates,
   UserResponse,
+  UserRoleUpdates,
   UserWithAgenciesByID,
 } from "../components/AdminPanel";
 import { groupBy } from "../utils";
@@ -46,7 +52,7 @@ const initialEmptyUserProvisioningUpdates = {
 };
 
 const initialEmptyAgencyProvisioningUpdates = {
-  agency_id: undefined,
+  agency_id: null,
   name: "",
   state_code: null,
   fips_county_code: null,
@@ -90,6 +96,10 @@ class AdminPanelStore {
 
   get agencies(): AgencyWithTeamByID[] {
     return AdminPanelStore.objectToSortedFlatMappedValues(this.agenciesByID);
+  }
+
+  get csgUsers(): UserWithAgenciesByID[] {
+    return this.users.filter((user) => user.email.includes("@csg.org"));
   }
 
   get searchableSystems(): SearchableListItem[] {
@@ -278,6 +288,29 @@ class AdminPanelStore {
 
   updateTeamMembers(team: AgencyTeamUpdates[]) {
     this.agencyProvisioningUpdates.team = team;
+  }
+
+  /**
+   * Returns a { [id]: <AgencyTeamMemberRole> } object of CSG users with their default roles
+   * to be consumed by `AgencyProvisioning` component to auto-add CSG users when creating a
+   * new agency.
+   */
+  getCSGTeamMembersIDToRoles(agencyName: string): UserRoleUpdates {
+    let role: AgencyTeamMemberRole;
+    const isStagingEnv = this.api.environment === Environment.STAGING;
+    const isDemoAgency =
+      agencyName.includes("DEMO") ||
+      agencyName.includes("Department of Corrections");
+    if (isStagingEnv || isDemoAgency) {
+      role = AgencyTeamMemberRole.AGENCY_ADMIN;
+    } else {
+      role = AgencyTeamMemberRole.READ_ONLY;
+    }
+
+    return this.csgUsers.reduce((acc, user) => {
+      acc[+user.id] = role;
+      return acc;
+    }, {} as UserRoleUpdates);
   }
 
   resetAgencyProvisioningUpdates() {


### PR DESCRIPTION
## Description of the change

Implements the final piece to the Agency Provisioning flow - adding/removing users and updating their roles. 

At this point of the stacked PRs, you should be able to create or edit an agency, add/update all of the agency's information, and add/remove team members in a single request (huge shout out to Nichelle for all the BE work to make this possible).

Update:
- One more thing I forgot to include (thank you for the reminder, Lili!) - there's also additional logic that automatically adds CSG users and their corresponding roles as team members when trying to create a new agency. This was previously accomplished in the backend because the current admin panel's flow is: go to Agency Provisioning view and add a team member -> request sent to the BE, and BE adds the roles -> go to separate Agency Team Members view (GET request sent for team members and roles) and the updated roles will be visible. In the new admin panel flow, you see everything upfront - no separate roundtrip to add CSG and update user roles to receive them in a separate view. You'll see the added CSG users while in the creating a new agency modal.

Demo:

https://github.com/Recidiviz/justice-counts/assets/59492998/39b96f94-216e-4c04-a941-6b985d0d4b40

(Don't mind the dropdowns cutting off in the video - will try to address this in #1075)

## Related issues

Contributes to #1051

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [x] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
