### PR TITLE
[Publisher] Admin Panel: Create User/Agency from opposite flows

### DIFF
--- a/common/components/DelayedRender/DelayedRender.tsx
+++ b/common/components/DelayedRender/DelayedRender.tsx
@@ -1,0 +1,32 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2023 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import { PropsWithChildren, useEffect, useState } from "react";
+
+export const DelayedRender: React.FC<{ delay: number } & PropsWithChildren> = ({
+  delay,
+  children,
+}) => {
+  const [delayed, setDelayed] = useState(true);
+
+  useEffect(() => {
+    const timeout = setTimeout(() => setDelayed(false), delay);
+    return () => clearTimeout(timeout);
+  }, []);
+
+  return !delayed ? children : null;
+};

--- a/common/components/DelayedRender/DelayedRender.tsx
+++ b/common/components/DelayedRender/DelayedRender.tsx
@@ -26,7 +26,7 @@ export const DelayedRender: React.FC<{ delay: number } & PropsWithChildren> = ({
   useEffect(() => {
     const timeout = setTimeout(() => setDelayed(false), delay);
     return () => clearTimeout(timeout);
-  }, []);
+  }, [delay]);
 
   return !delayed ? children : null;
 };

--- a/common/components/DelayedRender/index.ts
+++ b/common/components/DelayedRender/index.ts
@@ -1,0 +1,18 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2023 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+export * from "./DelayedRender";

