### PR TITLE
[Publisher][Bug] Fix superagency double upload bugs by removing special filtering in `UploadFile` component

### DIFF
--- a/publisher/src/components/DataUpload/InstructionsTemplate.tsx
+++ b/publisher/src/components/DataUpload/InstructionsTemplate.tsx
@@ -186,6 +186,9 @@ export const GeneralInstructions: React.FC<
     React.useState<{
       [key: string]: boolean;
     }>({});
+  const userSystemsExcludingSuperagency = systems.filter(
+    (system) => system !== "SUPERAGENCY"
+  );
 
   const fetchTemplate = async (
     isSinglePageTemplate: boolean,
@@ -304,7 +307,7 @@ export const GeneralInstructions: React.FC<
         {REPORTING_LOWERCASE} data for. Your agency is responsible for{" "}
         {REPORTING_LOWERCASE} data for:{" "}
         {/* replace last comma with "and": https://stackoverflow.com/a/41035407 */}
-        {systems
+        {userSystemsExcludingSuperagency
           .map((system) => systemToDetails[system].name)
           .join(", ")
           .replace(/,(?!.*,)/gim, " and")}
@@ -410,7 +413,7 @@ export const GeneralInstructions: React.FC<
         pages or multiple CSV files, a Single Page Upload template is also
         available (see the{" "}
         <i>
-          {systems
+          {userSystemsExcludingSuperagency
             .map((system) => systemToDetails[system].name)
             .join(", ")
             .replace(/,(?!.*,)/gim, " and")}{" "}

--- a/publisher/src/components/DataUpload/InstructionsTemplate.tsx
+++ b/publisher/src/components/DataUpload/InstructionsTemplate.tsx
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import { MiniLoader } from "@justice-counts/common/components/MiniLoader";
-import { AgencySystems } from "@justice-counts/common/types";
+import { AgencySystem, AgencySystems } from "@justice-counts/common/types";
 import React from "react";
 
 import { removeSnakeCase } from "../../utils";
@@ -39,7 +39,7 @@ import { MiniLoaderWrapper } from "./DataUpload.styles";
 
 export type GeneralInstructionsTemplateParams = {
   agencyId: string;
-  systems: string[];
+  systems: AgencySystem[];
   downloadTemplate: (
     system: string,
     isSinglePageTemplate: boolean
@@ -48,7 +48,7 @@ export type GeneralInstructionsTemplateParams = {
 };
 
 export type SystemsInstructionsTemplateParams = {
-  system: string;
+  system: AgencySystem;
 };
 
 type SystemDetails = {
@@ -189,6 +189,11 @@ export const GeneralInstructions: React.FC<
     }>({});
   const superagencyDisplayName = "Superagency";
 
+  const getSystemDisplayName = (system: AgencySystem) =>
+    system === AgencySystems.SUPERAGENCY
+      ? superagencyDisplayName
+      : systemToDetails[system].name;
+
   const fetchTemplate = async (
     isSinglePageTemplate: boolean,
     system: string
@@ -307,11 +312,7 @@ export const GeneralInstructions: React.FC<
         {REPORTING_LOWERCASE} data for:{" "}
         {/* replace last comma with "and": https://stackoverflow.com/a/41035407 */}
         {systems
-          .map((system) =>
-            system === AgencySystems.SUPERAGENCY
-              ? superagencyDisplayName
-              : systemToDetails[system].name
-          )
+          .map(getSystemDisplayName)
           .join(", ")
           .replace(/,(?!.*,)/gim, " and")}
         .
@@ -417,11 +418,7 @@ export const GeneralInstructions: React.FC<
         available (see the{" "}
         <i>
           {systems
-            .map((system) =>
-              system === AgencySystems.SUPERAGENCY
-                ? superagencyDisplayName
-                : systemToDetails[system].name
-            )
+            .map(getSystemDisplayName)
             .join(", ")
             .replace(/,(?!.*,)/gim, " and")}{" "}
           Single Page

--- a/publisher/src/components/DataUpload/InstructionsTemplate.tsx
+++ b/publisher/src/components/DataUpload/InstructionsTemplate.tsx
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import { MiniLoader } from "@justice-counts/common/components/MiniLoader";
+import { AgencySystems } from "@justice-counts/common/types";
 import React from "react";
 
 import { removeSnakeCase } from "../../utils";
@@ -186,9 +187,7 @@ export const GeneralInstructions: React.FC<
     React.useState<{
       [key: string]: boolean;
     }>({});
-  const userSystemsExcludingSuperagency = systems.filter(
-    (system) => system !== "SUPERAGENCY"
-  );
+  const superagencyDisplayName = "Superagency";
 
   const fetchTemplate = async (
     isSinglePageTemplate: boolean,
@@ -307,8 +306,12 @@ export const GeneralInstructions: React.FC<
         {REPORTING_LOWERCASE} data for. Your agency is responsible for{" "}
         {REPORTING_LOWERCASE} data for:{" "}
         {/* replace last comma with "and": https://stackoverflow.com/a/41035407 */}
-        {userSystemsExcludingSuperagency
-          .map((system) => systemToDetails[system].name)
+        {systems
+          .map((system) =>
+            system === AgencySystems.SUPERAGENCY
+              ? superagencyDisplayName
+              : systemToDetails[system].name
+          )
           .join(", ")
           .replace(/,(?!.*,)/gim, " and")}
         .
@@ -413,8 +416,12 @@ export const GeneralInstructions: React.FC<
         pages or multiple CSV files, a Single Page Upload template is also
         available (see the{" "}
         <i>
-          {userSystemsExcludingSuperagency
-            .map((system) => systemToDetails[system].name)
+          {systems
+            .map((system) =>
+              system === AgencySystems.SUPERAGENCY
+                ? superagencyDisplayName
+                : systemToDetails[system].name
+            )
             .join(", ")
             .replace(/,(?!.*,)/gim, " and")}{" "}
           Single Page

--- a/publisher/src/components/DataUpload/UploadFile.tsx
+++ b/publisher/src/components/DataUpload/UploadFile.tsx
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import { showToast } from "@justice-counts/common/components/Toast";
-import { AgencySystem } from "@justice-counts/common/types";
+import { AgencySystem, AgencySystems } from "@justice-counts/common/types";
 import React, { Fragment, useEffect, useRef, useState } from "react";
 import { useParams } from "react-router-dom";
 
@@ -61,9 +61,6 @@ export const UploadFile: React.FC<UploadFileProps> = ({
   ];
 
   const isReadOnly = userStore.isUserReadOnly(agencyId);
-  const userSystemsExcludingSuperagency = userSystems.filter(
-    (system) => system !== "SUPERAGENCY"
-  );
 
   const handleFileUploadAttempt = (
     e: React.ChangeEvent<HTMLInputElement> | DragEvent
@@ -80,11 +77,11 @@ export const UploadFile: React.FC<UploadFileProps> = ({
     }
 
     setIsLoading(true);
-    if (userSystemsExcludingSuperagency.length > 1) {
+    if (userSystems.length > 1) {
       setIsLoading(false);
       setSelectedFile(files[0]);
     } else {
-      handleFileUpload(files[0], userSystemsExcludingSuperagency[0]);
+      handleFileUpload(files[0], userSystems[0]);
     }
   };
   const handleDownloadSpreadsheetTemplate = async (
@@ -173,23 +170,25 @@ export const UploadFile: React.FC<UploadFileProps> = ({
         {/* General Instructions */}
         <GeneralInstructions
           agencyId={agencyId}
-          systems={userSystemsExcludingSuperagency}
+          systems={userSystems}
           downloadTemplate={handleDownloadSpreadsheetTemplate}
           isDownloading={isDownloading}
         />
 
         {/* System Specific Instructions (excludes Superagency systems) */}
-        {userSystemsExcludingSuperagency.map((system) => {
-          const systemName = removeSnakeCase(system).toLowerCase();
-          const systemTemplate = <SystemsInstructions system={system} />;
+        {userSystems
+          .filter((system) => system !== AgencySystems.SUPERAGENCY)
+          .map((system) => {
+            const systemName = removeSnakeCase(system).toLowerCase();
+            const systemTemplate = <SystemsInstructions system={system} />;
 
-          return (
-            <Fragment key={systemName}>
-              <h2>{systemName}</h2>
-              {systemTemplate}
-            </Fragment>
-          );
-        })}
+            return (
+              <Fragment key={systemName}>
+                <h2>{systemName}</h2>
+                {systemTemplate}
+              </Fragment>
+            );
+          })}
       </Instructions>
 
       <DragDropContainer ref={dragDropAreaRef} dragging={dragging}>


### PR DESCRIPTION
## Description of the change

Fix superagency double upload bugs by removing special filtering in `UploadFile` component.

Two bugs surfaced were:

* When you upload a file, the /spreadsheets endpoint is called twice by the FE
* When you upload a successful file (no errors/warnings) as an agency with Superagency + 1 other sector, you bypass the SystemSelection component

Both bugs only appeared for agencies with Superagency + 1 other sector, the other multi-sector agency (Supervision & Prisons) we tested did not experience these bugs. Both bugs point to a root issue of filtering out the Superagency sector from the list of the users agency in the `UploadFile` component (child of `DataUpload` component).

The filtering taking place only in the `UploadFile` component throws off the parent `DataUpload` component because it's set up to handle multi-sector agencies and single sector agencies differently in the Data Upload page.
  * The `DataUpload` believes the user has two sectors `["SUPERAGENCY", "<SECOND SECTOR>"]` and will display the sector selection screen and fire off it's upload handler function after a user selects a sector.
  * The `UploadFile` component believes there is only one sector `["<SECOND SECTOR>"]` and will also fire off its upload handler as it's instructed to do for single sector agencies
  * How it affects the other bug is more nuanced - the discrepancy between the two components (`DataUpload` and `UploadFile`) list of systems also meant that the `UploadFile` component's `handleFileUploadAttempt` never runs `setSelectedFile` (that state of which `DataUpload` uses to determine whether or not to show the `SystemSelection` component) because it believes it's a single sector agency and goes straight to the upload. 

The solution is to remove the special superagency sector filtering taking place in the `UploadedFile` component (and adjust the `InstructionsTemplate` crashing because there are no superagency instructions) - which solved both problems during our session. 

Huge thanks to @morden35 and @brandon-hills for a great debugging session yesterday that helped us get to the root of this issue!

Playtesting link for further testing: https://mahmoudtest---publisher-web-b47yvyxs3q-uc.a.run.app

## Related issues

Closes [#26520](https://github.com/Recidiviz/recidiviz-data/issues/26520)

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
