### PR TITLE
[Publisher] Admin Panel: Playtesting Followup - Add indicator on the agency overview cards for child agencies

### DIFF
--- a/publisher/src/components/AdminPanel/AdminPanel.styles.tsx
+++ b/publisher/src/components/AdminPanel/AdminPanel.styles.tsx
@@ -619,6 +619,10 @@ export const SuperagencyIndicator = styled(NumberOfAgencies)`
   color: ${palette.solid.green};
 `;
 
+export const ChildAgencyIndicator = styled(NumberOfAgencies)`
+  color: ${palette.solid.orange};
+`;
+
 export const AgenciesWrapper = styled.div`
   ${typography.sizeCSS.small}
   height: 130px;

--- a/publisher/src/components/AdminPanel/AdminPanel.test.tsx
+++ b/publisher/src/components/AdminPanel/AdminPanel.test.tsx
@@ -503,7 +503,7 @@ test("Agency provisioning overview search box properly searches and filters the 
   );
   let agency1: HTMLElement | null = screen.getByText("Super Agency");
   let agency2: HTMLElement | null = screen.getByText("Z Agency");
-  let agency3: HTMLElement | null = screen.getByText("Child Agency");
+  let agency3: HTMLElement | null = screen.getByText("M Child Agency");
 
   // Search by name
   fireEvent.change(searchBox, { target: { value: "Sup" } });
@@ -517,7 +517,7 @@ test("Agency provisioning overview search box properly searches and filters the 
   fireEvent.change(searchBox, { target: { value: "California" } });
   agency1 = screen.queryByText("Super Agency");
   agency2 = screen.getByText("Z Agency");
-  agency3 = screen.getByText("Child Agency");
+  agency3 = screen.getByText("M Child Agency");
 
   expect(searchBox).toHaveValue("California");
   expect(agency1).toBeNull();
@@ -569,7 +569,7 @@ test("Agency provisioning overview filter checkboxes properly filter superagenci
 
   let agency1 = screen.getByText("Super Agency");
   let agency2 = screen.queryByText("Z Agency");
-  let agency3 = screen.queryByText("Child Agency");
+  let agency3 = screen.queryByText("M Child Agency");
 
   expect(agency1).toBeInTheDocument();
   expect(agency2).toBeNull();
@@ -583,7 +583,7 @@ test("Agency provisioning overview filter checkboxes properly filter superagenci
 
   agency1 = screen.getByText("Super Agency");
   agency2 = screen.getByText("Z Agency");
-  agency3 = screen.queryByText("Child Agency");
+  agency3 = screen.queryByText("M Child Agency");
 
   expect(agency1).toBeInTheDocument();
   expect(agency2).toBeInTheDocument();
@@ -596,7 +596,7 @@ test("Agency provisioning overview filter checkboxes properly filter superagenci
 
   agency1 = screen.getByText("Super Agency");
   agency2 = screen.queryByText("Z Agency");
-  agency3 = screen.queryByText("Child Agency");
+  agency3 = screen.queryByText("M Child Agency");
 
   expect(agency1).toBeInTheDocument();
   expect(agency2).toBeNull();
@@ -697,7 +697,7 @@ test("Clicking on an existing agency card opens the edit agency modal", () => {
     screen.getByLabelText("Superagency");
   const childAgencyInput: HTMLInputElement =
     screen.getByLabelText("Child Agency");
-  const childAgencyChip = screen.getAllByText("Child Agency")[0];
+  const childAgencyChip = screen.getAllByText("M Child Agency")[0];
   const cancelButton = screen.getByText("Cancel");
   const saveButton = screen.getByText("Save");
 

--- a/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
@@ -313,6 +313,11 @@ export const AgencyProvisioningOverview = observer(() => {
                         Superagency
                       </Styled.SuperagencyIndicator>
                     )}
+                    {agency.super_agency_id && (
+                      <Styled.ChildAgencyIndicator>
+                        Child Agency
+                      </Styled.ChildAgencyIndicator>
+                    )}
                     {agency.is_dashboard_enabled && (
                       <Styled.LiveDashboardIndicator
                         onClick={(e) => e.stopPropagation()}

--- a/publisher/src/stores/AdminPanelStore.test.tsx
+++ b/publisher/src/stores/AdminPanelStore.test.tsx
@@ -205,7 +205,7 @@ export const mockAgenciesResponse = {
       id: 11,
       is_dashboard_enabled: null,
       is_superagency: null,
-      name: "Child Agency",
+      name: "M Child Agency",
       settings: [],
       state: "California",
       state_code: "us_ca",
@@ -279,7 +279,7 @@ test("fetchAgencies gets a list of agencies and stores them in the AdminPanelSto
   );
 
   /** The agencies should be sorted in alphabetical  order */
-  expect(adminPanelStore.agencies[0].name).toBe("Child Agency");
+  expect(adminPanelStore.agencies[0].name).toBe("M Child Agency");
   expect(adminPanelStore.agencies[1].name).toBe("Super Agency");
   expect(adminPanelStore.agencies[2].name).toBe("Z Agency");
 });
@@ -288,7 +288,7 @@ test("sortListByName sorts a list of agencies by name in default ascending order
   const sortedAgencies = AdminPanelStore.sortListByName(
     mockAgenciesResponse.agencies
   );
-  expect(sortedAgencies[0].name).toBe("Child Agency");
+  expect(sortedAgencies[0].name).toBe("M Child Agency");
   expect(sortedAgencies[1].name).toBe("Super Agency");
   expect(sortedAgencies[2].name).toBe("Z Agency");
 });
@@ -298,7 +298,7 @@ test("sortListByName sorts a list of agencies by name in explicit ascending orde
     mockAgenciesResponse.agencies,
     "ascending"
   );
-  expect(sortedAgencies[0].name).toBe("Child Agency");
+  expect(sortedAgencies[0].name).toBe("M Child Agency");
   expect(sortedAgencies[1].name).toBe("Super Agency");
   expect(sortedAgencies[2].name).toBe("Z Agency");
 });
@@ -310,7 +310,7 @@ test("sortListByName sorts a list of agencies by name in explicity descending or
   );
   expect(sortedAgencies[0].name).toBe("Z Agency");
   expect(sortedAgencies[1].name).toBe("Super Agency");
-  expect(sortedAgencies[2].name).toBe("Child Agency");
+  expect(sortedAgencies[2].name).toBe("M Child Agency");
 });
 
 test("sortListByName sorts a list of users by name in default ascending order", () => {
@@ -384,7 +384,7 @@ test("searchList returns a filtered list of agencies based on a string value mat
     ["state"]
   );
   expect(filteredListOfAgencies.length).toBe(2);
-  expect(filteredListOfAgencies[0].name).toBe("Child Agency");
+  expect(filteredListOfAgencies[0].name).toBe("M Child Agency");
   expect(filteredListOfAgencies[1].name).toBe("Z Agency");
 
   /** Search value: "11" | Search-by keys: "state" & "id" */
@@ -394,7 +394,7 @@ test("searchList returns a filtered list of agencies based on a string value mat
     ["state", "id"]
   );
   expect(filteredListOfAgencies.length).toBe(2);
-  expect(filteredListOfAgencies[0].name).toBe("Child Agency");
+  expect(filteredListOfAgencies[0].name).toBe("M Child Agency");
   expect(filteredListOfAgencies[1].name).toBe("Super Agency");
 
   /** Search value: "1011" | Search-by keys: "state" & "id" */
@@ -415,7 +415,7 @@ test("objectToSortedFlatMappedValues returns a sorted array of a `groupBy` objec
   const groupedAgenciesSortedValues =
     AdminPanelStore.objectToSortedFlatMappedValues(groupedAgencies);
 
-  expect(groupedAgenciesSortedValues[0].name).toBe("Child Agency");
+  expect(groupedAgenciesSortedValues[0].name).toBe("M Child Agency");
   expect(groupedAgenciesSortedValues[1].name).toBe("Super Agency");
   expect(groupedAgenciesSortedValues[2].name).toBe("Z Agency");
 


### PR DESCRIPTION
## Description of the change

Adds indicator in the Agency Provisioning Overview cards for child agencies. 

<img width="1724" alt="Screenshot 2023-12-26 at 10 05 14 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/ed097f67-6d82-4b4b-9250-db9c271cb37e">


## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
