### PR TITLE
[Justice Counts] update toggle copy and access

### DIFF
--- a/common/types.ts
+++ b/common/types.ts
@@ -100,6 +100,7 @@ export interface UserAgency {
   team: AgencyTeamMember[];
   is_superagency: boolean;
   is_dashboard_enabled: boolean;
+  super_agency_id: number | null | undefined;
 }
 
 export type ReportFrequency = "MONTHLY" | "ANNUAL";

--- a/publisher/src/components/Reports/CreateReport.test.tsx
+++ b/publisher/src/components/Reports/CreateReport.test.tsx
@@ -159,6 +159,7 @@ describe("test create report button", () => {
               },
             ],
             is_superagency: false,
+            super_agency_id: null,
             is_dashboard_enabled: false,
           },
         ];

--- a/publisher/src/components/Settings/AgencySettings.tsx
+++ b/publisher/src/components/Settings/AgencySettings.tsx
@@ -82,10 +82,11 @@ export const AgencySettings: React.FC = observer(() => {
       <AgencySettingsTitle />
       <AgencySettingsContent>
         <AgencySettingsBasicInfo />
-        {userStore.isJusticeCountsAdmin(agencyId) && (
-          // TODO(#26282):Un-gate this feature after playtesting
-          <AgencySettingsEmailNotifications />
-        )}
+        {/* TODO(#26632) Un-gate toggle once functionality for superagencies / child agencies is implemented  */}
+        {agencyStore.currentAgency?.is_superagency !== true &&
+          agencyStore.currentAgency?.super_agency_id === null && (
+            <AgencySettingsEmailNotifications />
+          )}
         <AgencySettingsDescription
           settingProps={generateSettingProps(ActiveSetting.Description)}
         />

--- a/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
+++ b/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
@@ -54,6 +54,11 @@ export const AgencySettingsEmailNotifications: React.FC = observer(() => {
           "the agency you are currently viewing"}
         . When you unsubscribe you will no longer receive any emails for this
         agency.
+        <br />
+        <br />
+        These email reminders will currently be sent on the 15th of each month.
+        In an upcoming release, you will be able to choose when the email
+        reminders are sent.
       </AgencySettingsBlockDescription>
     </AgencySettingsBlock>
   );


### PR DESCRIPTION
## Description of the change

Changes before launch, updates copy for email subscribe / unsubscribe toggle as well as the access to the toggle. Superagencies and child agencies will not have a toggle on their Agency Settings page because that functionality has not been implemented yet. 


https://github.com/Recidiviz/justice-counts/assets/19961693/3984118c-0f31-43f0-8d9b-ee94908b477e

## Related issues

Closes #26282, #27025

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [x] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
