### PR TITLE
[Publisher] Admin Panel: Quick UI adjustment of add agencies list position

### DIFF
--- a/publisher/src/components/AdminPanel/UserProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioning.tsx
@@ -354,6 +354,25 @@ export const UserProvisioning: React.FC<ProvisioningProps> = observer(
                   </Styled.InputLabelWrapper>
                 )}
 
+                {/* Add Agencies List */}
+                {isAddAction && (
+                  <InteractiveSearchList
+                    list={availableAgencies}
+                    buttons={interactiveSearchListButtons}
+                    selections={addedAgenciesIDs}
+                    updateSelections={updateAgencySelections}
+                    boxActionType={InteractiveSearchListActions.ADD}
+                    isActiveBox={isAddAction}
+                    searchByKeys={["name"]}
+                    metadata={{
+                      searchBoxLabel: "Search agencies",
+                      listBoxLabel: `Select agencies to add`,
+                      listBoxEmptyLabel:
+                        "User is connected to all available agencies",
+                    }}
+                  />
+                )}
+
                 {/* User's Agencies */}
                 {activeSecondaryModal !== Setting.USERS && (
                   <InteractiveSearchList
@@ -416,25 +435,6 @@ export const UserProvisioning: React.FC<ProvisioningProps> = observer(
                       Create New Agency
                     </Styled.ActionButton>
                   </Styled.FormActions>
-                )}
-
-                {/* Add Agencies List */}
-                {isAddAction && (
-                  <InteractiveSearchList
-                    list={availableAgencies}
-                    buttons={interactiveSearchListButtons}
-                    selections={addedAgenciesIDs}
-                    updateSelections={updateAgencySelections}
-                    boxActionType={InteractiveSearchListActions.ADD}
-                    isActiveBox={isAddAction}
-                    searchByKeys={["name"]}
-                    metadata={{
-                      searchBoxLabel: "Search agencies",
-                      listBoxLabel: `Select agencies to add`,
-                      listBoxEmptyLabel:
-                        "User is connected to all available agencies",
-                    }}
-                  />
                 )}
               </Styled.Form>
             </Styled.ScrollableContainer>

--- a/publisher/src/components/AdminPanel/UserProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioning.tsx
@@ -354,25 +354,6 @@ export const UserProvisioning: React.FC<ProvisioningProps> = observer(
                   </Styled.InputLabelWrapper>
                 )}
 
-                {/* Add Agencies List */}
-                {isAddAction && (
-                  <InteractiveSearchList
-                    list={availableAgencies}
-                    buttons={interactiveSearchListButtons}
-                    selections={addedAgenciesIDs}
-                    updateSelections={updateAgencySelections}
-                    boxActionType={InteractiveSearchListActions.ADD}
-                    isActiveBox={isAddAction}
-                    searchByKeys={["name"]}
-                    metadata={{
-                      searchBoxLabel: "Search agencies",
-                      listBoxLabel: `Select agencies to add`,
-                      listBoxEmptyLabel:
-                        "User is connected to all available agencies",
-                    }}
-                  />
-                )}
-
                 {/* User's Agencies */}
                 {activeSecondaryModal !== Setting.USERS && (
                   <InteractiveSearchList
@@ -391,6 +372,25 @@ export const UserProvisioning: React.FC<ProvisioningProps> = observer(
                           : `User's agencies`
                       }`,
                       listBoxEmptyLabel: "User has no agencies",
+                    }}
+                  />
+                )}
+
+                {/* Add Agencies List */}
+                {isAddAction && (
+                  <InteractiveSearchList
+                    list={availableAgencies}
+                    buttons={interactiveSearchListButtons}
+                    selections={addedAgenciesIDs}
+                    updateSelections={updateAgencySelections}
+                    boxActionType={InteractiveSearchListActions.ADD}
+                    isActiveBox={isAddAction}
+                    searchByKeys={["name"]}
+                    metadata={{
+                      searchBoxLabel: "Search agencies",
+                      listBoxLabel: `Select agencies to add`,
+                      listBoxEmptyLabel:
+                        "User is connected to all available agencies",
                     }}
                   />
                 )}


### PR DESCRIPTION
## Description of the change

No-op nitty change - just moving the position of the list of agencies to select from box to above the buttons instead of below. It feels a bit more natural this way.

<img width="815" alt="Screenshot 2023-12-27 at 3 35 07 PM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/b047c1e8-9a7f-4811-8385-953bd6cf1e8d">

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
