### PR TITLE
[Publisher] Admin Panel: Playtesting Followup - Remove "(required)" from state search box in Agency Provisioning modal

### DIFF
--- a/common/components/Toast/Toast.ts
+++ b/common/components/Toast/Toast.ts
@@ -46,7 +46,6 @@ const getToastStyles = (color?: ToastColor, positionNextToIcon?: boolean) => {
   const toastStyles = `
       width: auto;
       max-width: 400px;
-      height: ${HEADER_BAR_HEIGHT - 1}px;
       display: flex;
       align-items: center;
       background-color: ${toastBackgroundColor};

--- a/common/components/Toast/Toast.ts
+++ b/common/components/Toast/Toast.ts
@@ -16,7 +16,6 @@
 // =============================================================================
 
 import {
-  HEADER_BAR_HEIGHT,
   palette,
   typography,
 } from "@justice-counts/common/components/GlobalStyles";

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -517,37 +517,37 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                     </Styled.InputLabelWrapper>
 
                     {/* Agency State Input */}
+                    {showSelectionBox === SelectionInputBoxTypes.STATE && (
+                      <InteractiveSearchList
+                        list={AdminPanelStore.searchableStates}
+                        boxActionType={InteractiveSearchListActions.ADD}
+                        selections={
+                          agencyProvisioningUpdates.state_code
+                            ? new Set([agencyProvisioningUpdates.state_code])
+                            : new Set()
+                        }
+                        buttons={interactiveSearchListCloseButton}
+                        updateSelections={({ id }) => {
+                          updateStateCode(
+                            agencyProvisioningUpdates.state_code ===
+                              (id as StateCodeKey)
+                              ? selectedAgency?.state_code || null
+                              : (id as StateCodeKey)
+                          );
+                          /** Reset the county code input */
+                          updateCountyCode(null);
+                        }}
+                        searchByKeys={["name"]}
+                        metadata={{
+                          listBoxLabel: "Select a state",
+                          searchBoxLabel: "Search states",
+                        }}
+                        isActiveBox={
+                          showSelectionBox === SelectionInputBoxTypes.STATE
+                        }
+                      />
+                    )}
                     <Styled.InputLabelWrapper required>
-                      {showSelectionBox === SelectionInputBoxTypes.STATE && (
-                        <InteractiveSearchList
-                          list={AdminPanelStore.searchableStates}
-                          boxActionType={InteractiveSearchListActions.ADD}
-                          selections={
-                            agencyProvisioningUpdates.state_code
-                              ? new Set([agencyProvisioningUpdates.state_code])
-                              : new Set()
-                          }
-                          buttons={interactiveSearchListCloseButton}
-                          updateSelections={({ id }) => {
-                            updateStateCode(
-                              agencyProvisioningUpdates.state_code ===
-                                (id as StateCodeKey)
-                                ? selectedAgency?.state_code || null
-                                : (id as StateCodeKey)
-                            );
-                            /** Reset the county code input */
-                            updateCountyCode(null);
-                          }}
-                          searchByKeys={["name"]}
-                          metadata={{
-                            listBoxLabel: "Select a state",
-                            searchBoxLabel: "Search states",
-                          }}
-                          isActiveBox={
-                            showSelectionBox === SelectionInputBoxTypes.STATE
-                          }
-                        />
-                      )}
                       <input
                         id="state"
                         name="state"
@@ -567,36 +567,36 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                     </Styled.InputLabelWrapper>
 
                     {/* Agency County Input */}
+                    {showSelectionBox === SelectionInputBoxTypes.COUNTY && (
+                      <InteractiveSearchList
+                        list={searchableCounties}
+                        boxActionType={InteractiveSearchListActions.ADD}
+                        selections={
+                          agencyProvisioningUpdates.fips_county_code
+                            ? new Set([
+                                agencyProvisioningUpdates.fips_county_code,
+                              ])
+                            : new Set()
+                        }
+                        buttons={interactiveSearchListCloseButton}
+                        updateSelections={({ id }) => {
+                          updateCountyCode(
+                            agencyProvisioningUpdates.fips_county_code === id
+                              ? null
+                              : (id as FipsCountyCodeKey)
+                          );
+                        }}
+                        searchByKeys={["name"]}
+                        metadata={{
+                          listBoxLabel: "Select a county",
+                          searchBoxLabel: "Search counties",
+                        }}
+                        isActiveBox={
+                          showSelectionBox === SelectionInputBoxTypes.COUNTY
+                        }
+                      />
+                    )}
                     <Styled.InputLabelWrapper>
-                      {showSelectionBox === SelectionInputBoxTypes.COUNTY && (
-                        <InteractiveSearchList
-                          list={searchableCounties}
-                          boxActionType={InteractiveSearchListActions.ADD}
-                          selections={
-                            agencyProvisioningUpdates.fips_county_code
-                              ? new Set([
-                                  agencyProvisioningUpdates.fips_county_code,
-                                ])
-                              : new Set()
-                          }
-                          buttons={interactiveSearchListCloseButton}
-                          updateSelections={({ id }) => {
-                            updateCountyCode(
-                              agencyProvisioningUpdates.fips_county_code === id
-                                ? null
-                                : (id as FipsCountyCodeKey)
-                            );
-                          }}
-                          searchByKeys={["name"]}
-                          metadata={{
-                            listBoxLabel: "Select a county",
-                            searchBoxLabel: "Search counties",
-                          }}
-                          isActiveBox={
-                            showSelectionBox === SelectionInputBoxTypes.COUNTY
-                          }
-                        />
-                      )}
                       <input
                         id="county"
                         name="county"
@@ -617,31 +617,31 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                     </Styled.InputLabelWrapper>
 
                     {/* Agency Systems Input */}
+                    {showSelectionBox === SelectionInputBoxTypes.SYSTEMS && (
+                      <InteractiveSearchList
+                        list={searchableSystems}
+                        boxActionType={InteractiveSearchListActions.ADD}
+                        selections={selectedSystems}
+                        buttons={getInteractiveSearchListSelectDeselectCloseButtons(
+                          setSelectedSystems,
+                          new Set(systems)
+                        )}
+                        updateSelections={({ id }) => {
+                          setSelectedSystems((prev) =>
+                            toggleAddRemoveSetItem(prev, id as AgencySystems)
+                          );
+                        }}
+                        searchByKeys={["name"]}
+                        metadata={{
+                          listBoxLabel: "Select sector(s)",
+                          searchBoxLabel: "Search sectors",
+                        }}
+                        isActiveBox={
+                          showSelectionBox === SelectionInputBoxTypes.SYSTEMS
+                        }
+                      />
+                    )}
                     <Styled.InputLabelWrapper>
-                      {showSelectionBox === SelectionInputBoxTypes.SYSTEMS && (
-                        <InteractiveSearchList
-                          list={searchableSystems}
-                          boxActionType={InteractiveSearchListActions.ADD}
-                          selections={selectedSystems}
-                          buttons={getInteractiveSearchListSelectDeselectCloseButtons(
-                            setSelectedSystems,
-                            new Set(systems)
-                          )}
-                          updateSelections={({ id }) => {
-                            setSelectedSystems((prev) =>
-                              toggleAddRemoveSetItem(prev, id as AgencySystems)
-                            );
-                          }}
-                          searchByKeys={["name"]}
-                          metadata={{
-                            listBoxLabel: "Select sector(s)",
-                            searchBoxLabel: "Search sectors",
-                          }}
-                          isActiveBox={
-                            showSelectionBox === SelectionInputBoxTypes.SYSTEMS
-                          }
-                        />
-                      )}
                       <Styled.ChipContainer
                         onClick={() =>
                           setShowSelectionBox(SelectionInputBoxTypes.SYSTEMS)


### PR DESCRIPTION
## Description of the change

Removes the "(required)" text from the `Search State` input field in Agency Provisioning. No code changes at all - I just moved the search boxes outside of the `<Styled.InputLabelWrapper></Styled.InputLabelWrapper>` so the `(required)` CSS targets the labels properly.

<img width="702" alt="Screenshot 2023-12-21 at 8 47 31 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/7795c673-b007-41e5-99dd-d5a0547e267d">

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
