### PR TITLE
[Publisher] Admin Panel: Quick bug fix with link to Live Dashboard

### DIFF
--- a/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
@@ -284,7 +284,10 @@ export const AgencyProvisioningOverview = observer(() => {
                       <Styled.LiveDashboardIndicator
                         onClick={(e) => e.stopPropagation()}
                       >
-                        <LinkToDashboard agencyID={String(agency.id)}>
+                        <LinkToDashboard
+                          agencyID={String(agency.id)}
+                          name={agency.name}
+                        >
                           Live Dashboard
                         </LinkToDashboard>
                       </Styled.LiveDashboardIndicator>

--- a/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
+++ b/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
@@ -37,15 +37,15 @@ export const LinkToPublisher: React.FC<
 });
 
 export const LinkToDashboard: React.FC<
-  PropsWithChildren & { agencyID?: string }
-> = observer(({ children, agencyID }) => {
+  PropsWithChildren & { agencyID?: string; name?: string }
+> = observer(({ children, agencyID, name }) => {
   const { api, userStore } = useStore();
   const agencyIdLocalStorage = localStorage.getItem("agencyId");
   const agencyId =
     agencyID ||
     agencyIdLocalStorage ||
     userStore.getInitialAgencyId()?.toLocaleString();
-  const agencyName = agencyId && userStore.getAgency(agencyId)?.name;
+  const agencyName = name || (agencyId && userStore.getAgency(agencyId)?.name);
 
   if (!agencyName) return <>{children}</>;
 


### PR DESCRIPTION
## Description of the change

I noticed that the link to the **Live Dashboard** in the Agency Provisioning Overview page was not working (or even hovering). I realized that the `LinkToDashboard` component relies on the `agencyName` from the logged in user's list of agencies - so if the user isn't tied to the agency, the `userStore.getAgency(agencyId)?.name` will return `undefined` and the **Live Dashboard** link on the cards just appears as text. 

This adjustment allows the `LinkToDashboard` component to accept a `name` prop and use that if/when provided. From the Agency Provisioning Overview component, we can pass in the agency's name and get the proper linking to the the appropriate dashboard.

This was simple to test as the link and hover interactions began to appear after this change.

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
