### PR TITLE
[Publisher] Admin Panel: Add a FE trigger for the copying of superagency metric settings to child agencies process in the UI

### DIFF
--- a/publisher/src/components/AdminPanel/AdminPanel.styles.tsx
+++ b/publisher/src/components/AdminPanel/AdminPanel.styles.tsx
@@ -796,3 +796,9 @@ export const GraphicLines = styled.div<{ type?: SaveConfirmationType }>`
     border-radius: 5px;
   }
 `;
+
+export const WarningMessage = styled.p`
+  ${typography.sizeCSS.small}
+  color: ${palette.solid.red};
+  margin-top: 5px;
+`;

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -38,6 +38,7 @@ import React, { useEffect, useRef, useState } from "react";
 
 import { useStore } from "../../stores";
 import AdminPanelStore from "../../stores/AdminPanelStore";
+import { gateToAllowedEnvironment } from "../../utils/featureFlags";
 import { ButtonWithMiniLoaderContainer, MiniLoaderWrapper } from "../Reports";
 import {
   AgencyProvisioningSetting,
@@ -61,7 +62,6 @@ import {
   UserRoleUpdates,
 } from ".";
 import * as Styled from "./AdminPanel.styles";
-import { gateToAllowedEnvironment } from "../../utils/featureFlags";
 
 export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
   ({

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -36,6 +36,9 @@ import {
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useRef, useState } from "react";
 
+import { useStore } from "../../stores";
+import AdminPanelStore from "../../stores/AdminPanelStore";
+import { ButtonWithMiniLoaderContainer, MiniLoaderWrapper } from "../Reports";
 import {
   AgencyProvisioningSetting,
   AgencyProvisioningSettings,
@@ -56,9 +59,6 @@ import {
   userRoles,
   UserRoleUpdates,
 } from ".";
-import { useStore } from "../../stores";
-import AdminPanelStore from "../../stores/AdminPanelStore";
-import { ButtonWithMiniLoaderContainer, MiniLoaderWrapper } from "../Reports";
 import * as Styled from "./AdminPanel.styles";
 
 export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -36,14 +36,9 @@ import {
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useRef, useState } from "react";
 
-import { useStore } from "../../stores";
-import AdminPanelStore from "../../stores/AdminPanelStore";
-import { gateToAllowedEnvironment } from "../../utils/featureFlags";
-import { ButtonWithMiniLoaderContainer, MiniLoaderWrapper } from "../Reports";
 import {
   AgencyProvisioningSetting,
   AgencyProvisioningSettings,
-  Environment,
   FipsCountyCodeKey,
   FipsCountyCodes,
   InteractiveSearchList,
@@ -61,6 +56,9 @@ import {
   userRoles,
   UserRoleUpdates,
 } from ".";
+import { useStore } from "../../stores";
+import AdminPanelStore from "../../stores/AdminPanelStore";
+import { ButtonWithMiniLoaderContainer, MiniLoaderWrapper } from "../Reports";
 import * as Styled from "./AdminPanel.styles";
 
 export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -42,6 +42,7 @@ import { ButtonWithMiniLoaderContainer, MiniLoaderWrapper } from "../Reports";
 import {
   AgencyProvisioningSetting,
   AgencyProvisioningSettings,
+  Environment,
   FipsCountyCodeKey,
   FipsCountyCodes,
   InteractiveSearchList,
@@ -60,6 +61,7 @@ import {
   UserRoleUpdates,
 } from ".";
 import * as Styled from "./AdminPanel.styles";
+import { gateToAllowedEnvironment } from "../../utils/featureFlags";
 
 export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
   ({
@@ -868,33 +870,40 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                             Child agencies
                           </Styled.ChipContainerLabel>
                         </Styled.InputLabelWrapper>
-                        {hasSystems && hasChildAgencies && (
-                          <Styled.InputLabelWrapper flexRow>
-                            <input
-                              id="copy-superagency-metric-settings"
-                              name="copy-superagency-metric-settings"
-                              type="checkbox"
-                              onChange={() =>
-                                setIsCopySuperagencyMetricSettingsSelected(
-                                  (prev) => !prev
-                                )
-                              }
-                              checked={isCopySuperagencyMetricSettingsSelected}
-                            />
-                            <label htmlFor="copy-superagency-metric-settings">
-                              Copy all metric settings to child agencies
-                            </label>
-                            {isCopySuperagencyMetricSettingsSelected && (
-                              <Styled.WarningMessage>
-                                Warning! This action cannot be undone. After
-                                clicking <strong>Save</strong>, the copying
-                                process will begin and you will receive an email
-                                confirmation once the metrics settings have been
-                                copied over.
-                              </Styled.WarningMessage>
-                            )}
-                          </Styled.InputLabelWrapper>
-                        )}
+                        {gateToAllowedEnvironment(api.environment, [
+                          Environment.LOCAL,
+                          Environment.STAGING,
+                        ]) &&
+                          hasSystems &&
+                          hasChildAgencies && (
+                            <Styled.InputLabelWrapper flexRow>
+                              <input
+                                id="copy-superagency-metric-settings"
+                                name="copy-superagency-metric-settings"
+                                type="checkbox"
+                                onChange={() =>
+                                  setIsCopySuperagencyMetricSettingsSelected(
+                                    (prev) => !prev
+                                  )
+                                }
+                                checked={
+                                  isCopySuperagencyMetricSettingsSelected
+                                }
+                              />
+                              <label htmlFor="copy-superagency-metric-settings">
+                                Copy all metric settings to child agencies
+                              </label>
+                              {isCopySuperagencyMetricSettingsSelected && (
+                                <Styled.WarningMessage>
+                                  Warning! This action cannot be undone. After
+                                  clicking <strong>Save</strong>, the copying
+                                  process will begin and you will receive an
+                                  email confirmation once the metrics settings
+                                  have been copied over.
+                                </Styled.WarningMessage>
+                              )}
+                            </Styled.InputLabelWrapper>
+                          )}
                       </>
                     )}
 

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -260,8 +260,12 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
         })),
       ]);
 
-      /** If `isCopySuperagencyMetricSettingsSelected` is true, then trigger the copying process */
+      /**
+       * If `isCopySuperagencyMetricSettingsSelected` is true (and that it's a superagency w/ child agencies,
+       * and there is a valid user email), then trigger the copying process
+       */
       if (
+        isCopySuperagencyMetricSettingsSelected &&
         agencyProvisioningUpdates.is_superagency &&
         userStore.email &&
         hasChildAgencies

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -870,6 +870,7 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                             Child agencies
                           </Styled.ChipContainerLabel>
                         </Styled.InputLabelWrapper>
+                        {/* TODO(#1155) - Ungate feature */}
                         {gateToAllowedEnvironment(api.environment, [
                           Environment.LOCAL,
                           Environment.STAGING,

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -261,9 +261,13 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
       ]);
 
       /** If `isCopySuperagencyMetricSettingsSelected` is true, then trigger the copying process */
-      if (agencyProvisioningUpdates.super_agency_id && userStore.email) {
+      if (
+        agencyProvisioningUpdates.is_superagency &&
+        userStore.email &&
+        hasChildAgencies
+      ) {
         copySuperagencyMetricSettingsToChildAgencies(
-          String(agencyProvisioningUpdates.super_agency_id),
+          String(agencyProvisioningUpdates.agency_id),
           userStore.email,
           ["ALL"]
         );
@@ -428,6 +432,7 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
         agencyProvisioningUpdates.child_agency_ids.filter((id) =>
           selectedChildAgencyIDs.has(id)
         ).length === 0);
+    const hasChildAgencies = selectedChildAgencyIDs.size > 0;
     /**
      * An update has been made when the agency's `super_agency_id` does not match the agency's superagency id before
      * the modal was open.
@@ -449,19 +454,20 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
      * selection, and team member additions/deletions/role updates, or a newly created agency has no input for both name and state.
      */
     const isSaveDisabled =
-      isSaveInProgress ||
-      !hasSystems ||
-      (selectedAgency
-        ? !hasNameUpdate &&
-          !hasStateUpdate &&
-          !hasCountyUpdates &&
-          !hasSystemUpdates &&
-          !hasDashboardEnabledStatusUpdate &&
-          !hasIsSuperagencyUpdate &&
-          !hasChildAgencyUpdates &&
-          !hasSuperagencyUpdate &&
-          !hasTeamMemberOrRoleUpdates
-        : !(hasNameUpdate && hasStateUpdate && hasSystems));
+      !isCopySuperagencyMetricSettingsSelected && // Allows user to save if this is all they do is select that they want to copy superagency metric settings
+      (isSaveInProgress ||
+        !hasSystems ||
+        (selectedAgency
+          ? !hasNameUpdate &&
+            !hasStateUpdate &&
+            !hasCountyUpdates &&
+            !hasSystemUpdates &&
+            !hasDashboardEnabledStatusUpdate &&
+            !hasIsSuperagencyUpdate &&
+            !hasChildAgencyUpdates &&
+            !hasSuperagencyUpdate &&
+            !hasTeamMemberOrRoleUpdates
+          : !(hasNameUpdate && hasStateUpdate && hasSystems)));
 
     /** Automatically adds CSG and Recidiviz users to a newly created agency with the proper roles */
     useEffect(() => {
@@ -857,32 +863,33 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                             Child agencies
                           </Styled.ChipContainerLabel>
                         </Styled.InputLabelWrapper>
-                        <Styled.InputLabelWrapper flexRow>
-                          <input
-                            id="copy-superagency-metric-settings"
-                            name="copy-superagency-metric-settings"
-                            type="checkbox"
-                            onChange={() =>
-                              setIsCopySuperagencyMetricSettingsSelected(
-                                (prev) => !prev
-                              )
-                            }
-                            checked={isCopySuperagencyMetricSettingsSelected}
-                            disabled={!hasSystems}
-                          />
-                          <label htmlFor="copy-superagency-metric-settings">
-                            Copy metric settings to child agencies
-                          </label>
-                          {isCopySuperagencyMetricSettingsSelected && (
-                            <Styled.WarningMessage>
-                              Warning! This action cannot be undone. After
-                              clicking <strong>Save</strong>, the copying
-                              process will begin and you will receive an email
-                              confirmation once the metrics settings have been
-                              copied over.
-                            </Styled.WarningMessage>
-                          )}
-                        </Styled.InputLabelWrapper>
+                        {hasSystems && hasChildAgencies && (
+                          <Styled.InputLabelWrapper flexRow>
+                            <input
+                              id="copy-superagency-metric-settings"
+                              name="copy-superagency-metric-settings"
+                              type="checkbox"
+                              onChange={() =>
+                                setIsCopySuperagencyMetricSettingsSelected(
+                                  (prev) => !prev
+                                )
+                              }
+                              checked={isCopySuperagencyMetricSettingsSelected}
+                            />
+                            <label htmlFor="copy-superagency-metric-settings">
+                              Copy metric settings to child agencies
+                            </label>
+                            {isCopySuperagencyMetricSettingsSelected && (
+                              <Styled.WarningMessage>
+                                Warning! This action cannot be undone. After
+                                clicking <strong>Save</strong>, the copying
+                                process will begin and you will receive an email
+                                confirmation once the metrics settings have been
+                                copied over.
+                              </Styled.WarningMessage>
+                            )}
+                          </Styled.InputLabelWrapper>
+                        )}
                       </>
                     )}
 

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -458,7 +458,7 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
      * selection, and team member additions/deletions/role updates, or a newly created agency has no input for both name and state.
      */
     const isSaveDisabled =
-      !isCopySuperagencyMetricSettingsSelected && // Allows user to save if this is all they do is select that they want to copy superagency metric settings
+      !isCopySuperagencyMetricSettingsSelected && // Allows user to save if all they do is select that they want to copy superagency metric settings
       (isSaveInProgress ||
         !hasSystems ||
         (selectedAgency
@@ -881,7 +881,7 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                               checked={isCopySuperagencyMetricSettingsSelected}
                             />
                             <label htmlFor="copy-superagency-metric-settings">
-                              Copy metric settings to child agencies
+                              Copy all metric settings to child agencies
                             </label>
                             {isCopySuperagencyMetricSettingsSelected && (
                               <Styled.WarningMessage>

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -870,41 +870,34 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                             Child agencies
                           </Styled.ChipContainerLabel>
                         </Styled.InputLabelWrapper>
-                        {/* TODO(#1155) - Ungate feature */}
-                        {gateToAllowedEnvironment(api.environment, [
-                          Environment.LOCAL,
-                          Environment.STAGING,
-                        ]) &&
-                          hasSystems &&
-                          hasChildAgencies && (
-                            <Styled.InputLabelWrapper flexRow>
-                              <input
-                                id="copy-superagency-metric-settings"
-                                name="copy-superagency-metric-settings"
-                                type="checkbox"
-                                onChange={() =>
-                                  setIsCopySuperagencyMetricSettingsSelected(
-                                    (prev) => !prev
-                                  )
-                                }
-                                checked={
-                                  isCopySuperagencyMetricSettingsSelected
-                                }
-                              />
-                              <label htmlFor="copy-superagency-metric-settings">
-                                Copy all metric settings to child agencies
-                              </label>
-                              {isCopySuperagencyMetricSettingsSelected && (
-                                <Styled.WarningMessage>
-                                  Warning! This action cannot be undone. After
-                                  clicking <strong>Save</strong>, the copying
-                                  process will begin and you will receive an
-                                  email confirmation once the metrics settings
-                                  have been copied over.
-                                </Styled.WarningMessage>
-                              )}
-                            </Styled.InputLabelWrapper>
-                          )}
+
+                        {hasSystems && hasChildAgencies && (
+                          <Styled.InputLabelWrapper flexRow>
+                            <input
+                              id="copy-superagency-metric-settings"
+                              name="copy-superagency-metric-settings"
+                              type="checkbox"
+                              onChange={() =>
+                                setIsCopySuperagencyMetricSettingsSelected(
+                                  (prev) => !prev
+                                )
+                              }
+                              checked={isCopySuperagencyMetricSettingsSelected}
+                            />
+                            <label htmlFor="copy-superagency-metric-settings">
+                              Copy all metric settings to child agencies
+                            </label>
+                            {isCopySuperagencyMetricSettingsSelected && (
+                              <Styled.WarningMessage>
+                                Warning! This action cannot be undone. After
+                                clicking <strong>Save</strong>, the copying
+                                process will begin and you will receive an email
+                                confirmation once the metrics settings have been
+                                copied over.
+                              </Styled.WarningMessage>
+                            )}
+                          </Styled.InputLabelWrapper>
+                        )}
                       </>
                     )}
 

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -272,6 +272,7 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
       ) {
         copySuperagencyMetricSettingsToChildAgencies(
           String(agencyProvisioningUpdates.agency_id),
+          agencyProvisioningUpdates.name,
           userStore.email,
           ["ALL"]
         );

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -222,7 +222,7 @@ class AdminPanelStore {
   async copySuperagencyMetricSettingsToChildAgencies(
     superagencyID: string,
     userEmail: string,
-    metricDefinitionKeySubset: string[]
+    metricDefinitionKeySubset: string[] // A list of metric definition keys for future use to update a subset of metrics
   ) {
     try {
       const response = (await this.api.request({

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -221,6 +221,7 @@ class AdminPanelStore {
 
   async copySuperagencyMetricSettingsToChildAgencies(
     superagencyID: string,
+    agencyName: string,
     userEmail: string,
     metricDefinitionKeySubset: string[] // A list of metric definition keys for future use to update a subset of metrics
   ) {
@@ -229,6 +230,7 @@ class AdminPanelStore {
         path: `/admin/agency/${superagencyID}/child-agency/copy`,
         method: "POST",
         body: {
+          agency_name: agencyName,
           user_email: userEmail,
           metric_definition_key_subset: metricDefinitionKeySubset,
         },

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -219,6 +219,30 @@ class AdminPanelStore {
     });
   }
 
+  async copySuperagencyMetricSettingsToChildAgencies(
+    superagencyID: string,
+    userEmail: string,
+    metricDefinitionKeySubset: string[]
+  ) {
+    try {
+      const response = (await this.api.request({
+        path: `/admin/agency/${superagencyID}/child-agency/copy`,
+        method: "POST",
+        body: {
+          user_email: userEmail,
+          metric_definition_key_subset: metricDefinitionKeySubset,
+        },
+      })) as Response;
+
+      return response;
+    } catch (error) {
+      if (error instanceof Error)
+        return new Error(
+          "There was an issue copying metric settings from superagency to child agencies."
+        );
+    }
+  }
+
   /** User Provisioning */
 
   updateUsername(username: string) {


### PR DESCRIPTION
## Description of the change

Adds a way to trigger the copying of superagency metric settings to child agencies in the UI.

Within an open Agency Provisioning modal, and after a user has... 
1. Checked the `Superagency` box
2. Selected at least one non-Superagency sector, and
3. Selected at least one child agency

... there will be a new checkbox available labeled "Copy metric settings to child agencies". Checking this input will display a warning message that alerts the user that this action cannot be undone, and what to expect after clicking "Save".

Once the user clicks "Save", there will be a call to the `copy_metric_config_to_child_agencies` endpoint which will trigger the Cloud Run job that copies the metric settings and sends a confirmation email.

Demo:
https://www.loom.com/share/a2b24c6e0dac4dcd80bea7c34b302b2e

## Related issues

Closes #1056 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
