### PR TITLE
[Publisher] Admin Panel: Playtesting Followup - Add agency name header for single agency users

### DIFF
--- a/publisher/src/components/Menu/Menu.styles.tsx
+++ b/publisher/src/components/Menu/Menu.styles.tsx
@@ -180,6 +180,17 @@ export const AgencyDropdownWrapper = styled.div`
   }
 `;
 
+export const SingleAgencyHeader = styled.div`
+  height: ${HEADER_BAR_HEIGHT}px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: ${palette.solid.darkgrey};
+  color: ${palette.solid.white};
+  margin: auto 0;
+  padding: 16px;
+`;
+
 export const ProfileDropdownContainer = styled.div`
   @media only screen and (max-width: ${MIN_TABLET_WIDTH}px) {
     height: ${HEADER_BAR_HEIGHT}px;

--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -204,21 +204,29 @@ const Menu: React.FC = () => {
     <Styled.MenuContainer isMobileMenuOpen={isMobileMenuOpen}>
       <Styled.AgencyDropdownHeaderBadgeWrapper>
         {/* Agencies Dropdown */}
-        {userStore.userAgencies && userStore.userAgencies.length > 1 && (
-          <Styled.AgencyDropdownWrapper>
-            <Styled.MenuItem>
-              <Dropdown
-                label={currentAgency?.name}
-                options={agencyDropdownOptions}
-                size="small"
-                hover="label"
-                alignment="left"
-                caretPosition="right"
-                highlightIcon={<Styled.TargetIcon />}
-                typeaheadSearch={{ placeholder: "Search for Agency" }}
-              />
-            </Styled.MenuItem>
-          </Styled.AgencyDropdownWrapper>
+        {userStore.userAgencies && (
+          <>
+            {userStore.userAgencies.length < 2 ? (
+              <Styled.SingleAgencyHeader>
+                {currentAgency?.name}
+              </Styled.SingleAgencyHeader>
+            ) : (
+              <Styled.AgencyDropdownWrapper>
+                <Styled.MenuItem>
+                  <Dropdown
+                    label={currentAgency?.name}
+                    options={agencyDropdownOptions}
+                    size="small"
+                    hover="label"
+                    alignment="left"
+                    caretPosition="right"
+                    highlightIcon={<Styled.TargetIcon />}
+                    typeaheadSearch={{ placeholder: "Search for Agency" }}
+                  />
+                </Styled.MenuItem>
+              </Styled.AgencyDropdownWrapper>
+            )}
+          </>
         )}
         {headerBadge}
       </Styled.AgencyDropdownHeaderBadgeWrapper>


### PR DESCRIPTION
## Description of the change

Adds agency name header in the top navigation/header bar for users who belong to only one agency. 

Before:
<img width="1728" alt="Screenshot 2023-12-26 at 10 22 22 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/c7ec1af3-4977-49f1-af27-95414b6520d8">

After:
<img width="1728" alt="Screenshot 2023-12-26 at 10 20 14 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/1cecb4d9-483e-4b12-9346-8a709a4172e1">


## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
