### PR TITLE
[Publisher] Admin Panel: CSG Followups - Add link to Publisher in agency cards

### DIFF
--- a/publisher/src/components/AdminPanel/AdminPanel.styles.tsx
+++ b/publisher/src/components/AdminPanel/AdminPanel.styles.tsx
@@ -601,7 +601,7 @@ export const IndicatorWrapper = styled.div`
   gap: 8px;
 `;
 
-export const LiveDashboardIndicator = styled(NumberOfAgencies)`
+export const DashboardPublisherLinkIndicator = styled(NumberOfAgencies)`
   &,
   a,
   a:visited {

--- a/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioningOverview.tsx
@@ -23,7 +23,10 @@ import React, { useState } from "react";
 
 import { useStore } from "../../stores";
 import AdminPanelStore from "../../stores/AdminPanelStore";
-import { LinkToDashboard } from "../HelpCenter/LinkToPublisherDashboard";
+import {
+  LinkToDashboard,
+  LinkToPublisher,
+} from "../HelpCenter/LinkToPublisherDashboard";
 import { Loading } from "../Loading";
 import {
   AgencyKey,
@@ -281,7 +284,7 @@ export const AgencyProvisioningOverview = observer(() => {
                       </Styled.ChildAgencyIndicator>
                     )}
                     {agency.is_dashboard_enabled && (
-                      <Styled.LiveDashboardIndicator
+                      <Styled.DashboardPublisherLinkIndicator
                         onClick={(e) => e.stopPropagation()}
                       >
                         <LinkToDashboard
@@ -290,8 +293,18 @@ export const AgencyProvisioningOverview = observer(() => {
                         >
                           Live Dashboard
                         </LinkToDashboard>
-                      </Styled.LiveDashboardIndicator>
+                      </Styled.DashboardPublisherLinkIndicator>
                     )}
+                    <Styled.DashboardPublisherLinkIndicator
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      <LinkToPublisher
+                        publisherPath=""
+                        agencyID={String(agency.id)}
+                      >
+                        Publisher
+                      </LinkToPublisher>
+                    </Styled.DashboardPublisherLinkIndicator>
                   </Styled.IndicatorWrapper>
                 </Styled.NumberOfAgenciesLiveDashboardIndicatorWrapper>
               </Styled.Card>

--- a/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
+++ b/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
@@ -22,11 +22,12 @@ import React, { PropsWithChildren } from "react";
 import { useStore } from "../../stores";
 
 export const LinkToPublisher: React.FC<
-  PropsWithChildren & { publisherPath: string }
-> = observer(({ publisherPath, children }) => {
+  PropsWithChildren & { publisherPath: string; agencyID?: string }
+> = observer(({ publisherPath, agencyID, children }) => {
   const { userStore } = useStore();
   const agencyIdLocalStorage = localStorage.getItem("agencyId");
-  const agencyId = agencyIdLocalStorage || userStore.getInitialAgencyId();
+  const agencyId =
+    agencyID || agencyIdLocalStorage || userStore.getInitialAgencyId();
   const url = `/agency/${agencyId}/${publisherPath}`;
 
   return (


### PR DESCRIPTION
## Description of the change

Adds link to Publisher in the agency cards in the `AgencyOverview` component.

https://github.com/Recidiviz/justice-counts/assets/59492998/f4ad30b6-63f3-4f71-9c72-fd5943eb36b7

## Related issues

Contributes to #1135

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