--- a/publisher/src/components/AdminPanel/AdminPanel.styles.tsx
+++ b/publisher/src/components/AdminPanel/AdminPanel.styles.tsx
@@ -79,13 +79,15 @@ export const ScrollableContainer = styled.div`
 
 export const ModalWrapper = styled.div``;
 
-export const ModalContainer = styled.div`
+export const ModalContainer = styled.div<{ offScreen?: boolean }>`
   height: 90vh;
   width: 50vw;
   background: ${palette.solid.white};
   border-radius: 4px;
   padding: 32px 32px 100px 32px;
   position: relative;
+  transform: ${({ offScreen }) => (offScreen ? `translateX(-70vw)` : `none`)};
+  transition: transform 0.6s ease;
 `;
 
 export const ModalTitle = styled.div<{ noBottomMargin?: boolean }>`

--- a/publisher/src/components/AdminPanel/AdminPanel.test.tsx
+++ b/publisher/src/components/AdminPanel/AdminPanel.test.tsx
@@ -55,6 +55,10 @@ jest.mock("react-router-dom", () => ({
   }),
 }));
 
+beforeEach(() => {
+  adminPanelStore.loading = false;
+});
+
 test("AdminPanel renders with the expected elements in the default User Provisioning view", async () => {
   runInAction(() => {
     adminPanelStore.usersByID = usersByID;

--- a/publisher/src/components/AdminPanel/AdminPanel.tsx
+++ b/publisher/src/components/AdminPanel/AdminPanel.tsx
@@ -55,7 +55,9 @@ export const AdminPanel = observer(() => {
   ];
 
   useEffect(
-    () => fetchUsersAndAgencies(),
+    () => {
+      fetchUsersAndAgencies();
+    },
     /** Refetch users and agencies when switching between User/Agency Provisioning tabs */
     [currentProvisioningView, fetchUsersAndAgencies]
   );

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -19,8 +19,8 @@ import { Button } from "@justice-counts/common/components/Button";
 import { Dropdown } from "@justice-counts/common/components/Dropdown";
 import { MiniLoader } from "@justice-counts/common/components/MiniLoader";
 import {
-  TabOption,
   TabbedBar,
+  TabOption,
 } from "@justice-counts/common/components/TabbedBar";
 import {
   AgencySystem,

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -969,7 +969,7 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                           </Styled.ActionButton>
                         )}
 
-                        {/* Create New User Button (TODO(#1058)) */}
+                        {/* Create New User Button */}
                         <Styled.ActionButton onClick={openSecondaryModal}>
                           Create New User
                         </Styled.ActionButton>

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -48,6 +48,7 @@ import {
   SaveConfirmationTypes,
   SelectionInputBoxType,
   SelectionInputBoxTypes,
+  Setting,
   StateCodeKey,
   StateCodesToStateNames,
   userRoles,
@@ -56,7 +57,12 @@ import {
 import * as Styled from "./AdminPanel.styles";
 
 export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
-  ({ selectedIDToEdit, closeModal }) => {
+  ({
+    selectedIDToEdit,
+    activeSecondaryModal,
+    openSecondaryModal,
+    closeModal,
+  }) => {
     const { adminPanelStore } = useStore();
     const {
       users,
@@ -170,6 +176,9 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
           })),
         ]
       : [];
+
+    console.log("availableTeamMembers", availableTeamMembers);
+    console.log("currentTeamMembers", currentTeamMembers);
 
     /** Whether or not we are performing an add/delete action on a list of users/team members */
     const isAddUserAction =
@@ -438,7 +447,7 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
     }, [selectedAgency, agencyProvisioningUpdates, getCSGTeamMembersIDToRoles]);
 
     return (
-      <Styled.ModalContainer>
+      <Styled.ModalContainer offScreen={activeSecondaryModal === Setting.USERS}>
         {showSaveConfirmation.show ? (
           <SaveConfirmation
             type={showSaveConfirmation.type}
@@ -950,9 +959,11 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                         )}
 
                         {/* Create New User Button (TODO(#1058)) */}
-                        <Styled.ActionButton>
-                          Create New User
-                        </Styled.ActionButton>
+                        {activeSecondaryModal !== Setting.AGENCIES && (
+                          <Styled.ActionButton onClick={openSecondaryModal}>
+                            Create New User
+                          </Styled.ActionButton>
+                        )}
                       </Styled.FormActions>
                     </Styled.InputLabelWrapper>
 

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -18,7 +18,10 @@
 import { Button } from "@justice-counts/common/components/Button";
 import { Dropdown } from "@justice-counts/common/components/Dropdown";
 import { MiniLoader } from "@justice-counts/common/components/MiniLoader";
-import { TabbedBar } from "@justice-counts/common/components/TabbedBar";
+import {
+  TabOption,
+  TabbedBar,
+} from "@justice-counts/common/components/TabbedBar";
 import {
   AgencySystem,
   AgencySystems,
@@ -126,7 +129,7 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
     >({});
 
     /** Setting Tabs (Agency Information/Team Members) */
-    const settingOptions = [
+    const settingOptions: TabOption[] = [
       {
         key: "agency-information",
         label: AgencyProvisioningSettings.AGENCY_INFORMATION,
@@ -135,14 +138,25 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
         selected:
           currentSettingType === AgencyProvisioningSettings.AGENCY_INFORMATION,
       },
-      {
-        key: "team-members-roles",
-        label: AgencyProvisioningSettings.TEAM_MEMBERS_ROLES,
-        onClick: () =>
-          setCurrentSettingType(AgencyProvisioningSettings.TEAM_MEMBERS_ROLES),
-        selected:
-          currentSettingType === AgencyProvisioningSettings.TEAM_MEMBERS_ROLES,
-      },
+      /**
+       * Hide the Team Member & Roles tab if we are in the secondary modal b/c it is not
+       * necessary in that flow.
+       */
+      ...(activeSecondaryModal !== Setting.AGENCIES
+        ? [
+            {
+              key: "team-members-roles",
+              label: AgencyProvisioningSettings.TEAM_MEMBERS_ROLES,
+              onClick: () =>
+                setCurrentSettingType(
+                  AgencyProvisioningSettings.TEAM_MEMBERS_ROLES
+                ),
+              selected:
+                currentSettingType ===
+                AgencyProvisioningSettings.TEAM_MEMBERS_ROLES,
+            },
+          ]
+        : []),
     ];
 
     /** Selected agency to edit */
@@ -176,9 +190,6 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
           })),
         ]
       : [];
-
-    console.log("availableTeamMembers", availableTeamMembers);
-    console.log("currentTeamMembers", currentTeamMembers);
 
     /** Whether or not we are performing an add/delete action on a list of users/team members */
     const isAddUserAction =
@@ -959,11 +970,9 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                         )}
 
                         {/* Create New User Button (TODO(#1058)) */}
-                        {activeSecondaryModal !== Setting.AGENCIES && (
-                          <Styled.ActionButton onClick={openSecondaryModal}>
-                            Create New User
-                          </Styled.ActionButton>
-                        )}
+                        <Styled.ActionButton onClick={openSecondaryModal}>
+                          Create New User
+                        </Styled.ActionButton>
                       </Styled.FormActions>
                     </Styled.InputLabelWrapper>
 

--- a/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
@@ -157,7 +157,7 @@ export const AgencyProvisioningOverview = observer(() => {
 
           {/* Opens a secondary modal to create a new agency while in the middle of the create/edit user flow */}
           {activeSecondaryModal === Setting.USERS && (
-            <DelayedRender delay={300}>
+            <DelayedRender delay={250}>
               <Modal>
                 <UserProvisioning
                   closeModal={closeModal}

--- a/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
@@ -24,7 +24,14 @@ import { useStore } from "../../stores";
 import AdminPanelStore from "../../stores/AdminPanelStore";
 import { LinkToDashboard } from "../HelpCenter/LinkToPublisherDashboard";
 import { Loading } from "../Loading";
-import { AgencyKey, AgencyProvisioning, AgencyWithTeamByID } from ".";
+import {
+  AgencyKey,
+  AgencyProvisioning,
+  AgencyWithTeamByID,
+  Setting,
+  SettingType,
+  UserProvisioning,
+} from ".";
 import * as Styled from "./AdminPanel.styles";
 
 export const AgencyProvisioningOverview = observer(() => {
@@ -55,14 +62,21 @@ export const AgencyProvisioningOverview = observer(() => {
     useState(false);
   const [showSuperagencies, setShowSuperagencies] = useState(false);
   const [selectedAgencyID, setSelectedAgencyID] = useState<string | number>();
+  const [activeSecondaryModal, setActiveSecondaryModal] =
+    useState<SettingType>();
 
   const searchByKeys = ["name", "id", "state"] as AgencyKey[];
 
   const openModal = () => setIsModalOpen(true);
+  const openSecondaryModal = () => setActiveSecondaryModal(Setting.USERS);
   const closeModal = () => {
-    setSelectedAgencyID(undefined);
-    resetAgencyProvisioningUpdates();
-    setIsModalOpen(false);
+    if (!activeSecondaryModal) {
+      setSelectedAgencyID(undefined);
+      resetAgencyProvisioningUpdates();
+      setIsModalOpen(false);
+    } else {
+      setActiveSecondaryModal(undefined);
+    }
   };
   const searchAndFilter = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchInput(e.target.value);
@@ -128,12 +142,26 @@ export const AgencyProvisioningOverview = observer(() => {
   return (
     <>
       {isModalOpen && (
-        <Modal>
-          <AgencyProvisioning
-            closeModal={closeModal}
-            selectedIDToEdit={selectedAgencyID}
-          />
-        </Modal>
+        <>
+          <Modal>
+            <AgencyProvisioning
+              closeModal={closeModal}
+              selectedIDToEdit={selectedAgencyID}
+              activeSecondaryModal={activeSecondaryModal}
+              openSecondaryModal={openSecondaryModal}
+            />
+          </Modal>
+
+          {/* Opens a secondary modal to create a new agency while in the middle of the create/edit user flow */}
+          {activeSecondaryModal === Setting.USERS && (
+            <Modal>
+              <UserProvisioning
+                closeModal={closeModal}
+                activeSecondaryModal={activeSecondaryModal}
+              />
+            </Modal>
+          )}
+        </>
       )}
 
       {/* Settings Bar */}

--- a/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import { Button } from "@justice-counts/common/components/Button";
+import { DelayedRender } from "@justice-counts/common/components/DelayedRender";
 import { Modal } from "@justice-counts/common/components/Modal";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
@@ -33,7 +34,6 @@ import {
   UserProvisioning,
 } from ".";
 import * as Styled from "./AdminPanel.styles";
-import { DelayedRender } from "@justice-counts/common/components/DelayedRender";
 
 export const AgencyProvisioningOverview = observer(() => {
   const { adminPanelStore } = useStore();
@@ -52,6 +52,7 @@ export const AgencyProvisioningOverview = observer(() => {
     updateChildAgencyIDs,
     updateTeamMembers,
     resetAgencyProvisioningUpdates,
+    resetUserProvisioningUpdates,
   } = adminPanelStore;
 
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -76,6 +77,7 @@ export const AgencyProvisioningOverview = observer(() => {
       resetAgencyProvisioningUpdates();
       setIsModalOpen(false);
     } else {
+      resetUserProvisioningUpdates();
       setActiveSecondaryModal(undefined);
     }
   };

--- a/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
@@ -33,6 +33,7 @@ import {
   UserProvisioning,
 } from ".";
 import * as Styled from "./AdminPanel.styles";
+import { DelayedRender } from "@justice-counts/common/components/DelayedRender";
 
 export const AgencyProvisioningOverview = observer(() => {
   const { adminPanelStore } = useStore();
@@ -154,12 +155,14 @@ export const AgencyProvisioningOverview = observer(() => {
 
           {/* Opens a secondary modal to create a new agency while in the middle of the create/edit user flow */}
           {activeSecondaryModal === Setting.USERS && (
-            <Modal>
-              <UserProvisioning
-                closeModal={closeModal}
-                activeSecondaryModal={activeSecondaryModal}
-              />
-            </Modal>
+            <DelayedRender delay={300}>
+              <Modal>
+                <UserProvisioning
+                  closeModal={closeModal}
+                  activeSecondaryModal={activeSecondaryModal}
+                />
+              </Modal>
+            </DelayedRender>
           )}
         </>
       )}

--- a/publisher/src/components/AdminPanel/InteractiveSearchList.tsx
+++ b/publisher/src/components/AdminPanel/InteractiveSearchList.tsx
@@ -36,7 +36,7 @@ export const InteractiveSearchList = ({
   metadata,
   isActiveBox = true,
 }: InteractiveSearchListProps) => {
-  const [filteredList, setFilteredList] = useState<SearchableListItem[]>([]);
+  const [filteredList, setFilteredList] = useState<SearchableListItem[]>(list);
   const [searchInputValue, setSearchInputValue] = useState("");
 
   const getChipColor = (actionType?: InteractiveSearchListAction) => {

--- a/publisher/src/components/AdminPanel/UserProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioning.tsx
@@ -380,7 +380,7 @@ export const UserProvisioning: React.FC<ProvisioningProps> = observer(
                       </Styled.ActionButton>
                     )}
 
-                    {/* Create New Agency Button (TODO(#1058)) */}
+                    {/* Create New Agency Button */}
                     <Styled.ActionButton onClick={openSecondaryModal}>
                       Create New Agency
                     </Styled.ActionButton>

--- a/publisher/src/components/AdminPanel/UserProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioning.tsx
@@ -36,11 +36,17 @@ import {
   SaveConfirmation,
   SaveConfirmationType,
   SaveConfirmationTypes,
+  Setting,
 } from ".";
 import * as Styled from "./AdminPanel.styles";
 
 export const UserProvisioning: React.FC<ProvisioningProps> = observer(
-  ({ selectedIDToEdit, closeModal }) => {
+  ({
+    selectedIDToEdit,
+    activeSecondaryModal,
+    openSecondaryModal,
+    closeModal,
+  }) => {
     const { adminPanelStore } = useStore();
     const {
       agencies,
@@ -252,7 +258,9 @@ export const UserProvisioning: React.FC<ProvisioningProps> = observer(
         : (hasNameUpdate && hasEmailUpdate) !== true);
 
     return (
-      <Styled.ModalContainer>
+      <Styled.ModalContainer
+        offScreen={activeSecondaryModal === Setting.AGENCIES}
+      >
         {showSaveConfirmation.show ? (
           <SaveConfirmation
             type={showSaveConfirmation.type}
@@ -372,7 +380,11 @@ export const UserProvisioning: React.FC<ProvisioningProps> = observer(
                   )}
 
                   {/* Create New Agency Button (TODO(#1058)) */}
-                  <Styled.ActionButton>Create New Agency</Styled.ActionButton>
+                  {activeSecondaryModal !== Setting.USERS && (
+                    <Styled.ActionButton onClick={openSecondaryModal}>
+                      Create New Agency
+                    </Styled.ActionButton>
+                  )}
                 </Styled.FormActions>
 
                 {/* Add Agencies List */}

--- a/publisher/src/components/AdminPanel/UserProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioning.tsx
@@ -96,14 +96,12 @@ export const UserProvisioning: React.FC<ProvisioningProps> = observer(
       ...agenciesByID[id][0],
       action: InteractiveSearchListActions.ADD,
     }));
-    const userAgenciesAddedAgencies = selectedUser
-      ? [
-          ...addedAgenciesToDisplayInUserAgencies,
-          ...AdminPanelStore.objectToSortedFlatMappedValues(
-            selectedUser.agencies
-          ),
-        ]
-      : [];
+    const userAgenciesAddedAgencies = [
+      ...addedAgenciesToDisplayInUserAgencies,
+      ...(selectedUser
+        ? AdminPanelStore.objectToSortedFlatMappedValues(selectedUser.agencies)
+        : []),
+    ];
 
     /** Whether or not we are performing an add/delete action on an agencies' list */
     const isAddAction =
@@ -324,7 +322,7 @@ export const UserProvisioning: React.FC<ProvisioningProps> = observer(
                 )}
 
                 {/* User's Agencies */}
-                {selectedUser && (
+                {activeSecondaryModal !== Setting.USERS && (
                   <InteractiveSearchList
                     list={userAgenciesAddedAgencies}
                     buttons={interactiveSearchListButtons}

--- a/publisher/src/components/AdminPanel/UserProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioning.tsx
@@ -346,46 +346,46 @@ export const UserProvisioning: React.FC<ProvisioningProps> = observer(
                 )}
 
                 {/* Add/Remove/Create New Agencies */}
-                <Styled.FormActions>
-                  {/* Add Agencies Button */}
-                  <Styled.ActionButton
-                    buttonAction={InteractiveSearchListActions.ADD}
-                    selectedColor={isAddAction ? "green" : ""}
-                    onClick={() => {
-                      setAddOrDeleteAgencyAction((prev) =>
-                        prev === InteractiveSearchListActions.ADD
-                          ? undefined
-                          : InteractiveSearchListActions.ADD
-                      );
-                    }}
-                  >
-                    Add Agencies
-                  </Styled.ActionButton>
-
-                  {/* Remove Agencies Button (note: when creating a new user, the delete action button is not necessary) */}
-                  {selectedUser && (
+                {activeSecondaryModal !== Setting.USERS && (
+                  <Styled.FormActions>
+                    {/* Add Agencies Button */}
                     <Styled.ActionButton
-                      buttonAction={InteractiveSearchListActions.DELETE}
-                      selectedColor={isDeleteAction ? "red" : ""}
+                      buttonAction={InteractiveSearchListActions.ADD}
+                      selectedColor={isAddAction ? "green" : ""}
                       onClick={() => {
                         setAddOrDeleteAgencyAction((prev) =>
-                          prev === InteractiveSearchListActions.DELETE
+                          prev === InteractiveSearchListActions.ADD
                             ? undefined
-                            : InteractiveSearchListActions.DELETE
+                            : InteractiveSearchListActions.ADD
                         );
                       }}
                     >
-                      Delete Agencies
+                      Add Agencies
                     </Styled.ActionButton>
-                  )}
 
-                  {/* Create New Agency Button (TODO(#1058)) */}
-                  {activeSecondaryModal !== Setting.USERS && (
+                    {/* Remove Agencies Button (note: when creating a new user, the delete action button is not necessary) */}
+                    {selectedUser && (
+                      <Styled.ActionButton
+                        buttonAction={InteractiveSearchListActions.DELETE}
+                        selectedColor={isDeleteAction ? "red" : ""}
+                        onClick={() => {
+                          setAddOrDeleteAgencyAction((prev) =>
+                            prev === InteractiveSearchListActions.DELETE
+                              ? undefined
+                              : InteractiveSearchListActions.DELETE
+                          );
+                        }}
+                      >
+                        Delete Agencies
+                      </Styled.ActionButton>
+                    )}
+
+                    {/* Create New Agency Button (TODO(#1058)) */}
                     <Styled.ActionButton onClick={openSecondaryModal}>
                       Create New Agency
                     </Styled.ActionButton>
-                  )}
-                </Styled.FormActions>
+                  </Styled.FormActions>
+                )}
 
                 {/* Add Agencies List */}
                 {isAddAction && (

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import { Button } from "@justice-counts/common/components/Button";
+import { DelayedRender } from "@justice-counts/common/components/DelayedRender";
 import { Modal } from "@justice-counts/common/components/Modal";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
@@ -109,12 +110,14 @@ export const UserProvisioningOverview = observer(() => {
 
           {/* Opens a secondary modal to create a new agency while in the middle of the create/edit user flow */}
           {activeSecondaryModal === Setting.AGENCIES && (
-            <Modal>
-              <AgencyProvisioning
-                closeModal={closeModal}
-                activeSecondaryModal={activeSecondaryModal}
-              />
-            </Modal>
+            <DelayedRender delay={300}>
+              <Modal>
+                <AgencyProvisioning
+                  closeModal={closeModal}
+                  activeSecondaryModal={activeSecondaryModal}
+                />
+              </Modal>
+            </DelayedRender>
           )}
         </>
       )}

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -23,7 +23,14 @@ import React, { useEffect, useState } from "react";
 import { useStore } from "../../stores";
 import AdminPanelStore from "../../stores/AdminPanelStore";
 import { Loading } from "../Loading";
-import { UserKey, UserProvisioning, UserWithAgenciesByID } from ".";
+import {
+  AgencyProvisioning,
+  Setting,
+  SettingType,
+  UserKey,
+  UserProvisioning,
+  UserWithAgenciesByID,
+} from ".";
 import * as Styled from "./AdminPanel.styles";
 
 export const UserProvisioningOverview = observer(() => {
@@ -45,14 +52,21 @@ export const UserProvisioningOverview = observer(() => {
     []
   );
   const [selectedUserID, setSelectedUserID] = useState<string | number>();
+  const [activeSecondaryModal, setActiveSecondaryModal] =
+    useState<SettingType>();
 
   const searchByKeys = ["name", "email", "id"] as UserKey[];
 
   const openModal = () => setIsModalOpen(true);
+  const openSecondaryModal = () => setActiveSecondaryModal(Setting.AGENCIES);
   const closeModal = () => {
-    setSelectedUserID(undefined);
-    resetUserProvisioningUpdates();
-    setIsModalOpen(false);
+    if (!activeSecondaryModal) {
+      setSelectedUserID(undefined);
+      resetUserProvisioningUpdates();
+      setIsModalOpen(false);
+    } else {
+      setActiveSecondaryModal(undefined);
+    }
   };
   const searchAndFilter = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchInput(e.target.value);
@@ -83,12 +97,26 @@ export const UserProvisioningOverview = observer(() => {
   return (
     <>
       {isModalOpen && (
-        <Modal>
-          <UserProvisioning
-            closeModal={closeModal}
-            selectedIDToEdit={selectedUserID}
-          />
-        </Modal>
+        <>
+          <Modal>
+            <UserProvisioning
+              closeModal={closeModal}
+              selectedIDToEdit={selectedUserID}
+              activeSecondaryModal={activeSecondaryModal}
+              openSecondaryModal={openSecondaryModal}
+            />
+          </Modal>
+
+          {/* Opens a secondary modal to create a new agency while in the middle of the create/edit user flow */}
+          {activeSecondaryModal === Setting.AGENCIES && (
+            <Modal>
+              <AgencyProvisioning
+                closeModal={closeModal}
+                activeSecondaryModal={activeSecondaryModal}
+              />
+            </Modal>
+          )}
+        </>
       )}
 
       {/* Settings Bar */}

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -39,12 +39,12 @@ export const UserProvisioningOverview = observer(() => {
     resetUserProvisioningUpdates,
   } = adminPanelStore;
 
-  const [selectedUserID, setSelectedUserID] = useState<string | number>();
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [searchInput, setSearchInput] = useState<string>("");
   const [filteredUsers, setFilteredUsers] = useState<UserWithAgenciesByID[]>(
     []
   );
+  const [selectedUserID, setSelectedUserID] = useState<string | number>();
 
   const searchByKeys = ["name", "email", "id"] as UserKey[];
 

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -45,6 +45,7 @@ export const UserProvisioningOverview = observer(() => {
     updateUserAgencies,
     updateUserAccountId,
     resetUserProvisioningUpdates,
+    resetAgencyProvisioningUpdates,
   } = adminPanelStore;
 
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -62,10 +63,11 @@ export const UserProvisioningOverview = observer(() => {
   const openSecondaryModal = () => setActiveSecondaryModal(Setting.AGENCIES);
   const closeModal = () => {
     if (!activeSecondaryModal) {
-      setSelectedUserID(undefined);
       resetUserProvisioningUpdates();
+      setSelectedUserID(undefined);
       setIsModalOpen(false);
     } else {
+      resetAgencyProvisioningUpdates();
       setActiveSecondaryModal(undefined);
     }
   };

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -112,7 +112,7 @@ export const UserProvisioningOverview = observer(() => {
 
           {/* Opens a secondary modal to create a new agency while in the middle of the create/edit user flow */}
           {activeSecondaryModal === Setting.AGENCIES && (
-            <DelayedRender delay={300}>
+            <DelayedRender delay={250}>
               <Modal>
                 <AgencyProvisioning
                   closeModal={closeModal}

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -48,14 +48,15 @@ export const UserProvisioningOverview = observer(() => {
     resetAgencyProvisioningUpdates,
   } = adminPanelStore;
 
+  const [selectedUserID, setSelectedUserID] = useState<string | number>();
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const [activeSecondaryModal, setActiveSecondaryModal] =
+    useState<SettingType>();
+
   const [searchInput, setSearchInput] = useState<string>("");
   const [filteredUsers, setFilteredUsers] = useState<UserWithAgenciesByID[]>(
     []
   );
-  const [selectedUserID, setSelectedUserID] = useState<string | number>();
-  const [activeSecondaryModal, setActiveSecondaryModal] =
-    useState<SettingType>();
 
   const searchByKeys = ["name", "email", "id"] as UserKey[];
 

--- a/publisher/src/components/AdminPanel/types.ts
+++ b/publisher/src/components/AdminPanel/types.ts
@@ -45,6 +45,8 @@ export type SaveConfirmationType = `${SaveConfirmationTypes}`;
 
 export type ProvisioningProps = {
   selectedIDToEdit?: string | number;
+  activeSecondaryModal?: SettingType;
+  openSecondaryModal?: () => void;
   closeModal: () => void;
 };
 

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -428,22 +428,6 @@ class AdminPanelStore {
       Object.values(obj).flatMap((item) => item)
     );
   }
-
-  /**
-   * Updates a set of selections by either adding or removing a specified item.
-   * @param prevSet - The previous set of selected items to update
-   * @param item - The item within the set to be added or removed depending on whether or not it already exists within the set
-   * @returns An updated set of selected items after the addition or removal operation.
-   */
-  static toggleAddRemoveSetItem<T>(prevSet: Set<T>, item: T): Set<T> {
-    const updatedSet = new Set(prevSet);
-    if (updatedSet.has(item)) {
-      updatedSet.delete(item);
-    } else {
-      updatedSet.add(item);
-    }
-    return updatedSet;
-  }
 }
 
 export default AdminPanelStore;

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -190,9 +190,8 @@ class AdminPanelStore {
     }
   }
 
-  fetchUsersAndAgencies() {
-    this.fetchUsers();
-    this.fetchAgencies();
+  async fetchUsersAndAgencies() {
+    await Promise.all([this.fetchUsers(), this.fetchAgencies()]);
     runInAction(() => {
       this.loading = false;
     });

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -429,6 +429,22 @@ class AdminPanelStore {
       Object.values(obj).flatMap((item) => item)
     );
   }
+
+  /**
+   * Updates a set of selections by either adding or removing a specified item.
+   * @param prevSet - The previous set of selected items to update
+   * @param item - The item within the set to be added or removed depending on whether or not it already exists within the set
+   * @returns An updated set of selected items after the addition or removal operation.
+   */
+  static toggleAddRemoveSetItem<T>(prevSet: Set<T>, item: T): Set<T> {
+    const updatedSet = new Set(prevSet);
+    if (updatedSet.has(item)) {
+      updatedSet.delete(item);
+    } else {
+      updatedSet.add(item);
+    }
+    return updatedSet;
+  }
 }
 
 export default AdminPanelStore;


### PR DESCRIPTION
## Description of the change

This implementation allows users to quickly create a new user _while_ in the middle of creating an agency - and vice versa - quickly create a new agency _while_ in the middle of creating a new user. There are some edge cases that still need to be tested for (e.g. the auto adding of CSG members when creating a new agency, etc.) - but this works well so far in local development. Will do a more thorough testing in staging, but mostly trying to get the foundation in for now. Hopefully this makes things a bit easier for us when provisioning new users and agencies - but if it ends up being a pain, it's easy enough to strip out.

Demo (user provisioning):

https://github.com/Recidiviz/justice-counts/assets/59492998/e58bce4f-8998-4b9a-af2e-cd5910b644af


Demo (agency provisioning):

https://github.com/Recidiviz/justice-counts/assets/59492998/042460fa-652a-4750-b77a-b446de0ec3ee



## Related issues

Closes #1058, Contributes to #1075

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
