### PR TITLE
[Publisher][Bug] Explore Data: Fix broken "Go to Metric Settings" link

### DIFF
--- a/publisher/src/components/DataViz/MetricsDataChart.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.tsx
@@ -155,7 +155,17 @@ export const MetricsDataChart: React.FC = observer(() => {
         `data?system=${currentSystem.toLocaleLowerCase()}&metric=${currentMetric.key.toLocaleLowerCase()}`
       );
       dataVizStore.setInitialStateFromSearchParams();
+      setSettingsSearchParams({
+        system: currentSystem,
+        metric: currentMetric.key,
+      });
     }
+    /**
+     * Disable eslint rule requiring adding `setSettingsSearchParams` as dependency
+     * as it is recreated every render & this effect does not need to depend on it.
+     * All other dependencies are required.
+     */
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [dataVizStore, metricsBySystem, currentMetric, currentSystem]);
 
   useEffect(() => {


### PR DESCRIPTION
## Description of the change

When I was poking around the Explore Data page to resolve a separate issue, I noticed that the "Go to Metric Settings" link at times navigated to a Page Not Found component - and other times go to the proper metric configuration component. 

<img width="463" alt="Screenshot 2023-12-27 at 10 44 37 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/11a68327-203d-420a-b66e-f6da61ea707b">

This is due to the `settingsSearchParams` not being updated when the URL params are being set, thus sending `undefined` for the `system` param and `metric` param (i.e. it navigates to `http://.../agency/147/metric-config?system=undefined&metric=undefined` which shows the Page Not Found component). 

If you refresh the Explore Data page and go to those links, it will work because the `settingsSearchParams` picks up on the already set URL params (e.g. `http://.../agency/147/data?system=superagency&metric=superagency_funding&...`) and will navigate to `http://.../agency/147/metric-config?system=superagency&metric=superagency_funding`.

So this PR solves the problem by updating the `settingsSearchParams` when the Explore Data page URL params are being set (and every time they are updated) - keeping everything...
<img src="https://media3.giphy.com/media/UTMmSeNki6wx0TMD2u/giphy.gif" width="350" />


https://github.com/Recidiviz/justice-counts/assets/59492998/2b6c2014-a3f6-4a70-bbb4-65417df15763

## Related issues

Closes #1109 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
