### PR TITLE
[Publisher][Bug] Fix encoding of agency names when linking to dashboards

### DIFF
--- a/agency-dashboard/src/Home/Home.tsx
+++ b/agency-dashboard/src/Home/Home.tsx
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { slugify } from "@justice-counts/common/utils";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
@@ -67,9 +66,7 @@ export const Home = observer(() => {
         {agenciesMetadataSortedByName.map((agency) => (
           <Styled.AgencyDetailsWrapper
             key={agency.id}
-            onClick={() =>
-              navigate(`/agency/${encodeURIComponent(slugify(agency.name))}`)
-            }
+            onClick={() => navigate(`/agency/${encodeURI(agency.name)}`)}
           >
             <Styled.AgencyName>{agency.name}</Styled.AgencyName>
             <Styled.NumberOfPublishedMetrics>

--- a/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
+++ b/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
@@ -15,7 +15,6 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { slugify } from "@justice-counts/common/utils";
 import { observer } from "mobx-react-lite";
 import React, { PropsWithChildren } from "react";
 
@@ -65,4 +64,4 @@ export const generateDashboardURL = (
 ) =>
   `https://dashboard-${
     env !== "production" ? "staging" : "demo"
-  }.justice-counts.org/agency/${slugify(agencyName || "")}`;
+  }.justice-counts.org/agency/${encodeURI(agencyName || "")}`;


### PR DESCRIPTION
## Description of the change

Fix encoding of agency names when linking to dashboards by using the native `encodeURI` function instead of the helper method `slugify`'s strategy of replacing spaces with hyphens.

This resolves an issue CSG noticed with agencies that have hyphens in their name. Currently, the FE uses a helper method called `slugify` that replaces spaces with hyphens, and the BE decodes the 'slugified' agency name by replacing the hyphens with spaces. Instead, the FE can use the `encodeURI` which will naturally replace spaces with a `%20` and the BE can decode encoded URIs and naturally decode a `%20` into a space and leave hyphens alone.


https://github.com/Recidiviz/justice-counts/assets/59492998/eae3c0aa-47bd-48c2-8b8e-e94218bcdd92



## Type of change

## Related issues

Closes #1144

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
