### PR TITLE
[Publisher] Admin Panel: Agency Provisioning - Superagency System Addition/Removal (6/n)

### DIFF
--- a/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
+++ b/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
@@ -17,7 +17,7 @@
 
 import MiniBarChart from "@justice-counts/common/components/DataViz/MiniBarChart";
 import {
-  AgencySystems,
+  AgencySystem,
   DataVizAggregateName,
 } from "@justice-counts/common/types";
 import { removeSnakeCase, slugify } from "@justice-counts/common/utils";
@@ -82,7 +82,7 @@ export const AgencyOverview = observer(() => {
     agencyOverviewVisibleCategoriesMetadata
   );
 
-  const [currentSystem, setCurrentSystem] = useState<AgencySystems | undefined>(
+  const [currentSystem, setCurrentSystem] = useState<AgencySystem | undefined>(
     availableSystems[0]
   );
 

--- a/agency-dashboard/src/stores/AgencyDataStore.ts
+++ b/agency-dashboard/src/stores/AgencyDataStore.ts
@@ -23,7 +23,7 @@ import {
 } from "@justice-counts/common/components/DataViz/utils";
 import {
   AgencySetting,
-  AgencySystems,
+  AgencySystem,
   DatapointsByMetric,
   DataVizAggregateName,
   Metric,
@@ -66,7 +66,7 @@ class AgencyDataStore {
     return this.agencySettingsBySettingType.HOMEPAGE_URL?.value;
   }
 
-  get agencySystems(): AgencySystems[] | undefined {
+  get agencySystems(): AgencySystem[] | undefined {
     return this.agency?.systems;
   }
 
@@ -263,8 +263,8 @@ class AgencyDataStore {
 
   agencySystemsWithData(
     visibleCategoriesMetadata: VisibleCategoriesMetadata
-  ): AgencySystems[] {
-    const agencySystems = new Set() as Set<AgencySystems>;
+  ): AgencySystem[] {
+    const agencySystems = new Set() as Set<AgencySystem>;
     const metricsWithData = this.getMetricsByAvailableCategoriesWithData(
       visibleCategoriesMetadata
     );

--- a/common/types.ts
+++ b/common/types.ts
@@ -22,19 +22,22 @@ export enum AgencyTeamMemberRole {
   READ_ONLY = "READ_ONLY",
 }
 
-export type AgencySystems =
-  | "LAW_ENFORCEMENT"
-  | "PROSECUTION"
-  | "DEFENSE"
-  | "COURTS_AND_PRETRIAL"
-  | "JAILS"
-  | "PRISONS"
-  | "SUPERVISION"
-  | "PAROLE"
-  | "PROBATION"
-  | "PRETRIAL_SUPERVISION"
-  | "OTHER_SUPERVISION"
-  | "SUPERAGENCY";
+export enum AgencySystems {
+  LAW_ENFORCEMENT = "LAW_ENFORCEMENT",
+  PROSECUTION = "PROSECUTION",
+  DEFENSE = "DEFENSE",
+  COURTS_AND_PRETRIAL = "COURTS_AND_PRETRIAL",
+  JAILS = "JAILS",
+  PRISONS = "PRISONS",
+  SUPERVISION = "SUPERVISION",
+  PAROLE = "PAROLE",
+  PROBATION = "PROBATION",
+  PRETRIAL_SUPERVISION = "PRETRIAL_SUPERVISION",
+  OTHER_SUPERVISION = "OTHER_SUPERVISION",
+  SUPERAGENCY = "SUPERAGENCY",
+}
+
+export type AgencySystem = `${AgencySystems}`;
 
 export type AgencyTeamMember = {
   user_account_id: number | null;
@@ -45,9 +48,9 @@ export type AgencyTeamMember = {
   role: AgencyTeamMemberRole;
 };
 
-export const SupervisionSystem: AgencySystems = "SUPERVISION";
+export const SupervisionSystem: AgencySystem = "SUPERVISION";
 
-export const SupervisionSubsystems: AgencySystems[] = [
+export const SupervisionSubsystems: AgencySystem[] = [
   "PAROLE",
   "PROBATION",
   "PRETRIAL_SUPERVISION",
@@ -83,7 +86,7 @@ export interface PublicUserAgency {
   id: number;
   name: string;
   settings: AgencySetting[];
-  systems: AgencySystems[];
+  systems: AgencySystem[];
 }
 
 export interface UserAgency {
@@ -93,7 +96,7 @@ export interface UserAgency {
   state: string;
   state_code: string;
   settings: AgencySetting[];
-  systems: AgencySystems[];
+  systems: AgencySystem[];
   team: AgencyTeamMember[];
   is_superagency: boolean;
   is_dashboard_enabled: boolean;
@@ -161,7 +164,7 @@ export type MetricConfigurationSettings = {
 export interface Metric {
   key: string;
   system: {
-    key: AgencySystems;
+    key: AgencySystem;
     display_name: string;
   };
   custom_frequency?: ReportFrequency;

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -304,6 +304,7 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
         agencyProvisioningUpdates.state_code?.toLocaleLowerCase() !==
           selectedAgency.state_code?.toLocaleLowerCase()
       : Boolean(agencyProvisioningUpdates.state_code);
+
     /**
      * Note: the following checks are only relevant to existing agency updates, since the 'Save' button for creating a new
      * agency only requires the above `name` and `state_code` to be enabled.

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -669,10 +669,11 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                         type="checkbox"
                         onChange={() => {
                           updateSuperagencyStatusAndSystems();
+                          setShowSelectionBox(undefined);
+                          // Reset child agency selections
                           updateSuperagencyID(null);
                           setSelectedChildAgencyIDs(new Set());
                           setIsChildAgencySelected(false);
-                          setShowSelectionBox(undefined);
                         }}
                         checked={Boolean(
                           agencyProvisioningUpdates.is_superagency
@@ -688,11 +689,12 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                           setIsChildAgencySelected((prev) => !prev);
                           setSelectedChildAgencyIDs(new Set());
                           setShowSelectionBox(undefined);
-
                           if (agencyProvisioningUpdates.is_superagency) {
+                            // Uncheck Superagency checkbox and remove Superagency system
                             updateSuperagencyStatusAndSystems();
                           }
                           if (isChildAgencySelected) {
+                            // Reset selected superagency ID when unchecked
                             updateSuperagencyID(null);
                           }
                         }}

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -292,14 +292,16 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
      * the "Superagency" system should be added to the agency. When an agency is no longer checked as a superagency,
      * the "Superagency" system should be removed from the agency.
      */
-    const updateSuperagencyStatusAndSystems = () => {
+    const toggleSuperagencyStatusAndSystems = () => {
       const updatedSystemsSet = new Set(selectedSystems);
+      // If "Superagency" is currently checked, uncheck it and remove the "Superagency" system
       if (agencyProvisioningUpdates.is_superagency) {
         updatedSystemsSet.delete(AgencySystems.SUPERAGENCY);
         setSelectedSystems(updatedSystemsSet);
         updateIsSuperagency(false);
         return;
       }
+      // If "Superagency" is not currently checked, check it and add the "Superagency" system
       updatedSystemsSet.add(AgencySystems.SUPERAGENCY);
       setSelectedSystems(updatedSystemsSet);
       updateIsSuperagency(true);
@@ -602,7 +604,7 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                           )}
                           updateSelections={({ id }) => {
                             if (id === AgencySystems.SUPERAGENCY) {
-                              updateSuperagencyStatusAndSystems();
+                              toggleSuperagencyStatusAndSystems();
                               return;
                             }
                             setSelectedSystems((prev) =>
@@ -668,7 +670,7 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                         name="superagency"
                         type="checkbox"
                         onChange={() => {
-                          updateSuperagencyStatusAndSystems();
+                          toggleSuperagencyStatusAndSystems();
                           setShowSelectionBox(undefined);
                           // Reset child agency selections
                           updateSuperagencyID(null);
@@ -691,7 +693,7 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                           setShowSelectionBox(undefined);
                           if (agencyProvisioningUpdates.is_superagency) {
                             // Uncheck Superagency checkbox and remove Superagency system
-                            updateSuperagencyStatusAndSystems();
+                            toggleSuperagencyStatusAndSystems();
                           }
                           if (isChildAgencySelected) {
                             // Reset selected superagency ID when unchecked

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -38,12 +38,12 @@ export const UserProvisioningOverview = observer(() => {
     resetUserProvisioningUpdates,
   } = adminPanelStore;
 
+  const [selectedUserID, setSelectedUserID] = useState<string | number>();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [searchInput, setSearchInput] = useState<string>("");
   const [filteredUsers, setFilteredUsers] = useState<UserWithAgenciesByID[]>(
     []
   );
-  const [selectedUserID, setSelectedUserID] = useState<string | number>();
 
   const searchByKeys = ["name", "email", "id"] as UserKey[];
 

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -38,12 +38,12 @@ export const UserProvisioningOverview = observer(() => {
     resetUserProvisioningUpdates,
   } = adminPanelStore;
 
-  const [selectedUserID, setSelectedUserID] = useState<string | number>();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [searchInput, setSearchInput] = useState<string>("");
   const [filteredUsers, setFilteredUsers] = useState<UserWithAgenciesByID[]>(
     []
   );
+  const [selectedUserID, setSelectedUserID] = useState<string | number>();
 
   const searchByKeys = ["name", "email", "id"] as UserKey[];
 

--- a/publisher/src/components/AdminPanel/types.ts
+++ b/publisher/src/components/AdminPanel/types.ts
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import {
-  AgencySystems,
+  AgencySystem,
   AgencyTeamMember,
   AgencyTeamMemberRole,
 } from "@justice-counts/common/types";
@@ -63,7 +63,7 @@ export type SelectionInputBoxType = `${SelectionInputBoxTypes}`;
 export type Agency = {
   id: string | number;
   name: string;
-  systems: AgencySystems[];
+  systems: AgencySystem[];
   state: StateCodeValue;
   state_code: StateCodeKey | null;
   fips_county_code: FipsCountyCodeKey | null;
@@ -86,7 +86,7 @@ export type AgencyWithTeamByID = Omit<Agency, "team"> & {
 
 export type AgencyResponse = {
   agencies: Agency[];
-  systems: AgencySystems[];
+  systems: AgencySystem[];
 };
 
 export const AgencyProvisioningSettings = {
@@ -102,7 +102,7 @@ export type AgencyProvisioningUpdates = {
   name: string;
   state_code: StateCodeKey | null;
   fips_county_code: FipsCountyCodeKey | null;
-  systems: AgencySystems[];
+  systems: AgencySystem[];
   is_dashboard_enabled: boolean | null;
   super_agency_id: number | null; // If this is set, then the agency is a child agency belonging to the superagency w/ this ID
   is_superagency: boolean | null;

--- a/publisher/src/components/AdminPanel/types.ts
+++ b/publisher/src/components/AdminPanel/types.ts
@@ -138,8 +138,6 @@ export const userRoles = [
   "READ_ONLY",
 ] as const;
 
-// export type AgencyTeamMemberRole = (typeof userRoles)[number];
-
 export type UserProvisioningUpdates = {
   name: string;
   email: string;

--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -21,7 +21,7 @@ import { HeaderBar } from "@justice-counts/common/components/HeaderBar";
 import { showToast } from "@justice-counts/common/components/Toast";
 import { useWindowWidth } from "@justice-counts/common/hooks";
 import {
-  AgencySystems,
+  AgencySystem,
   AgencyTeamMemberRole,
   ReportOverview,
   SupervisionSubsystems,
@@ -64,7 +64,7 @@ export type UploadedFile = {
     name: string;
     role: AgencyTeamMemberRole;
   };
-  system: AgencySystems;
+  system: AgencySystem;
   status: UploadedFileStatus | null;
 };
 
@@ -109,7 +109,7 @@ export const DataUpload: React.FC = observer(() => {
     useState<ErrorsWarningsMetrics>();
   const [selectedFile, setSelectedFile] = useState<File>();
   const [selectedSystem, setSelectedSystem] = useState<
-    AgencySystems | undefined
+    AgencySystem | undefined
   >();
   const [newAndUpdatedReports, setNewAndUpdatedReports] = useState<{
     newReports: ReportOverview[];
@@ -131,7 +131,7 @@ export const DataUpload: React.FC = observer(() => {
 
   const handleFileUpload = async (
     file: File,
-    system: AgencySystems
+    system: AgencySystem
   ): Promise<void> => {
     if (file && system && agencyId) {
       setSelectedFile(file);
@@ -198,7 +198,7 @@ export const DataUpload: React.FC = observer(() => {
     }
   };
 
-  const handleSystemSelection = (file: File, system: AgencySystems) => {
+  const handleSystemSelection = (file: File, system: AgencySystem) => {
     setIsLoading(true);
     setSelectedSystem(system);
     handleFileUpload(file, system);

--- a/publisher/src/components/DataUpload/SystemSelection.tsx
+++ b/publisher/src/components/DataUpload/SystemSelection.tsx
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { AgencySystems } from "@justice-counts/common/types";
+import { AgencySystem } from "@justice-counts/common/types";
 import React from "react";
 
 import { removeSnakeCase } from "../../utils";
@@ -32,8 +32,8 @@ import {
 
 type SystemSelectionProps = {
   selectedFile: File;
-  userSystems: AgencySystems[];
-  handleSystemSelection: (file: File, system: AgencySystems) => void;
+  userSystems: AgencySystem[];
+  handleSystemSelection: (file: File, system: AgencySystem) => void;
 };
 
 export const SystemSelection: React.FC<SystemSelectionProps> = ({

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -17,7 +17,7 @@
 
 import checkIcon from "@justice-counts/common/assets/status-check-icon.png";
 import { Button } from "@justice-counts/common/components/Button";
-import { AgencySystems, ReportOverview } from "@justice-counts/common/types";
+import { AgencySystem, ReportOverview } from "@justice-counts/common/types";
 import React, { Fragment } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
@@ -55,7 +55,7 @@ import {
 
 type UploadErrorsWarningsProps = {
   errorsWarningsMetrics: ErrorsWarningsMetrics;
-  selectedSystem: AgencySystems | undefined;
+  selectedSystem: AgencySystem | undefined;
   resetToNewUpload: () => void;
   fileName?: string;
   newAndUpdatedReports: {

--- a/publisher/src/components/DataUpload/UploadFile.tsx
+++ b/publisher/src/components/DataUpload/UploadFile.tsx
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import { showToast } from "@justice-counts/common/components/Toast";
-import { AgencySystems } from "@justice-counts/common/types";
+import { AgencySystem } from "@justice-counts/common/types";
 import React, { Fragment, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 
@@ -36,10 +36,10 @@ import {
 } from ".";
 
 type UploadFileProps = {
-  userSystems: AgencySystems[];
+  userSystems: AgencySystem[];
   setIsLoading: React.Dispatch<React.SetStateAction<boolean>>;
   setSelectedFile: React.Dispatch<React.SetStateAction<File | undefined>>;
-  handleFileUpload: (file: File, system: AgencySystems) => Promise<void>;
+  handleFileUpload: (file: File, system: AgencySystem) => Promise<void>;
 };
 
 export const UploadFile: React.FC<UploadFileProps> = ({

--- a/publisher/src/components/DataUpload/UploadedFiles.tsx
+++ b/publisher/src/components/DataUpload/UploadedFiles.tsx
@@ -23,7 +23,7 @@ import {
 import { Button } from "@justice-counts/common/components/Button";
 import { showToast } from "@justice-counts/common/components/Toast";
 import {
-  AgencySystems,
+  AgencySystem,
   AgencyTeamMemberRole,
 } from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
@@ -64,7 +64,7 @@ export const UploadedFileRow: React.FC<{
     badgeText: string;
     dateUploaded: string;
     dateIngested: string;
-    system?: AgencySystems;
+    system?: AgencySystem;
     uploadedByName: string;
     uploadedByRole: AgencyTeamMemberRole;
   };
@@ -287,7 +287,7 @@ export const UploadedFiles: React.FC = observer(() => {
       system: formatSystemName(file.system, {
         allUserSystems: currentAgency?.systems,
         hideCombined: true,
-      }) as AgencySystems,
+      }) as AgencySystem,
       uploadedByName: file.uploaded_by_v2.name,
       uploadedByRole: file.uploaded_by_v2.role,
     };

--- a/publisher/src/components/DataViz/MetricsDataChart.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.tsx
@@ -28,7 +28,7 @@ import {
 } from "@justice-counts/common/components/Dropdown";
 import { MIN_DESKTOP_WIDTH } from "@justice-counts/common/components/GlobalStyles";
 import { useWindowWidth } from "@justice-counts/common/hooks";
-import { AgencySystems, ReportFrequency } from "@justice-counts/common/types";
+import { AgencySystem, ReportFrequency } from "@justice-counts/common/types";
 import { downloadMetricData } from "@justice-counts/common/utils";
 import { frequencyString } from "@justice-counts/common/utils/helperUtils";
 import FileSaver from "file-saver";
@@ -250,7 +250,7 @@ export const MetricsDataChart: React.FC = observer(() => {
                         selected={currentMetric.key === metric.key}
                         onClick={() =>
                           setSettingsSearchParams({
-                            system: system as AgencySystems,
+                            system: system as AgencySystem,
                             metric: metric.key,
                           })
                         }

--- a/publisher/src/components/Home/types.ts
+++ b/publisher/src/components/Home/types.ts
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import {
-  AgencySystems,
+  AgencySystem,
   Metric,
   Report,
   ReportFrequency,
@@ -84,4 +84,4 @@ export type TaskCardMetadataValueConfigurationGroup = {
   addDataConfigureMetricsTaskCardMetadatas: TaskCardMetadata[];
 };
 
-export type SystemSelectionOptions = AgencySystems | "ALL";
+export type SystemSelectionOptions = AgencySystem | "ALL";

--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { AgencySystems } from "@justice-counts/common/types";
+import { AgencySystem } from "@justice-counts/common/types";
 import { frequencyString } from "@justice-counts/common/utils/helperUtils";
 import { observer } from "mobx-react-lite";
 import React from "react";
@@ -41,7 +41,7 @@ export const MetricsOverview = observer(() => {
 
   const { system: systemSearchParam } = settingsSearchParams;
 
-  const handleSystemClick = (option: AgencySystems) => {
+  const handleSystemClick = (option: AgencySystem) => {
     setSettingsSearchParams(
       {
         system: option,

--- a/publisher/src/components/Reports/DataEntryForm.tsx
+++ b/publisher/src/components/Reports/DataEntryForm.tsx
@@ -19,7 +19,7 @@ import { Button } from "@justice-counts/common/components/Button";
 import { HeaderBar } from "@justice-counts/common/components/HeaderBar";
 import { MiniLoader } from "@justice-counts/common/components/MiniLoader";
 import { showToast } from "@justice-counts/common/components/Toast";
-import { AgencySystems, Report } from "@justice-counts/common/types";
+import { AgencySystem, Report } from "@justice-counts/common/types";
 import { runInAction } from "mobx";
 import { observer } from "mobx-react-lite";
 import React, { Fragment, useEffect, useRef, useState } from "react";
@@ -325,7 +325,7 @@ const DataEntryForm: React.FC<{
                   <Fragment key={system}>
                     {showMetricSectionTitles && (
                       <MetricSystemTitle firstTitle={systemIndex === 0}>
-                        {formatSystemName(system as AgencySystems, {
+                        {formatSystemName(system as AgencySystem, {
                           allUserSystems: currentAgency?.systems,
                         })}
                       </MetricSystemTitle>

--- a/publisher/src/components/Reports/PublishConfirmationSummaryPanel.tsx
+++ b/publisher/src/components/Reports/PublishConfirmationSummaryPanel.tsx
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import errorIcon from "@justice-counts/common/assets/status-error-icon.png";
-import { AgencySystems, Metric } from "@justice-counts/common/types";
+import { AgencySystem, Metric } from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
 import React from "react";
 import { useParams } from "react-router-dom";
@@ -82,7 +82,7 @@ const PublishConfirmationSummaryPanel: React.FC<{
             <React.Fragment key={system}>
               {showMetricSectionTitles && (
                 <MetricSummarySectionTitle>
-                  {formatSystemName(system as AgencySystems, {
+                  {formatSystemName(system as AgencySystem, {
                     allUserSystems: currentAgency?.systems,
                   })}
                 </MetricSummarySectionTitle>

--- a/publisher/src/components/Reports/ReportSummaryPanel.tsx
+++ b/publisher/src/components/Reports/ReportSummaryPanel.tsx
@@ -22,7 +22,7 @@ import {
   palette,
   typography,
 } from "@justice-counts/common/components/GlobalStyles";
-import { AgencySystems, Metric } from "@justice-counts/common/types";
+import { AgencySystem, Metric } from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
 import React from "react";
 import { useParams } from "react-router-dom";
@@ -263,7 +263,7 @@ const ReportSummaryPanel: React.FC<{
             <React.Fragment key={system}>
               {showMetricSectionTitles ? (
                 <MetricSummarySectionTitle>
-                  {formatSystemName(system as AgencySystems, {
+                  {formatSystemName(system as AgencySystem, {
                     allUserSystems: currentAgency?.systems,
                   })}
                 </MetricSummarySectionTitle>

--- a/publisher/src/components/Settings/AgencySettingsSupervisions.tsx
+++ b/publisher/src/components/Settings/AgencySettingsSupervisions.tsx
@@ -17,7 +17,7 @@
 
 import blueCheck from "@justice-counts/common/assets/status-check-icon.png";
 import { Button } from "@justice-counts/common/components/Button";
-import { AgencySystems } from "@justice-counts/common/types";
+import { AgencySystem } from "@justice-counts/common/types";
 import React, { useState } from "react";
 import { useParams } from "react-router-dom";
 
@@ -39,7 +39,7 @@ import {
 } from "./AgencySettings.styles";
 import { AgencySettingsEditModeModal } from "./AgencySettingsEditModeModal";
 
-const supervisionAgencySystems: { label: string; value: AgencySystems }[] = [
+const supervisionAgencySystems: { label: string; value: AgencySystem }[] = [
   { label: "Parole", value: "PAROLE" },
   {
     label: "Probation",
@@ -88,12 +88,12 @@ export const AgencySettingsSupervisions: React.FC<{
     removeEditMode();
   };
 
-  const handleSetSupervisionSystemsToSave = (value: AgencySystems) => {
+  const handleSetSupervisionSystemsToSave = (value: AgencySystem) => {
     if (isSettingInEditMode) {
       setSupervisionSystemsToSave(systemsToSave(value));
     }
   };
-  const systemsToSave = (systemToToggle: AgencySystems): AgencySystems[] => {
+  const systemsToSave = (systemToToggle: AgencySystem): AgencySystem[] => {
     if (!supervisionSystemsToSave) return [systemToToggle];
     return supervisionSystemsToSave.includes(systemToToggle)
       ? supervisionSystemsToSave.filter((system) => system !== systemToToggle)
@@ -154,7 +154,7 @@ export const AgencySettingsSupervisions: React.FC<{
                     type="checkbox"
                     checked={
                       supervisionSystemsToSave?.includes(
-                        value as AgencySystems
+                        value as AgencySystem
                       ) || false
                     }
                     onChange={() => handleSetSupervisionSystemsToSave(value)}

--- a/publisher/src/components/Settings/types.ts
+++ b/publisher/src/components/Settings/types.ts
@@ -15,10 +15,10 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { AgencySystems } from "@justice-counts/common/types";
+import { AgencySystem } from "@justice-counts/common/types";
 
 export type SettingsSearchParams = {
-  system?: AgencySystems;
+  system?: AgencySystem;
   metric?: string;
 };
 

--- a/publisher/src/components/Settings/utils.ts
+++ b/publisher/src/components/Settings/utils.ts
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { AgencySystems } from "@justice-counts/common/types";
+import { AgencySystem } from "@justice-counts/common/types";
 
 import { SettingsSearchParams } from "./types";
 
@@ -30,7 +30,7 @@ export const getSettingsSearchParams = (
   params: URLSearchParams
 ): SettingsSearchParams => {
   const system =
-    (params.get("system")?.toUpperCase() as AgencySystems) || undefined;
+    (params.get("system")?.toUpperCase() as AgencySystem) || undefined;
   const metric = params.get("metric")?.toUpperCase() || undefined;
 
   return { system, metric };

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import {
-  AgencySystems,
+  AgencySystem,
   AgencyTeamMember,
   AgencyTeamMemberRole,
 } from "@justice-counts/common/types";
@@ -73,7 +73,7 @@ class AdminPanelStore {
 
   agenciesByID: Record<string, AgencyWithTeamByID[]>;
 
-  systems: AgencySystems[];
+  systems: AgencySystem[];
 
   userProvisioningUpdates: UserProvisioningUpdates;
 
@@ -266,7 +266,7 @@ class AdminPanelStore {
       lowercaseCountyCode || null;
   }
 
-  updateSystems(systems: AgencySystems[]) {
+  updateSystems(systems: AgencySystem[]) {
     this.agencyProvisioningUpdates.systems = systems;
   }
 

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -424,6 +424,22 @@ class AdminPanelStore {
       Object.values(obj).flatMap((item) => item)
     );
   }
+
+  /**
+   * Updates a set of selections by either adding or removing a specified item.
+   * @param prevSet - The previous set of selected items to update
+   * @param item - The item within the set to be added or removed depending on whether or not it already exists within the set
+   * @returns An updated set of selected items after the addition or removal operation.
+   */
+  static toggleAddRemoveSetItem<T>(prevSet: Set<T>, item: T): Set<T> {
+    const updatedSet = new Set(prevSet);
+    if (updatedSet.has(item)) {
+      updatedSet.delete(item);
+    } else {
+      updatedSet.add(item);
+    }
+    return updatedSet;
+  }
 }
 
 export default AdminPanelStore;

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -424,22 +424,6 @@ class AdminPanelStore {
       Object.values(obj).flatMap((item) => item)
     );
   }
-
-  /**
-   * Updates a set of selections by either adding or removing a specified item.
-   * @param prevSet - The previous set of selected items to update
-   * @param item - The item within the set to be added or removed depending on whether or not it already exists within the set
-   * @returns An updated set of selected items after the addition or removal operation.
-   */
-  static toggleAddRemoveSetItem<T>(prevSet: Set<T>, item: T): Set<T> {
-    const updatedSet = new Set(prevSet);
-    if (updatedSet.has(item)) {
-      updatedSet.delete(item);
-    } else {
-      updatedSet.add(item);
-    }
-    return updatedSet;
-  }
 }
 
 export default AdminPanelStore;

--- a/publisher/src/stores/AgencyStore.ts
+++ b/publisher/src/stores/AgencyStore.ts
@@ -18,7 +18,7 @@
 import { showToast } from "@justice-counts/common/components/Toast";
 import {
   AgencySetting,
-  AgencySystems as AgencySystem,
+  AgencySystem,
   AgencyTeamMember,
   AgencyTeamMemberRole,
   UserAgency,

--- a/publisher/src/stores/HomeStore.ts
+++ b/publisher/src/stores/HomeStore.ts
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import {
-  AgencySystems,
+  AgencySystem,
   Metric,
   Report,
   ReportFrequency,
@@ -591,7 +591,7 @@ class HomeStore {
    */
   supervisionSubsystemsWithEnabledMetrics(system: SystemSelectionOptions) {
     const isSupervisionSubsystem = Boolean(
-      SupervisionSubsystems.includes(system.toUpperCase() as AgencySystems)
+      SupervisionSubsystems.includes(system.toUpperCase() as AgencySystem)
     );
     if (!isSupervisionSubsystem) return true;
 

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -17,7 +17,7 @@
 
 import { showToast } from "@justice-counts/common/components/Toast";
 import {
-  AgencySystems,
+  AgencySystem,
   FormError,
   Metric,
   MetricConfigurationSettings,
@@ -169,7 +169,7 @@ class MetricConfigStore {
     });
   };
 
-  getMetricsBySystem = (systemName: AgencySystems | undefined) => {
+  getMetricsBySystem = (systemName: AgencySystem | undefined) => {
     if (systemName) {
       const metrics = Object.entries(this.metrics).reduce(
         (filteredMetrics, [systemMetricKey, metric]) => {
@@ -353,7 +353,7 @@ class MetricConfigStore {
   };
 
   initializeMetric = (
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string,
     metricInfo: MetricInfo
   ) => {
@@ -366,7 +366,7 @@ class MetricConfigStore {
   };
 
   initializeMetricDefinitionSetting = (
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string,
     includesExcludesKey: string,
     metricDefinitionSettings: MetricConfigurationSettings[]
@@ -397,7 +397,7 @@ class MetricConfigStore {
   };
 
   initializeDisaggregation = (
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string,
     disaggregationKey: string,
     disaggregationData: Pick<MetricDisaggregations, "display_name" | "enabled">
@@ -416,7 +416,7 @@ class MetricConfigStore {
   };
 
   initializeDimension = (
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string,
     disaggregationKey: string,
     dimensionKey: string,
@@ -462,7 +462,7 @@ class MetricConfigStore {
   };
 
   initializeDimensionDefinitionSetting = (
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string,
     disaggregationKey: string,
     dimensionKey: string,
@@ -514,7 +514,7 @@ class MetricConfigStore {
   };
 
   initializeDimensionContexts = (
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string,
     disaggregationKey: string,
     dimensionKey: string,
@@ -548,7 +548,7 @@ class MetricConfigStore {
   };
 
   initializeContext = (
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string,
     contextKey: string,
     contextData: {
@@ -572,7 +572,7 @@ class MetricConfigStore {
   };
 
   updateMetricEnabledStatus = (
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string,
     enabledStatus: boolean
   ): MetricSettings => {
@@ -592,7 +592,7 @@ class MetricConfigStore {
   };
 
   updateMetricReportFrequency = (
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string,
     update: ReportFrequencyUpdate
   ) => {
@@ -619,7 +619,7 @@ class MetricConfigStore {
 
   /** Allows a supervision agency to specify whether or not a metric is reported as disaggregated by supervision subsystems */
   updateDisaggregatedBySupervisionSubsystems = (
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string,
     status: boolean
   ) => {
@@ -639,7 +639,7 @@ class MetricConfigStore {
   };
 
   updateMetricDefinitionSetting = (
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string,
     includesExcludesKey: string,
     settingKey: string,
@@ -663,7 +663,7 @@ class MetricConfigStore {
   };
 
   updateDisaggregationEnabledStatus = (
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string,
     disaggregationKey: string,
     enabledStatus: boolean
@@ -704,7 +704,7 @@ class MetricConfigStore {
   };
 
   updateDimensionEnabledStatus = (
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string,
     disaggregationKey: string,
     dimensionKey: string,
@@ -765,7 +765,7 @@ class MetricConfigStore {
   };
 
   updateDimensionContexts = (
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string,
     disaggregationKey: string,
     dimensionKey: string,
@@ -805,7 +805,7 @@ class MetricConfigStore {
   };
 
   updateDimensionDefinitionSetting = (
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string,
     disaggregationKey: string,
     dimensionKey: string,
@@ -846,7 +846,7 @@ class MetricConfigStore {
   };
 
   updateContextValue = (
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string,
     contextKey: string,
     contextType: MetricContext["type"] | undefined,
@@ -880,7 +880,7 @@ class MetricConfigStore {
     };
   };
 
-  getEthnicitiesByRace = (system: AgencySystems, metricKey: string) => {
+  getEthnicitiesByRace = (system: AgencySystem, metricKey: string) => {
     const systemMetricKey = MetricConfigStore.getSystemMetricKey(
       system,
       metricKey
@@ -911,7 +911,7 @@ class MetricConfigStore {
   updateAllRaceEthnicitiesToDefaultState = (
     state: StateKeys,
     gridStates: RaceEthnicitiesGridStates,
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string
   ): UpdatedDisaggregation => {
     const ethnicitiesByRace = this.getEthnicitiesByRace(system, metricKey);
@@ -994,7 +994,7 @@ class MetricConfigStore {
     enabled: boolean,
     state: StateKeys,
     gridStates: RaceEthnicitiesGridStates,
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string
   ): UpdatedDisaggregation => {
     const ethnicitiesByRace = this.getEthnicitiesByRace(system, metricKey);
@@ -1045,7 +1045,7 @@ class MetricConfigStore {
     racesStatusObject: { [key: string]: boolean },
     state: StateKeys,
     gridStates: RaceEthnicitiesGridStates,
-    system: AgencySystems,
+    system: AgencySystem,
     metricKey: string
   ): UpdatedDisaggregation => {
     const ethnicitiesByRace = this.getEthnicitiesByRace(system, metricKey);

--- a/publisher/src/stores/ReportStore.ts
+++ b/publisher/src/stores/ReportStore.ts
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import {
-  AgencySystems,
+  AgencySystem,
   Metric,
   Report,
   ReportOverview,
@@ -456,7 +456,7 @@ class ReportStore {
     return metricsBySystem;
   };
 
-  getMetricsBySystem = (system: AgencySystems | undefined) => {
+  getMetricsBySystem = (system: AgencySystem | undefined) => {
     if (system) {
       return this.metricsBySystem[system];
     }

--- a/publisher/src/utils/helperUtils.ts
+++ b/publisher/src/utils/helperUtils.ts
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import {
-  AgencySystems,
+  AgencySystem,
   MetricContext,
   ReportEditor,
   SupervisionSubsystems,
@@ -254,7 +254,7 @@ export function removeAgencyFromPath(location: string) {
  */
 
 export const formatSystemName = (
-  systemName: AgencySystems,
+  systemName: AgencySystem,
   options?: FormatSystemNameOptions
 ) => {
   if (
@@ -274,7 +274,7 @@ export const formatSystemName = (
 };
 
 type FormatSystemNameOptions = {
-  allUserSystems?: AgencySystems[];
+  allUserSystems?: AgencySystem[];
   hideCombined?: boolean;
 };
 


### PR DESCRIPTION
## Description of the change

Implements special handling for marking an agency as a Superagency and/or adding/removing a `Superagency` system. When a user marks the agency as a Superagency by clicking on the checkbox, the `Superagency` system will automatically be added the the list of systems for the agency. When a user unchecks the `Superagency` checkbox, the `Superagency` system will be removed. Similarly, when you add or remove a superagency system, the corresponding checkmark will toggle checked/unchecked.

Note: I realized we didn't have constants for agency systems, so I added an enum and updated all dependent components - hence the large # of files changed. Feel free to just focus on the `AgencyProvisioning.tsx` file as the other 24 files are type name updates.

Much easier to show visually than describe in words:

https://github.com/Recidiviz/justice-counts/assets/59492998/a3df29e4-ba7b-4961-b197-6ae879bf17f9



## Related issues

Closes #1051

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
