### PR TITLE
[Publisher] Admin Panel: Playtesting Followup - Fix Select All users bug in Agency Provisioning modal

### DIFF
--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -210,12 +210,16 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
     ];
     const getInteractiveSearchListSelectDeselectCloseButtons = <T,>(
       setState: React.Dispatch<React.SetStateAction<Set<T>>>,
-      selectAllSet: Set<T>
+      selectAllSet: Set<T>,
+      selectAllCallback?: () => void
     ) => {
       return [
         {
           label: "Select All",
-          onClick: () => setState(selectAllSet),
+          onClick: () => {
+            setState(selectAllSet);
+            if (selectAllCallback) selectAllCallback();
+          },
         },
         {
           label: "Deselect All",
@@ -876,7 +880,26 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                             setSelectedTeamMembersToAdd,
                             new Set(
                               availableTeamMembers.map((member) => +member.id)
-                            )
+                            ),
+                            () => {
+                              setTeamMemberRoleUpdates((prev) => {
+                                return {
+                                  ...prev,
+                                  ...availableTeamMembers.reduce(
+                                    (acc, member) => {
+                                      acc[+member.id] =
+                                        isCSGOrRecidivizUserByEmail(
+                                          member.email
+                                        )
+                                          ? csgAndRecidivizDefaultRole
+                                          : AgencyTeamMemberRole.AGENCY_ADMIN;
+                                      return acc;
+                                    },
+                                    {} as UserRoleUpdates
+                                  ),
+                                };
+                              });
+                            }
                           )}
                           updateSelections={({ id, email }) => {
                             setSelectedTeamMembersToAdd((prev) =>


### PR DESCRIPTION
## Description of the change

Fixes Select All bug in the Agency Provisioning modal when trying to add users. Previously, it showed that it was adding users, but never sent those added users to the backend. This adjustment ensures that the "Select All" button adds those users to the final list AND designates the appropriate default role for each user.

https://github.com/Recidiviz/justice-counts/assets/59492998/5dde545e-ecce-40ee-b857-0b112953f02f


## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
