### PR TITLE
[Publisher] Admin Panel: CSG Followups - Ensure supervision subpopulation sectors cannot be selected without Supervision sector also being selected

### DIFF
--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -26,6 +26,7 @@ import {
   AgencySystem,
   AgencySystems,
   AgencyTeamMemberRole,
+  SupervisionSubsystems,
 } from "@justice-counts/common/types";
 import {
   isCSGOrRecidivizUserByEmail,
@@ -635,9 +636,37 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                           new Set(systems)
                         )}
                         updateSelections={({ id }) => {
-                          setSelectedSystems((prev) =>
-                            toggleAddRemoveSetItem(prev, id as AgencySystems)
-                          );
+                          setSelectedSystems((prev) => {
+                            const currentSystems = prev;
+                            /**
+                             * Special handling for Supervision & subpopulation sectors:
+                             *  - If the user selects a supervision subpopulation and they have not explicitly selected the Supervision
+                             *    sector, auto-add the Supervision sector.
+                             *  - If the user de-selects the Supervision sector, then auto-de-select all selected supervision subpopulation
+                             *    sectors
+                             */
+                            if (
+                              SupervisionSubsystems.includes(
+                                id as AgencySystem
+                              ) &&
+                              !currentSystems.has(AgencySystems.SUPERVISION)
+                            ) {
+                              currentSystems.add(AgencySystems.SUPERVISION);
+                            }
+                            if (
+                              id === AgencySystems.SUPERVISION &&
+                              currentSystems.has(AgencySystems.SUPERVISION)
+                            ) {
+                              SupervisionSubsystems.forEach((subsystem) =>
+                                currentSystems.delete(subsystem)
+                              );
+                            }
+
+                            return toggleAddRemoveSetItem(
+                              currentSystems,
+                              id as AgencySystems
+                            );
+                          });
                         }}
                         searchByKeys={["name"]}
                         metadata={{


### PR DESCRIPTION
## Description of the change

Auto-select Supervision sector when any supervision subpopulation sector is selected and auto-deselect subpopulation sectors when Supervision sector is deselected.

Currently, when creating/editing an agency in the admin panel, a user is able to select supervision subpopulations sectors without the selection of the Supervision sector and save. This solution prevents that by automatically handling these supervision selections and avoiding a state where a user has only supervision subpopulation sectors and no Supervision sector.

https://github.com/Recidiviz/justice-counts/assets/59492998/271d263f-3f4f-4ffe-8165-a15f9ac3c8b3

## Related issues

Contributes to #1135

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
