### PR TITLE
[Publisher] Admin Panel: Playtesting Followup - Refetch users and agencies when a change has been made to a superagency/child agency selection

### DIFF
--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -249,7 +249,9 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
         })),
       ]);
 
-      const response = await saveAgencyProvisioningUpdates();
+      /** Refetch when changes are made to superagency or child agencies so all related agencies are updated */
+      const shouldRefetch = hasSuperagencyUpdate || hasChildAgencyUpdates;
+      const response = await saveAgencyProvisioningUpdates(shouldRefetch);
 
       setShowSaveConfirmation({
         show: true,

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -337,7 +337,7 @@ class AdminPanelStore {
     this.agenciesByID[agency.id] = [agencyWithGroupedTeams];
   }
 
-  async saveAgencyProvisioningUpdates() {
+  async saveAgencyProvisioningUpdates(refetch?: boolean) {
     try {
       const response = (await this.api.request({
         path: `/admin/agency`,
@@ -347,7 +347,12 @@ class AdminPanelStore {
       const agencyResponse = (await response.json()) as Agency | ErrorResponse;
 
       if (response.status === 200) {
-        runInAction(() => this.updateAgencies(agencyResponse as Agency));
+        if (!refetch) {
+          runInAction(() => this.updateAgencies(agencyResponse as Agency));
+        } else {
+          await this.fetchUsersAndAgencies();
+        }
+
         return response;
       }
 


### PR DESCRIPTION
## Description of the change

Refetches users and agencies when a change has been made to a superagency selection or a list of child agency - since changes to either will require other agency objects to update reflecting the relationship. Instead of having the FE coordinate all of those individual changes, we can refetch a new list of agencies after saving which will give us all of the updated relationships. (Thank you Lili for the idea to isolate the refetching only when these changes are made!)

I don't think we necessarily need to refetch users - I just included them here because I figured why not get a new list of users to keep the updates in sync. LMK if you think it's better to just refetch a list of agencies.

https://github.com/Recidiviz/justice-counts/assets/59492998/62bab8eb-a067-41e6-9fbf-dfece665dcb9


## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
