### PR TITLE
[Justice Counts] update task cards for uploading missing metrics

### DIFF
--- a/publisher/src/components/Home/Home.test.tsx
+++ b/publisher/src/components/Home/Home.test.tsx
@@ -90,9 +90,9 @@ test("the proper welcome, description, and task cards appear based on the mocked
   const useOfForceIncidentsTaskCard = screen.getByText(
     "Use of Force Incidents"
   );
-  const fundingTaskCard = screen.getByText("Funding");
-  const expensesTaskCard = screen.getByText("Expenses");
-  const staffTaskCard = screen.getByText("Staff");
+  const fundingTaskCard = screen.getByText("Upload Funding Metric");
+  const expensesTaskCard = screen.getByText("Upload Expenses Metric");
+  const staffTaskCard = screen.getByText("Upload Staff Metric");
   const annualRecordTaskCard = screen.getByText("Annual Record 2023 (January)");
   const monthlyRecordTaskCard = screen.getByText("July 2023");
   const metricConfigTaskCards = screen.getAllByText("Set Metric Availability");
@@ -156,16 +156,17 @@ test("setting a metric configuration should replace the set metric availability 
     mockAgencyID
   );
 
-  /** Check to see if Reported Crime metric now has an "Upload Data"/"Manual Entry" task card */
-  reportedCrimeActionLinkNodes =
-    screen.getByText("Reported Crime").nextSibling?.nextSibling?.childNodes;
+  /** Check to see if Reported Crime metric now has an "Bulk Upload"/"Manual Entry" task card */
+  reportedCrimeActionLinkNodes = screen.getByText(
+    "Upload Reported Crime Metric"
+  ).nextSibling?.nextSibling?.childNodes;
   reportedCrimeActionLinkText =
     reportedCrimeActionLinkNodes &&
     (reportedCrimeActionLinkNodes.length > 1
       ? `${reportedCrimeActionLinkNodes[0].textContent} ${reportedCrimeActionLinkNodes[1].textContent}`
       : reportedCrimeActionLinkNodes[0].textContent);
 
-  expect(reportedCrimeActionLinkText).toBe("Upload Data Manual Entry");
+  expect(reportedCrimeActionLinkText).toBe("Bulk Upload Manual Entry");
   expect.hasAssertions();
 });
 
