### PR TITLE
[Publisher] Admin Panel: Playtesting Followup - Empty search input in overview pages after saving & refactor filtering logic

### DIFF
--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -191,7 +191,7 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
 
     /** Modal Buttons (Save/Cancel) */
     const modalButtons = [
-      { label: "Cancel", onClick: closeModal },
+      { label: "Cancel", onClick: () => closeModal() },
       {
         label: "Save",
         onClick: () => saveUpdates(),
@@ -277,7 +277,7 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
           errorMessage: undefined,
         }));
         if (response && "status" in response && response.status === 200)
-          closeModal();
+          closeModal(true);
         setIsSaveInProgress(false);
       }, 2000);
     };

--- a/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
@@ -19,12 +19,8 @@ import { Button } from "@justice-counts/common/components/Button";
 import { DelayedRender } from "@justice-counts/common/components/DelayedRender";
 import { Modal } from "@justice-counts/common/components/Modal";
 import { observer } from "mobx-react-lite";
-import React, { useEffect, useMemo, useState } from "react";
+import React, { useState } from "react";
 
-import { useStore } from "../../stores";
-import AdminPanelStore from "../../stores/AdminPanelStore";
-import { LinkToDashboard } from "../HelpCenter/LinkToPublisherDashboard";
-import { Loading } from "../Loading";
 import {
   AgencyKey,
   AgencyProvisioning,
@@ -33,6 +29,10 @@ import {
   SettingType,
   UserProvisioning,
 } from ".";
+import { useStore } from "../../stores";
+import AdminPanelStore from "../../stores/AdminPanelStore";
+import { LinkToDashboard } from "../HelpCenter/LinkToPublisherDashboard";
+import { Loading } from "../Loading";
 import * as Styled from "./AdminPanel.styles";
 
 export const AgencyProvisioningOverview = observer(() => {
@@ -57,8 +57,8 @@ export const AgencyProvisioningOverview = observer(() => {
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [searchInput, setSearchInput] = useState<string>("");
-  const [filteredAgencies, setFilteredAgencies] =
-    useState<AgencyWithTeamByID[]>(agencies);
+  // const [filteredAgencies, setFilteredAgencies] =
+  //   useState<AgencyWithTeamByID[]>(agencies);
   const [showAgenciesWithLiveDashboards, setShowAgenciesWithLiveDashboards] =
     useState(false);
   const [showSuperagencies, setShowSuperagencies] = useState(false);
@@ -67,21 +67,39 @@ export const AgencyProvisioningOverview = observer(() => {
     useState<SettingType>();
 
   const searchByKeys = ["name", "id", "state"] as AgencyKey[];
-  const superagenciesAndAgenciesWithLiveDashboards = useMemo(
-    () =>
-      agencies.filter(
-        (agency) => agency.is_dashboard_enabled && agency.is_superagency
-      ),
-    [agencies]
+  const superagenciesAndAgenciesWithLiveDashboards = agencies.filter(
+    (agency) => agency.is_dashboard_enabled && agency.is_superagency
   );
-  const superagencies = useMemo(
-    () => agencies.filter((agency) => agency.is_superagency),
-    [agencies]
+  const superagencies = agencies.filter((agency) => agency.is_superagency);
+  const agenciesWithLiveDashboards = agencies.filter(
+    (agency) => agency.is_dashboard_enabled
   );
-  const agenciesWithLiveDashboards = useMemo(
-    () => agencies.filter((agency) => agency.is_dashboard_enabled),
-    [agencies]
-  );
+
+  const getFilteredAgencies = () => {
+    if (showAgenciesWithLiveDashboards && showSuperagencies) {
+      return AdminPanelStore.searchList(
+        superagenciesAndAgenciesWithLiveDashboards,
+        searchInput,
+        searchByKeys
+      );
+    }
+    if (showAgenciesWithLiveDashboards) {
+      return AdminPanelStore.searchList(
+        agenciesWithLiveDashboards,
+        searchInput,
+        searchByKeys
+      );
+    }
+    if (showSuperagencies) {
+      return AdminPanelStore.searchList(
+        superagencies,
+        searchInput,
+        searchByKeys
+      );
+    }
+    return AdminPanelStore.searchList(agencies, searchInput, searchByKeys);
+  };
+  const filteredAgencies = getFilteredAgencies();
 
   const openModal = () => setIsModalOpen(true);
   const openSecondaryModal = () => setActiveSecondaryModal(Setting.USERS);
@@ -95,36 +113,9 @@ export const AgencyProvisioningOverview = observer(() => {
       setActiveSecondaryModal(undefined);
     }
     setSearchInput("");
-    setFilteredAgencies(agencies);
   };
   const searchAndFilter = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchInput(e.target.value);
-    if (showAgenciesWithLiveDashboards && showSuperagencies) {
-      return setFilteredAgencies(
-        AdminPanelStore.searchList(
-          superagenciesAndAgenciesWithLiveDashboards,
-          e.target.value,
-          searchByKeys
-        )
-      );
-    }
-    if (showAgenciesWithLiveDashboards) {
-      return setFilteredAgencies(
-        AdminPanelStore.searchList(
-          agenciesWithLiveDashboards,
-          e.target.value,
-          searchByKeys
-        )
-      );
-    }
-    if (showSuperagencies) {
-      return setFilteredAgencies(
-        AdminPanelStore.searchList(superagencies, e.target.value, searchByKeys)
-      );
-    }
-    setFilteredAgencies(
-      AdminPanelStore.searchList(agencies, e.target.value, searchByKeys)
-    );
   };
   const editAgency = (agencyID: string | number) => {
     const selectedAgency = agenciesByID[agencyID][0];
@@ -148,33 +139,6 @@ export const AgencyProvisioningOverview = observer(() => {
     );
     openModal();
   };
-
-  useEffect(() => setFilteredAgencies(agencies), [agencies]);
-
-  /**
-   * Filters the list of agencies to display all agencies that are superagencies or
-   * agencies that have live dashboards or both based on the selected checkbox in the Settings Bar.
-   */
-  useEffect(() => {
-    setSearchInput("");
-    if (showAgenciesWithLiveDashboards && showSuperagencies) {
-      return setFilteredAgencies(superagenciesAndAgenciesWithLiveDashboards);
-    }
-    if (showAgenciesWithLiveDashboards) {
-      return setFilteredAgencies(agenciesWithLiveDashboards);
-    }
-    if (showSuperagencies) {
-      return setFilteredAgencies(superagencies);
-    }
-    return setFilteredAgencies(agencies);
-  }, [
-    showAgenciesWithLiveDashboards,
-    showSuperagencies,
-    agencies,
-    superagenciesAndAgenciesWithLiveDashboards,
-    agenciesWithLiveDashboards,
-    superagencies,
-  ]);
 
   if (loading) {
     return <Loading />;
@@ -226,7 +190,6 @@ export const AgencyProvisioningOverview = observer(() => {
               <Styled.LabelButton
                 onClick={() => {
                   setSearchInput("");
-                  setFilteredAgencies(agencies);
                 }}
               >
                 Clear

--- a/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
@@ -100,7 +100,7 @@ export const AgencyProvisioningOverview = observer(() => {
 
   const openModal = () => setIsModalOpen(true);
   const openSecondaryModal = () => setActiveSecondaryModal(Setting.USERS);
-  const closeModal = () => {
+  const closeModal = (resetSearchInput?: boolean) => {
     if (!activeSecondaryModal) {
       setSelectedAgencyID(undefined);
       resetAgencyProvisioningUpdates();
@@ -109,7 +109,7 @@ export const AgencyProvisioningOverview = observer(() => {
       resetUserProvisioningUpdates();
       setActiveSecondaryModal(undefined);
     }
-    setSearchInput("");
+    if (resetSearchInput) setSearchInput("");
   };
   const searchAndFilter = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchInput(e.target.value);

--- a/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
@@ -94,6 +94,8 @@ export const AgencyProvisioningOverview = observer(() => {
       resetUserProvisioningUpdates();
       setActiveSecondaryModal(undefined);
     }
+    setSearchInput("");
+    setFilteredAgencies(agencies);
   };
   const searchAndFilter = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchInput(e.target.value);

--- a/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
@@ -21,18 +21,17 @@ import { Modal } from "@justice-counts/common/components/Modal";
 import { observer } from "mobx-react-lite";
 import React, { useState } from "react";
 
-import {
-  AgencyKey,
-  AgencyProvisioning,
-  AgencyWithTeamByID,
-  Setting,
-  SettingType,
-  UserProvisioning,
-} from ".";
 import { useStore } from "../../stores";
 import AdminPanelStore from "../../stores/AdminPanelStore";
 import { LinkToDashboard } from "../HelpCenter/LinkToPublisherDashboard";
 import { Loading } from "../Loading";
+import {
+  AgencyKey,
+  AgencyProvisioning,
+  Setting,
+  SettingType,
+  UserProvisioning,
+} from ".";
 import * as Styled from "./AdminPanel.styles";
 
 export const AgencyProvisioningOverview = observer(() => {
@@ -57,8 +56,6 @@ export const AgencyProvisioningOverview = observer(() => {
 
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [searchInput, setSearchInput] = useState<string>("");
-  // const [filteredAgencies, setFilteredAgencies] =
-  //   useState<AgencyWithTeamByID[]>(agencies);
   const [showAgenciesWithLiveDashboards, setShowAgenciesWithLiveDashboards] =
     useState(false);
   const [showSuperagencies, setShowSuperagencies] = useState(false);

--- a/publisher/src/components/AdminPanel/UserProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioning.tsx
@@ -113,7 +113,7 @@ export const UserProvisioning: React.FC<ProvisioningProps> = observer(
 
     /** Modal Buttons (Save/Cancel) */
     const modalButtons = [
-      { label: "Cancel", onClick: closeModal },
+      { label: "Cancel", onClick: () => closeModal() },
       {
         label: "Save",
         onClick: () => saveUpdates(),
@@ -228,7 +228,7 @@ export const UserProvisioning: React.FC<ProvisioningProps> = observer(
       setTimeout(() => {
         setShowSaveConfirmation((prev) => ({ ...prev, show: false }));
         if (response && "status" in response && response.status === 200)
-          closeModal();
+          closeModal(true);
         setIsSaveInProgress(false);
       }, 2000);
     };

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -19,7 +19,7 @@ import { Button } from "@justice-counts/common/components/Button";
 import { DelayedRender } from "@justice-counts/common/components/DelayedRender";
 import { Modal } from "@justice-counts/common/components/Modal";
 import { observer } from "mobx-react-lite";
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 
 import { useStore } from "../../stores";
 import AdminPanelStore from "../../stores/AdminPanelStore";
@@ -30,7 +30,6 @@ import {
   SettingType,
   UserKey,
   UserProvisioning,
-  UserWithAgenciesByID,
 } from ".";
 import * as Styled from "./AdminPanel.styles";
 
@@ -54,11 +53,13 @@ export const UserProvisioningOverview = observer(() => {
     useState<SettingType>();
 
   const [searchInput, setSearchInput] = useState<string>("");
-  const [filteredUsers, setFilteredUsers] = useState<UserWithAgenciesByID[]>(
-    []
-  );
 
   const searchByKeys = ["name", "email", "id"] as UserKey[];
+  const filteredUsers = AdminPanelStore.searchList(
+    users,
+    searchInput,
+    searchByKeys
+  );
 
   const openModal = () => setIsModalOpen(true);
   const openSecondaryModal = () => setActiveSecondaryModal(Setting.AGENCIES);
@@ -71,12 +72,10 @@ export const UserProvisioningOverview = observer(() => {
       resetAgencyProvisioningUpdates();
       setActiveSecondaryModal(undefined);
     }
+    setSearchInput("");
   };
   const searchAndFilter = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchInput(e.target.value);
-    setFilteredUsers(
-      AdminPanelStore.searchList(users, e.target.value, searchByKeys)
-    );
   };
   /**
    * Note: when a user is selected, we are in the context of editing a user.
@@ -91,8 +90,6 @@ export const UserProvisioningOverview = observer(() => {
     updateUserAgencies(Object.keys(selectedUser.agencies).map((id) => +id));
     openModal();
   };
-
-  useEffect(() => setFilteredUsers(users), [users]);
 
   if (loading) {
     return <Loading />;
@@ -144,7 +141,6 @@ export const UserProvisioningOverview = observer(() => {
               <Styled.LabelButton
                 onClick={() => {
                   setSearchInput("");
-                  setFilteredUsers(users);
                 }}
               >
                 Clear

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -63,7 +63,7 @@ export const UserProvisioningOverview = observer(() => {
 
   const openModal = () => setIsModalOpen(true);
   const openSecondaryModal = () => setActiveSecondaryModal(Setting.AGENCIES);
-  const closeModal = () => {
+  const closeModal = (resetSearchInput?: boolean) => {
     if (!activeSecondaryModal) {
       resetUserProvisioningUpdates();
       setSelectedUserID(undefined);
@@ -72,7 +72,9 @@ export const UserProvisioningOverview = observer(() => {
       resetAgencyProvisioningUpdates();
       setActiveSecondaryModal(undefined);
     }
-    setSearchInput("");
+    if (resetSearchInput) {
+      setSearchInput("");
+    }
   };
   const searchAndFilter = (e: React.ChangeEvent<HTMLInputElement>) => {
     setSearchInput(e.target.value);

--- a/publisher/src/components/AdminPanel/types.ts
+++ b/publisher/src/components/AdminPanel/types.ts
@@ -47,7 +47,7 @@ export type ProvisioningProps = {
   selectedIDToEdit?: string | number;
   activeSecondaryModal?: SettingType;
   openSecondaryModal?: () => void;
-  closeModal: () => void;
+  closeModal: (resetSearchInput?: boolean) => void;
 };
 
 export enum SelectionInputBoxTypes {

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -414,7 +414,12 @@ class AdminPanelStore {
     searchInput: string,
     searchByKeys: (keyof T)[]
   ) {
-    const regex = new RegExp(`${searchInput}`, `i`);
+    // Escape special characters in search input
+    const sanitizedSearchInput = searchInput.replace(
+      /[.*+?^${}()|[\]\\]/g,
+      "\\$&"
+    );
+    const regex = new RegExp(`${sanitizedSearchInput}`, `i`);
     return list.filter((listItem) =>
       searchByKeys.some(
         (key) => listItem[key] && regex.test(listItem[key] as string)


### PR DESCRIPTION
## Description of the change

Empties out the search input in the overview pages after saving. 

While I was doing this, I ran into a "off-by-one-render" (for lack of a better phrase) bug in the overview pages and realized that I had fallen into an overcomplicated state w/ mobx and local state (search + filtering logic) that could be dramatically simplified. A nice benefit of this small refactor is that it also takes care of the feedback of retaining the value in the searchbox while checking/unchecking the filter checkboxes in the agency provisioning overview - and everything searches and filters as expected.


https://github.com/Recidiviz/justice-counts/assets/59492998/e279d3e7-e26e-4f3f-9f51-d8952803687d

If anyone is super curious - I'm happy to sync with you & dive deeper into the mobx and local state adjustments!

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
