### PR TITLE
[Bug][Publisher] Admin Panel: Playtesting Followup - Fix crash edgecase when username is a string full of spaces

### DIFF
--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -61,7 +61,7 @@ const Menu: React.FC = () => {
       if (splitName.length > 1) {
         return (splitName[0][0] + splitName[1][0]).toUpperCase();
       }
-      return splitName[0][0].toUpperCase();
+      return splitName[0][0]?.toUpperCase();
     }
   };
 

--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -56,7 +56,8 @@ const Menu: React.FC = () => {
 
   const usernameToInitials = () => {
     if (userStore.name) {
-      const splitName = userStore.name.split(" ");
+      const splitName = userStore.name.trim().split(" ");
+
       if (splitName.length > 1) {
         return (splitName[0][0] + splitName[1][0]).toUpperCase();
       }

--- a/publisher/src/components/Settings/AccountSettings.tsx
+++ b/publisher/src/components/Settings/AccountSettings.tsx
@@ -53,7 +53,7 @@ export const AccountSettings = () => {
           label="Full Name"
           value={name}
           onChange={(e) => {
-            setName(e.target.value);
+            setName((prev) => e.target.value.trimStart() || prev);
             debouncedSave(e.target.value, undefined);
           }}
         />
@@ -62,7 +62,7 @@ export const AccountSettings = () => {
           label="Email"
           value={email}
           onChange={(e) => {
-            setEmail(e.target.value);
+            setEmail((prev) => e.target.value || prev);
             debouncedSave(undefined, e.target.value);
           }}
         />

--- a/publisher/src/components/Settings/AccountSettings.tsx
+++ b/publisher/src/components/Settings/AccountSettings.tsx
@@ -54,7 +54,7 @@ export const AccountSettings = () => {
           value={name}
           onChange={(e) => {
             setName((prev) => e.target.value.trimStart() || prev);
-            debouncedSave(e.target.value, undefined);
+            debouncedSave(e.target.value.trimStart() || name, undefined);
           }}
         />
         <Input
@@ -63,7 +63,7 @@ export const AccountSettings = () => {
           value={email}
           onChange={(e) => {
             setEmail((prev) => e.target.value || prev);
-            debouncedSave(undefined, e.target.value);
+            debouncedSave(undefined, e.target.value || email);
           }}
         />
       </AccountSettingsInputsWrapper>

--- a/publisher/src/components/Settings/AccountSettings.tsx
+++ b/publisher/src/components/Settings/AccountSettings.tsx
@@ -54,7 +54,10 @@ export const AccountSettings = () => {
           value={name}
           onChange={(e) => {
             setName((prev) => e.target.value.trimStart() || prev);
-            debouncedSave(e.target.value.trimStart() || name, undefined);
+            debouncedSave(
+              e.target.value.trimStart() || userStore?.name,
+              undefined
+            );
           }}
         />
         <Input
@@ -62,8 +65,11 @@ export const AccountSettings = () => {
           label="Email"
           value={email}
           onChange={(e) => {
-            setEmail((prev) => e.target.value || prev);
-            debouncedSave(undefined, e.target.value || email);
+            setEmail((prev) => e.target.value.trimStart() || prev);
+            debouncedSave(
+              undefined,
+              e.target.value.trimStart() || userStore?.email
+            );
           }}
         />
       </AccountSettingsInputsWrapper>

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -222,7 +222,7 @@ class AdminPanelStore {
   /** User Provisioning */
 
   updateUsername(username: string) {
-    this.userProvisioningUpdates.name = username;
+    this.userProvisioningUpdates.name = username.trimStart();
   }
 
   updateEmail(email: string) {


### PR DESCRIPTION
## Description of the change

Fixes a crash that happens when logging into Publisher when your name set as only spaces. In addition to that, adds extra trimming of leading spaces (in admin panel and Publisher account settings) and a bit of logic to prevent users from emptying out the name & email fields in Publisher account settings (which is already in place in admin panel). Thanks to Forrest for uncovering this weird edge case.

I tested this manually by adjusting my name to only spaces via Auth0 (no crash when logging in), and trying to empty the name and email fields in Publisher account settings (reasonably difficult to empty) and the name field in the admin panel (email is not editable at this time - so at creation time, this isn't necessary because the email is being validated).

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
