### PR TITLE
include `user_account_id` in request when creating new users from the admin panel

### DIFF
--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -35,6 +35,7 @@ export const UserProvisioningOverview = observer(() => {
     updateEmail,
     updateUsername,
     updateUserAgencies,
+    updateUserAccountId,
     resetUserProvisioningUpdates,
   } = adminPanelStore;
 
@@ -66,6 +67,7 @@ export const UserProvisioningOverview = observer(() => {
   const editUser = (userID: string | number) => {
     const selectedUser = usersByID[userID][0];
     setSelectedUserID(userID);
+    updateUserAccountId(+userID);
     updateEmail(selectedUser.email);
     updateUsername(selectedUser.name);
     updateUserAgencies(Object.keys(selectedUser.agencies).map((id) => +id));

--- a/publisher/src/components/AdminPanel/types.ts
+++ b/publisher/src/components/AdminPanel/types.ts
@@ -144,6 +144,7 @@ export const userRoles = [
 export type UserRole = (typeof userRoles)[number];
 
 export type UserProvisioningUpdates = {
+  user_account_id?: number | string | null;
   name: string;
   email: string;
   agency_ids: number[];

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -40,6 +40,7 @@ import { groupBy } from "../utils";
 import API from "./API";
 
 const initialEmptyUserProvisioningUpdates = {
+  user_account_id: null,
   name: "",
   email: "",
   agency_ids: [],
@@ -195,6 +196,10 @@ class AdminPanelStore {
 
   updateEmail(email: string) {
     this.userProvisioningUpdates.email = email;
+  }
+
+  updateUserAccountId(id: number) {
+    this.userProvisioningUpdates.user_account_id = id;
   }
 
   updateUserAgencies(agencies: number[]) {


### PR DESCRIPTION
## Description of the change

Sends over `user_account_id` in admin panel requests to create new users ([companion BE PR](https://github.com/Recidiviz/recidiviz-data/pull/26167))



## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [x] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
