### PR TITLE
[Agency Dashboards] Hide disabled metrics

### DIFF
--- a/agency-dashboard/src/stores/AgencyDataStore.ts
+++ b/agency-dashboard/src/stores/AgencyDataStore.ts
@@ -200,7 +200,9 @@ class AgencyDataStore {
         const result = await response.json();
         runInAction(() => {
           this.agency = result.agency;
-          this.metrics = result.metrics;
+          this.metrics = (result.metrics as Metric[]).filter(
+            (metric) => metric.enabled
+          );
         });
       } else {
         const error = await response.json();

--- a/agency-dashboard/src/stores/AgencyDataStore.ts
+++ b/agency-dashboard/src/stores/AgencyDataStore.ts
@@ -201,6 +201,7 @@ class AgencyDataStore {
         runInAction(() => {
           this.agency = result.agency;
           this.metrics = (result.metrics as Metric[]).filter(
+            // Filter out disabled metrics
             (metric) => metric.enabled
           );
         });


### PR DESCRIPTION
## Description of the change

Hides disabled metrics in Agency Dashboards by filtering them out of the `metrics` list before the list is set in the `AgencyDataStore`.

The came up when CSG had a Prisons & Supervision agency mistakenly published datapoints for the Prisons metrics that were meant to be for the Supervision sector. Adjusting the frequency and disabling the Prisons metrics was futile because the published datapoints don't go away. This change helps provide a bit more control for agencies who need to remove a metric from dashboards. In the above scenario - the agency's datapoints were clean up (thank you @morden35), and they will now be able to disable the Prisons metrics that they are not currently reporting and hide that from their Dashboards.



https://github.com/Recidiviz/justice-counts/assets/59492998/1ce235d9-ae10-4783-b038-c9c0eb235f92





## Related issues

Closes [#26818](https://github.com/Recidiviz/recidiviz-data/issues/26818)

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
