### PR TITLE
[Publisher] Prevent agencies from being able to have supervisions metrics that are both combined and disaggregated

### DIFF
--- a/common/components/RadioButton/RadioButtonsWrapper.tsx
+++ b/common/components/RadioButton/RadioButtonsWrapper.tsx
@@ -24,18 +24,20 @@ import {
 import { WrapperSpacing } from "./types";
 
 type RadioButtonsWrapperProps = {
+  id?: string;
   children: React.ReactNode;
   spacing?: WrapperSpacing;
   disabled?: boolean;
 };
 
 export function RadioButtonsWrapper({
+  id,
   children,
   spacing,
   disabled,
 }: RadioButtonsWrapperProps) {
   return (
-    <Wrapper spacing={spacing}>
+    <Wrapper spacing={spacing} id={id}>
       <RadioButtonsFieldset disabled={disabled}>
         {children}
       </RadioButtonsFieldset>

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -26,6 +26,7 @@ import {
   RadioButtonsWrapper,
 } from "@justice-counts/common/components/RadioButton";
 import { ToggleSwitch } from "@justice-counts/common/components/ToggleSwitch";
+import { Tooltip } from "@justice-counts/common/components/Tooltip";
 import {
   SupervisionSubsystems,
   SupervisionSystem,
@@ -99,10 +100,19 @@ function MetricAvailability({ goToDefineMetrics }: MetricAvailabilityProps) {
     disaggregatedBySupervisionSubsystems &&
     systemSearchParam &&
     !SupervisionSubsystems.includes(systemSearchParam);
-  const isSupervisionSubsystemMetricAndNotDisaggregatedBySubsystems =
+  const isSupervisionSubsystemMetricAndSubsystemsCombined =
     !disaggregatedBySupervisionSubsystems &&
     systemSearchParam &&
     SupervisionSubsystems.includes(systemSearchParam);
+
+  const getDisaggregatedBySupervisionSubtypeTooltipMsg = () => {
+    if (isSupervisionMetricAndDisaggregatedBySupervisionSubsystems) {
+      return `This metric is marked as 'Disaggregated'. Please adjust the availability on the disaggregated metrics or update the 'Disaggregated by Supervision Type' to 'Combined'.`;
+    }
+    if (isSupervisionSubsystemMetricAndSubsystemsCombined) {
+      return `This metric is marked as 'Combined'. Please adjust the availability on the combined metric or update the 'Disaggregated by Supervision Type' to 'Disaggregated'.`;
+    }
+  };
 
   const handleUpdateMetricEnabledStatus = (enabledStatus: boolean) => {
     if (systemSearchParam && metricSearchParam) {
@@ -258,10 +268,11 @@ function MetricAvailability({ goToDefineMetrics }: MetricAvailabilityProps) {
                 </Styled.InfoIconWrapper>
               </Styled.SettingName>
               <RadioButtonsWrapper
+                id="availability-buttons-wrapper"
                 disabled={
                   isReadOnly ||
                   isSupervisionMetricAndDisaggregatedBySupervisionSubsystems ||
-                  isSupervisionSubsystemMetricAndNotDisaggregatedBySubsystems
+                  isSupervisionSubsystemMetricAndSubsystemsCombined
                 }
               >
                 <RadioButton
@@ -306,6 +317,14 @@ function MetricAvailability({ goToDefineMetrics }: MetricAvailabilityProps) {
                   }
                 />
               </RadioButtonsWrapper>
+              {(isSupervisionMetricAndDisaggregatedBySupervisionSubsystems ||
+                isSupervisionSubsystemMetricAndSubsystemsCombined) && (
+                <Tooltip
+                  anchorId="availability-buttons-wrapper"
+                  position="top"
+                  content={getDisaggregatedBySupervisionSubtypeTooltipMsg()}
+                />
+              )}
             </Styled.SettingRow>
             {metricEnabled && customFrequency === "ANNUAL" && (
               <Styled.SettingRow>

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -95,6 +95,14 @@ function MetricAvailability({ goToDefineMetrics }: MetricAvailabilityProps) {
     .map((system) => system.toLowerCase());
   const hasEnabledSupervisionSubsystems =
     enabledSupervisionSubsystems && enabledSupervisionSubsystems.length > 0;
+  const isSupervisionMetricAndDisaggregatedBySupervisionSubsystems =
+    disaggregatedBySupervisionSubsystems &&
+    systemSearchParam &&
+    !SupervisionSubsystems.includes(systemSearchParam);
+  const isSupervisionSubsystemMetricAndNotDisaggregatedBySubsystems =
+    !disaggregatedBySupervisionSubsystems &&
+    systemSearchParam &&
+    SupervisionSubsystems.includes(systemSearchParam);
 
   const handleUpdateMetricEnabledStatus = (enabledStatus: boolean) => {
     if (systemSearchParam && metricSearchParam) {
@@ -249,7 +257,13 @@ function MetricAvailability({ goToDefineMetrics }: MetricAvailabilityProps) {
                   </Styled.SettingTooltip>
                 </Styled.InfoIconWrapper>
               </Styled.SettingName>
-              <RadioButtonsWrapper disabled={isReadOnly}>
+              <RadioButtonsWrapper
+                disabled={
+                  isReadOnly ||
+                  isSupervisionMetricAndDisaggregatedBySupervisionSubsystems ||
+                  isSupervisionSubsystemMetricAndNotDisaggregatedBySubsystems
+                }
+              >
                 <RadioButton
                   type="radio"
                   id="metric-config-not-available"


### PR DESCRIPTION
## Description of the change

Prevents supervision + subsystems agencies from entering a state where both combined and disaggregated metrics are enabled.


https://github.com/Recidiviz/justice-counts/assets/59492998/2de1c109-47dd-404c-a770-be8ec9067546


Tooltips (all copy improvement suggestions welcome):
<img width="552" alt="Screenshot 2023-12-27 at 1 45 27 PM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/3c268e03-d721-4f81-a71c-bd601c9960e8">
<img width="552" alt="Screenshot 2023-12-27 at 1 45 13 PM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/18c6be74-1fd8-4788-b275-e113ce1fc4eb">

## Related issues

Closes [#25629](https://github.com/Recidiviz/recidiviz-data/issues/25629)

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
