### PR TITLE
[Publisher] Rename Bulk Upload 'example(s)' to 'template(s)'

### DIFF
--- a/publisher/src/components/DataUpload/InstructionsTemplate.tsx
+++ b/publisher/src/components/DataUpload/InstructionsTemplate.tsx
@@ -234,12 +234,12 @@ export const GeneralInstructions: React.FC<
         automation on our end to easily upload this data into our platform.
       </p>
 
-      <h3>Examples</h3>
+      <h3>Templates</h3>
 
       <p>
-        Example spreadsheets can be found below. We suggest that you download
-        the example and review it, and then read the instructions below for more
-        details.
+        Template spreadsheets can be found below. We suggest that you download
+        the template and review it, and then read the instructions below for
+        more details.
       </p>
 
       <ButtonWrapper>
@@ -336,9 +336,9 @@ export const GeneralInstructions: React.FC<
       <p>
         If you are uploading an Excel workbook, we require that each sheet is
         given a standard name.{" "}
-        <b>Refer to your example file for the valid sheet names. </b> If you are
-        uploading a set of CSV files, their filenames names should also exactly
-        match these sheet names (e.g. admissions.csv).
+        <b>Refer to your template file for the valid sheet names. </b> If you
+        are uploading a set of CSV files, their filenames names should also
+        exactly match these sheet names (e.g. admissions.csv).
       </p>
       <p>
         All sheets will have columns for <i>year</i> and <i>value</i>. Monthly
@@ -446,14 +446,14 @@ export const GeneralInstructions: React.FC<
       <p>
         We require that each sheet and column is given a standard name.{" "}
         <b>
-          Refer to your example file for the name of the new sheet, the name of
+          Refer to your template file for the name of the new sheet, the name of
           the new column for category names, and the valid values for this
           column.
         </b>
       </p>
       <p>
         <b>
-          Please only provide valid category names (as seen in your example
+          Please only provide valid category names (as seen in your template
           file) in the new column.{" "}
         </b>
         If your agency categorizes the metric differently, group any unmatched

--- a/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
+++ b/publisher/src/components/DataUpload/UploadErrorsWarnings.tsx
@@ -335,7 +335,7 @@ export const UploadErrorsWarnings: React.FC<UploadErrorsWarningsProps> = ({
         </span>{" "}
         {SYSTEM_LOWERCASE} (
         <a href={`/assets/${systemFileName}`} download={systemFileName}>
-          download example
+          download template
         </a>
         )
       </>


### PR DESCRIPTION
## Description of the change

Rename all references to the spreadsheet templates in the Bulk Upload page from "example(s)" to "template(s)".

View changes here: https://mahmoudtest---publisher-web-b47yvyxs3q-uc.a.run.app/

## Related issues

Closes [#26334](https://github.com/Recidiviz/recidiviz-data/issues/26334)

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