@@ -204,16 +205,16 @@ test("adding data to a metric should remove the add data task card for the metri
 
   expect(screen.queryByText("Annual Record 2023 (January)")).toBeNull();
 
-  /** Check to see if Funding metric (annual frequency) has an "Upload Data"/"Manual Entry" task card  */
-  const fundingActionLinkNodes =
-    screen.queryByText("Funding")?.nextSibling?.nextSibling?.childNodes;
+  /** Check to see if Funding metric (annual frequency) has an "Bulk Upload"/"Manual Entry" task card  */
+  const fundingActionLinkNodes = screen.queryByText("Upload Funding Metric")
+    ?.nextSibling?.nextSibling?.childNodes;
   const fundingActionLinkText =
     fundingActionLinkNodes &&
     (fundingActionLinkNodes.length > 1
       ? `${fundingActionLinkNodes[0].textContent} ${fundingActionLinkNodes[1].textContent}`
       : fundingActionLinkNodes[0].textContent);
 
-  expect(fundingActionLinkText).toBe("Upload Data Manual Entry");
+  expect(fundingActionLinkText).toBe("Bulk Upload Manual Entry");
 
   /** Mock user setting adding data for Funding metric */
   updatedLatestRecordsMetrics = updateMetricProps(
@@ -232,12 +233,12 @@ test("adding data to a metric should remove the add data task card for the metri
 
   /**
    * Check to see if adding value to Funding metric (annual frequency) created an annual record publish task card
-   * and there is no longer a Funding metric "Upload Data"/"Manual Entry" task card
+   * and there is no longer a Funding metric "Bulk Upload"/"Manual Entry" task card
    */
   expect(
     screen.queryByText("Annual Record 2023 (January)")
   ).toBeInTheDocument();
-  expect(screen.queryByText("Funding")).toBeNull();
+  expect(screen.queryByText("Upload Funding Metric")).toBeNull();
   expect.hasAssertions();
 });
 

--- a/publisher/src/components/Home/TaskCard.tsx
+++ b/publisher/src/components/Home/TaskCard.tsx
@@ -48,7 +48,7 @@ export const TaskCard: React.FC<{
       {actionLinks && (
         <Styled.TaskCardActionLinksWrapper>
           {actionLinks.map((action) => {
-            /** Exclude "Upload Data" action link from Superagency data entry metric task cards */
+            /** Exclude "Bulk Upload" action link from Superagency data entry metric task cards */
             if (
               isSuperagency &&
               action.label === taskCardLabelsActionLinks.uploadData.label

--- a/publisher/src/components/Home/types.ts
+++ b/publisher/src/components/Home/types.ts
@@ -25,7 +25,7 @@ import {
 
 export const taskCardLabelsActionLinks: TaskCardActionLinksMetadataList = {
   publish: { label: "Publish", path: "records/" },
-  uploadData: { label: "Upload Data", path: "upload" },
+  uploadData: { label: "Bulk Upload", path: "upload" },
   manualEntry: { label: "Manual Entry", path: "records/" },
   metricAvailability: {
     label: "Set Metric Availability",

--- a/publisher/src/stores/HomeStore.test.tsx
+++ b/publisher/src/stores/HomeStore.test.tsx
@@ -107,13 +107,17 @@ test("latestAnnualRecordsMetadata reflects the latest annual record(s)' metadata
 });
 
 test("addDataConfigureMetricsTaskCardMetadatas reflects the metrics that are unconfigured or missing data", () => {
-  const enabledUnconfiguredMetricDisplayNames = [
-    ...homeStore.enabledCurrentSystemMetrics,
-    ...homeStore.unconfiguredCurrentSystemMetrics,
-  ]
+  const enabledMetrics = [...homeStore.enabledCurrentSystemMetrics]
     .filter((metric) => metric.enabled === null || metric.value === null)
-    .map((metric) => metric.display_name)
-    .sort();
+    .map((metric) => `Upload ${metric.display_name} Metric`);
+
+  const unconfiguredMetrics = [...homeStore.unconfiguredCurrentSystemMetrics]
+    .filter((metric) => metric.enabled === null || metric.value === null)
+    .map((metric) => metric.display_name);
+  const enabledUnconfiguredMetricDisplayNames = [
+    ...enabledMetrics,
+    ...unconfiguredMetrics,
+  ].sort();
   expect(homeStore.addDataConfigureMetricsTaskCardMetadatas?.length).toEqual(5);
   expect(
     homeStore.addDataConfigureMetricsTaskCardMetadatas

--- a/publisher/src/stores/HomeStore.ts
+++ b/publisher/src/stores/HomeStore.ts
@@ -468,7 +468,7 @@ class HomeStore {
       key: currentMetric.key,
       recordID: recordMetadata?.id,
       title: HomeStore.formatTaskCardTitle(
-        currentMetric.display_name,
+        `Upload ${currentMetric.display_name} Metric`,
         currentMetric.system.display_name,
         hasMultipleSystemsAndAllSystemsFilter
       ),


### PR DESCRIPTION
## Description of the change

P0 of the Publisher Notifications project requires that we change the homepage card wording for uploading for a metric.  Title should become “Upload {metric name} Metric” and the “Upload Data” cta should become “Bulk Upload”

<img width="1709" alt="Screenshot 2024-01-05 at 8 45 48 PM" src="https://github.com/Recidiviz/justice-counts/assets/19961693/d7e9feb1-40fa-4670-b607-0e8a355e60bf">


## Related issues

Closes  #1129

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [x] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
