### PR TITLE
[Publisher][Bug] Admin Panel: Exclude superagency sector from consideration when determining whether or not a user has sectors selected

### DIFF
--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -640,10 +640,12 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                         selections={selectedSystems}
                         buttons={getInteractiveSearchListSelectDeselectCloseButtons(
                           setSelectedSystems,
+                          // If superagencies is checked, include the Superagency sector when user selects all
                           agencyProvisioningUpdates.is_superagency
                             ? new Set([...systems, AgencySystems.SUPERAGENCY])
                             : new Set(systems),
                           undefined,
+                          // If superagencies is checked, still include the Superagency sector when user deselects all
                           agencyProvisioningUpdates.is_superagency
                             ? new Set([AgencySystems.SUPERAGENCY])
                             : undefined

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -378,7 +378,14 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
         agencyProvisioningUpdates.systems.filter((system) =>
           selectedSystems.has(system)
         ).length === 0);
-    const hasSystems = selectedSystems.size > 0;
+
+    const hasSystems =
+      selectedSystems.size > 0 &&
+      // Exclude Superagency system from consideration.
+      !(
+        selectedSystems.size === 1 &&
+        selectedSystems.has(AgencySystems.SUPERAGENCY)
+      );
     /**
      * An update has been made when the agency's `is_dashboard_enabled` boolean flag does not match the agency's
      * boolean flag for that property before the modal was open.

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -640,12 +640,12 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                         selections={selectedSystems}
                         buttons={getInteractiveSearchListSelectDeselectCloseButtons(
                           setSelectedSystems,
-                          // If superagencies is checked, include the Superagency sector when user selects all
+                          // If Superagency is checked, include the Superagency sector when user selects all
                           agencyProvisioningUpdates.is_superagency
                             ? new Set([...systems, AgencySystems.SUPERAGENCY])
                             : new Set(systems),
                           undefined,
-                          // If superagencies is checked, still include the Superagency sector when user deselects all
+                          // If Superagency is checked, still include the Superagency sector when user deselects all
                           agencyProvisioningUpdates.is_superagency
                             ? new Set([AgencySystems.SUPERAGENCY])
                             : undefined

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -211,7 +211,8 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
     const getInteractiveSearchListSelectDeselectCloseButtons = <T,>(
       setState: React.Dispatch<React.SetStateAction<Set<T>>>,
       selectAllSet: Set<T>,
-      selectAllCallback?: () => void
+      selectAllCallback?: () => void,
+      deselectAllSetOverride?: Set<T>
     ) => {
       return [
         {
@@ -223,7 +224,7 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
         },
         {
           label: "Deselect All",
-          onClick: () => setState(new Set()),
+          onClick: () => setState(deselectAllSetOverride || new Set()),
         },
         interactiveSearchListCloseButton[0],
       ];
@@ -639,7 +640,13 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                         selections={selectedSystems}
                         buttons={getInteractiveSearchListSelectDeselectCloseButtons(
                           setSelectedSystems,
-                          new Set(systems)
+                          agencyProvisioningUpdates.is_superagency
+                            ? new Set([...systems, AgencySystems.SUPERAGENCY])
+                            : new Set(systems),
+                          undefined,
+                          agencyProvisioningUpdates.is_superagency
+                            ? new Set([AgencySystems.SUPERAGENCY])
+                            : undefined
                         )}
                         updateSelections={({ id }) => {
                           setSelectedSystems((prev) =>


### PR DESCRIPTION
## Description of the change

Exclude superagency sector from consideration when determining whether or not a user has sectors selected.

Currently, when creating/editing an agency, a user is able to check the **Superagency** checkbox (which auto-adds the Superagency sector) and the `hasSystems` logic registers that as a user having a minimum of 1 sector and allows you to save with only a Superagency sector (provided all other required fields are filled out). This adjustments prevents a state where an agency can only have a Superagency sector by requiring a user to select an additional sector before being allowed to save.

Note: I also noticed a small bug in the "Select All" and "Deselect All" logic for selecting sectors that I included here - when deselecting all, the Superagency sector is removed as well despite still being checked, and when selecting all, the superagency system is excluded.


https://github.com/Recidiviz/justice-counts/assets/59492998/9e4aeb9f-8340-4e88-a6c3-75b733e8a322

## Related issues

Contributes to #1135

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
