### PR TITLE
[Publisher] Admin Panel: Add functionality for deleting users

### DIFF
--- a/publisher/src/components/AdminPanel/AdminPanel.styles.tsx
+++ b/publisher/src/components/AdminPanel/AdminPanel.styles.tsx
@@ -22,6 +22,7 @@ import {
 } from "@justice-counts/common/components/GlobalStyles";
 import styled, { css, keyframes } from "styled-components/macro";
 
+import { ReactComponent as TrashSVG } from "../assets/icons8-trash.svg";
 import {
   InteractiveSearchListAction,
   InteractiveSearchListActions,
@@ -75,6 +76,29 @@ export const ScrollableContainer = styled.div`
   padding-right: 16px;
 `;
 
+export const TrashIcon = styled(TrashSVG)`
+  width: 24px;
+  position: absolute;
+  bottom: 10px;
+  right: 16px;
+  display: none;
+
+  fill: ${palette.solid.red};
+  border: 1px solid ${palette.solid.red};
+  border-radius: 3px;
+  margin-top: 3px;
+  padding: 0 4px;
+  transition: 0.2s ease;
+
+  div:hover > & {
+    display: block;
+  }
+
+  &:hover {
+    background: ${palette.highlight.red};
+  }
+`;
+
 /** Modal */
 
 export const ModalWrapper = styled.div``;
@@ -115,6 +139,7 @@ export const ModalActionButtons = styled.div`
   align-items: center;
   justify-content: space-between;
   padding-top: 16px;
+  border-top: 1px solid ${palette.highlight.grey2};
 `;
 
 export const SaveCancelButtonsWrapper = styled.div`
@@ -547,6 +572,7 @@ export const Card = styled.div`
   border-radius: 3px;
   padding: 16px;
   transition: 0.2s ease;
+  position: relative;
 
   &:hover {
     cursor: pointer;

--- a/publisher/src/components/AdminPanel/AdminPanel.styles.tsx
+++ b/publisher/src/components/AdminPanel/AdminPanel.styles.tsx
@@ -77,12 +77,11 @@ export const ScrollableContainer = styled.div`
 `;
 
 export const TrashIcon = styled(TrashSVG)`
+  display: none;
   width: 24px;
   position: absolute;
   bottom: 10px;
   right: 16px;
-  display: none;
-
   fill: ${palette.solid.red};
   border: 1px solid ${palette.solid.red};
   border-radius: 3px;

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -228,10 +228,10 @@ export const UserProvisioningOverview = observer(() => {
                       <Styled.Chip key={agency.id}>{agency.name}</Styled.Chip>
                     ))}
                   </Styled.AgenciesWrapper>
-
                   <Styled.NumberOfAgencies>
                     {userAgencies.length} agencies
                   </Styled.NumberOfAgencies>
+                  {/* Delete Users Button */}
                   <Styled.TrashIcon
                     onClick={(e) => {
                       e.stopPropagation();

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -22,6 +22,9 @@ import { showToast } from "@justice-counts/common/components/Toast";
 import { observer } from "mobx-react-lite";
 import React, { useState } from "react";
 
+import { useStore } from "../../stores";
+import AdminPanelStore from "../../stores/AdminPanelStore";
+import { Loading } from "../Loading";
 import {
   AgencyProvisioning,
   Setting,
@@ -30,9 +33,6 @@ import {
   UserProvisioning,
   UserWithAgenciesByID,
 } from ".";
-import { useStore } from "../../stores";
-import AdminPanelStore from "../../stores/AdminPanelStore";
-import { Loading } from "../Loading";
 import * as Styled from "./AdminPanel.styles";
 
 export const UserProvisioningOverview = observer(() => {

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -24,6 +24,7 @@ import React, { useState } from "react";
 
 import { useStore } from "../../stores";
 import AdminPanelStore from "../../stores/AdminPanelStore";
+import { gateToAllowedEnvironment } from "../../utils/featureFlags";
 import { Loading } from "../Loading";
 import {
   AgencyProvisioning,
@@ -35,7 +36,6 @@ import {
   UserWithAgenciesByID,
 } from ".";
 import * as Styled from "./AdminPanel.styles";
-import { gateToAllowedEnvironment } from "../../utils/featureFlags";
 
 export const UserProvisioningOverview = observer(() => {
   const { adminPanelStore, api } = useStore();

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -99,13 +99,22 @@ export const UserProvisioningOverview = observer(() => {
     updateUserAgencies(Object.keys(selectedUser.agencies).map((id) => +id));
     openModal();
   };
-  const handleDeleteUser = (userID: string | number) => {
-    deleteUser(String(userID));
-    showToast({
-      message: `${usersByID[userID][0].name} has been deleted.`,
-      check: true,
-    });
+  const handleDeleteUser = async (userID: string | number) => {
     setDeleteConfirmation({ show: false });
+    const response = (await deleteUser(String(userID))) as Response;
+
+    if (response.status !== 200) {
+      showToast({
+        message: `${usersByID[userID][0].name} has been deleted.`,
+        check: true,
+      });
+      return;
+    }
+    showToast({
+      message: `${usersByID[userID][0].name} could not be deleted. Please reach out to a Recidiviz team member for assistance.`,
+      color: "red",
+      timeout: 3500,
+    });
   };
 
   if (loading) {

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -27,6 +27,7 @@ import AdminPanelStore from "../../stores/AdminPanelStore";
 import { Loading } from "../Loading";
 import {
   AgencyProvisioning,
+  Environment,
   Setting,
   SettingType,
   UserKey,
@@ -34,9 +35,10 @@ import {
   UserWithAgenciesByID,
 } from ".";
 import * as Styled from "./AdminPanel.styles";
+import { gateToAllowedEnvironment } from "../../utils/featureFlags";
 
 export const UserProvisioningOverview = observer(() => {
-  const { adminPanelStore } = useStore();
+  const { adminPanelStore, api } = useStore();
   const {
     loading,
     users,
@@ -232,12 +234,18 @@ export const UserProvisioningOverview = observer(() => {
                     {userAgencies.length} agencies
                   </Styled.NumberOfAgencies>
                   {/* Delete Users Button */}
-                  <Styled.TrashIcon
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      setDeleteConfirmation({ show: true, user });
-                    }}
-                  />
+                  {/* TODO(#1156) - Ungate feature */}
+                  {gateToAllowedEnvironment(api.environment, [
+                    Environment.LOCAL,
+                    Environment.STAGING,
+                  ]) && (
+                    <Styled.TrashIcon
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setDeleteConfirmation({ show: true, user });
+                      }}
+                    />
+                  )}
                 </Styled.Card>
               );
             })}

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -103,7 +103,7 @@ export const UserProvisioningOverview = observer(() => {
     setDeleteConfirmation({ show: false });
     const response = (await deleteUser(String(userID))) as Response;
 
-    if (response.status !== 200) {
+    if (response.status === 200) {
       showToast({
         message: `${usersByID[userID][0].name} has been deleted.`,
         check: true,

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -51,6 +51,8 @@ export const UserProvisioningOverview = observer(() => {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [activeSecondaryModal, setActiveSecondaryModal] =
     useState<SettingType>();
+  const [showDeleteConfirmationModal, setShowDeleteConfirmationModal] =
+    useState<boolean>(false);
 
   const [searchInput, setSearchInput] = useState<string>("");
 
@@ -124,6 +126,28 @@ export const UserProvisioningOverview = observer(() => {
         </>
       )}
 
+      {/* Delete User Confirmation Modal */}
+      {showDeleteConfirmationModal && (
+        <Modal
+          modalType="alert"
+          title="Are you sure you want to delete this user?"
+          buttons={[
+            {
+              label: "Cancel",
+              onClick: () => {
+                setShowDeleteConfirmationModal(false);
+              },
+            },
+            {
+              label: "Yes, delete user",
+              onClick: () => {
+                console.log("Call delete endpoint");
+              },
+            },
+          ]}
+        />
+      )}
+
       {/* Settings Bar */}
       <Styled.SettingsBar>
         {/* Search */}
@@ -178,9 +202,16 @@ export const UserProvisioningOverview = observer(() => {
                       <Styled.Chip key={agency.id}>{agency.name}</Styled.Chip>
                     ))}
                   </Styled.AgenciesWrapper>
+
                   <Styled.NumberOfAgencies>
                     {userAgencies.length} agencies
                   </Styled.NumberOfAgencies>
+                  <Styled.TrashIcon
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setShowDeleteConfirmationModal(true);
+                    }}
+                  />
                 </Styled.Card>
               );
             })}

--- a/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioningOverview.tsx
@@ -22,23 +22,21 @@ import { showToast } from "@justice-counts/common/components/Toast";
 import { observer } from "mobx-react-lite";
 import React, { useState } from "react";
 
-import { useStore } from "../../stores";
-import AdminPanelStore from "../../stores/AdminPanelStore";
-import { gateToAllowedEnvironment } from "../../utils/featureFlags";
-import { Loading } from "../Loading";
 import {
   AgencyProvisioning,
-  Environment,
   Setting,
   SettingType,
   UserKey,
   UserProvisioning,
   UserWithAgenciesByID,
 } from ".";
+import { useStore } from "../../stores";
+import AdminPanelStore from "../../stores/AdminPanelStore";
+import { Loading } from "../Loading";
 import * as Styled from "./AdminPanel.styles";
 
 export const UserProvisioningOverview = observer(() => {
-  const { adminPanelStore, api } = useStore();
+  const { adminPanelStore } = useStore();
   const {
     loading,
     users,
@@ -234,18 +232,12 @@ export const UserProvisioningOverview = observer(() => {
                     {userAgencies.length} agencies
                   </Styled.NumberOfAgencies>
                   {/* Delete Users Button */}
-                  {/* TODO(#1156) - Ungate feature */}
-                  {gateToAllowedEnvironment(api.environment, [
-                    Environment.LOCAL,
-                    Environment.STAGING,
-                  ]) && (
-                    <Styled.TrashIcon
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        setDeleteConfirmation({ show: true, user });
-                      }}
-                    />
-                  )}
+                  <Styled.TrashIcon
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      setDeleteConfirmation({ show: true, user });
+                    }}
+                  />
                 </Styled.Card>
               );
             })}

--- a/publisher/src/components/assets/icons8-trash.svg
+++ b/publisher/src/components/assets/icons8-trash.svg
@@ -1,0 +1,2 @@
+// Trash icon (https://icons8.com/icon/85081/trash) by Icons8 (https://icons8.com)
+<svg xmlns="http://www.w3.org/2000/svg"  viewBox="0 0 24 24" width="24px" height="24px"><path d="M 10 2 L 9 3 L 4 3 L 4 5 L 5 5 L 5 20 C 5 20.522222 5.1913289 21.05461 5.5683594 21.431641 C 5.9453899 21.808671 6.4777778 22 7 22 L 17 22 C 17.522222 22 18.05461 21.808671 18.431641 21.431641 C 18.808671 21.05461 19 20.522222 19 20 L 19 5 L 20 5 L 20 3 L 15 3 L 14 2 L 10 2 z M 7 5 L 17 5 L 17 20 L 7 20 L 7 5 z M 9 7 L 9 18 L 11 18 L 11 7 L 9 7 z M 13 7 L 13 18 L 15 18 L 15 7 L 13 7 z"/></svg>

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -291,9 +291,7 @@ class AdminPanelStore {
       return response;
     } catch (error) {
       if (error instanceof Error)
-        return new Error(
-          "There was an issue saving user provisioning updates."
-        );
+        return new Error(`There was an issue deleting user ID ${userID}.`);
     }
   }
 

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -275,6 +275,28 @@ class AdminPanelStore {
     }
   }
 
+  async deleteUser(userID: string) {
+    try {
+      const response = (await this.api.request({
+        path: `/admin/user/${userID}`,
+        method: "DELETE",
+      })) as Response;
+      if (response.status === 200) {
+        runInAction(() => {
+          const updatedUsersByID = { ...this.usersByID };
+          delete updatedUsersByID[userID];
+          this.usersByID = updatedUsersByID;
+        });
+      }
+      return response;
+    } catch (error) {
+      if (error instanceof Error)
+        return new Error(
+          "There was an issue saving user provisioning updates."
+        );
+    }
+  }
+
   /** Agency Provisioning */
 
   updateAgencyID(id: number) {


### PR DESCRIPTION
## Description of the change

Add functionality for deleting users from within the admin panel.

Using @brandon-hills' new DELETE endpoint ([reference](https://github.com/Recidiviz/recidiviz-data/pull/26773)), I added a little trash icon on all the cards in the `UserProvisioningOverview` page that appears on hover. When a user clicks this icon, a warning modal appears asking the user to confirm this action. Once confirmed, a call is sent to the delete users endpoint and upon a successful response, the UI updates the list of users with the desired user removed.


https://github.com/Recidiviz/justice-counts/assets/59492998/33a486a8-730b-4fb2-9ae4-c51e0668a55b

Note: for the error condition, I just negated the `response.status === 200` conditional, so it will still delete successfully, but just demo the UI state when it encounters an error.

## Related issues

Closes #1145

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
