### PR TITLE
[Justice Counts] Add "Define Metric ->" link to all aggregate metrics in metric configuration

### DIFF
--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.styled.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.styled.tsx
@@ -84,7 +84,7 @@ export const SettingRowsContainer = styled.div`
   display: flex;
   flex-direction: column;
   gap: 12px;
-  margin-bottom: 64px;
+  margin-bottom: 32px;
 `;
 
 export const SettingRow = styled.div`
@@ -169,6 +169,11 @@ export const MonthSelectionDropdownContainer = styled.div<{
         background-color: ${palette.solid.darkblue};
       }
     `};
+`;
+
+export const LeftAlignedButtonWrapper = styled.div`
+  display: flex;
+  justify-content: flex-start;
 `;
 
 export const BreakdownsSection = styled.div<{ disabled: boolean }>`

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -407,6 +407,17 @@ function MetricAvailability({ goToDefineMetrics }: MetricAvailabilityProps) {
                   </RadioButtonsWrapper>
                 </Styled.SettingRow>
               )}
+            {metricEnabled && (
+              <Styled.LeftAlignedButtonWrapper>
+                <Button
+                  label="Define Metric ->"
+                  onClick={goToDefineMetrics}
+                  labelColor="blue"
+                  noHover
+                  noSidePadding
+                />
+              </Styled.LeftAlignedButtonWrapper>
+            )}
           </Styled.SettingRowsContainer>
           {hasDisaggregations && (
             <Styled.BreakdownsSection disabled={!metricEnabled}>
@@ -515,7 +526,7 @@ function MetricAvailability({ goToDefineMetrics }: MetricAvailabilityProps) {
               })}
               {metricEnabled && (
                 <Button
-                  label="Define Metrics ->"
+                  label="Define Metric Breakdowns ->"
                   onClick={goToDefineMetrics}
                   labelColor="blue"
                   noHover

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -518,7 +518,9 @@ function MetricAvailability({ goToDefineMetrics }: MetricAvailabilityProps) {
           {metricEnabled && (
             <Styled.LeftAlignedButtonWrapper>
               <Button
-                label="Define Metrics ->"
+                label={`Define Metric ${
+                  hasDisaggregations ? `and Breakdowns ` : ``
+                }->`}
                 onClick={goToDefineMetrics}
                 labelColor="blue"
                 noHover

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -407,17 +407,6 @@ function MetricAvailability({ goToDefineMetrics }: MetricAvailabilityProps) {
                   </RadioButtonsWrapper>
                 </Styled.SettingRow>
               )}
-            {metricEnabled && (
-              <Styled.LeftAlignedButtonWrapper>
-                <Button
-                  label="Define Metric ->"
-                  onClick={goToDefineMetrics}
-                  labelColor="blue"
-                  noHover
-                  noSidePadding
-                />
-              </Styled.LeftAlignedButtonWrapper>
-            )}
           </Styled.SettingRowsContainer>
           {hasDisaggregations && (
             <Styled.BreakdownsSection disabled={!metricEnabled}>
@@ -524,16 +513,18 @@ function MetricAvailability({ goToDefineMetrics }: MetricAvailabilityProps) {
                   </Styled.DimensionsContainer>
                 );
               })}
-              {metricEnabled && (
-                <Button
-                  label="Define Metric Breakdowns ->"
-                  onClick={goToDefineMetrics}
-                  labelColor="blue"
-                  noHover
-                  noSidePadding
-                />
-              )}
             </Styled.BreakdownsSection>
+          )}
+          {metricEnabled && (
+            <Styled.LeftAlignedButtonWrapper>
+              <Button
+                label="Define Metrics ->"
+                onClick={goToDefineMetrics}
+                labelColor="blue"
+                noHover
+                noSidePadding
+              />
+            </Styled.LeftAlignedButtonWrapper>
           )}
         </Styled.InnerWrapper>
       </Styled.Wrapper>


### PR DESCRIPTION
## Description of the change

We received a request from CSG to include a link to define metrics (includes/excludes) on the top aggregate level metric for metrics with no breakdowns - because the top aggregate level metric will still have includes/excludes to define (and currently, we only show this link when a metric has breakdowns). This change moves the `Define Metrics ->` from within the `hasDisaggregations` conditional, so it will always appear when a metric is enabled. 

I also felt an itch to update the copy a little bit to "Define Metric and Breakdowns" or "Define Metric" depending on whether or not there are breakdowns - let me know your thoughts!

Metric w/ breakdowns:
<img width="1728" alt="Screenshot 2023-12-11 at 10 30 48 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/b5872230-5016-4fbd-aab0-96b0c684aaba">


Metric w/out breakdowns:
<img width="1728" alt="Screenshot 2023-12-11 at 10 30 37 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/ccacc639-e959-4768-9681-97d46f3886b4">



## Related issues

Closes #1093

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
