### PR TITLE
[Publisher][Bug] Fix Race & Ethnicities grid displaying and saving incorrect enabled/disabled dimension states when set for the first time

### DIFF
--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -1052,14 +1052,25 @@ class MetricConfigStore {
 
     Object.entries(racesStatusObject).forEach(([race, enabled]) =>
       ethnicities.forEach((ethnicity) => {
+        const isCurrentRaceEthnicityEnabled = Boolean(
+          ethnicitiesByRace[race][ethnicity].enabled
+        );
+        console.log(race, ethnicity);
+        console.log("enabled", enabled);
+        console.log(
+          "ethnicitiesByRace[race][ethnicity].enabled",
+          ethnicitiesByRace[race][ethnicity].enabled
+        );
+        console.log(
+          "gridStates[state][race][ethnicity]",
+          gridStates[state][race][ethnicity]
+        );
         /** No update if intended update matches the current state (e.g. enabling an already enabled dimension) */
-        if (Boolean(ethnicitiesByRace[race][ethnicity].enabled) === enabled)
-          return;
+        if (isCurrentRaceEthnicityEnabled === enabled) return;
         /** No update if enabling a disabled dimension that is not available to the user to edit (determined by current grid state) */
         if (
           enabled &&
-          Boolean(ethnicitiesByRace[race][ethnicity].enabled) ===
-            gridStates[state][race][ethnicity]
+          isCurrentRaceEthnicityEnabled === gridStates[state][race][ethnicity]
         )
           return;
 

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -1059,7 +1059,7 @@ class MetricConfigStore {
         console.log("enabled", enabled);
         console.log(
           "ethnicitiesByRace[race][ethnicity].enabled",
-          ethnicitiesByRace[race][ethnicity].enabled
+          isCurrentRaceEthnicityEnabled
         );
         console.log(
           "gridStates[state][race][ethnicity]",

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -1053,11 +1053,12 @@ class MetricConfigStore {
     Object.entries(racesStatusObject).forEach(([race, enabled]) =>
       ethnicities.forEach((ethnicity) => {
         /** No update if intended update matches the current state (e.g. enabling an already enabled dimension) */
-        if (ethnicitiesByRace[race][ethnicity].enabled === enabled) return;
+        if (Boolean(ethnicitiesByRace[race][ethnicity].enabled) === enabled)
+          return;
         /** No update if enabling a disabled dimension that is not available to the user to edit (determined by current grid state) */
         if (
           enabled &&
-          ethnicitiesByRace[race][ethnicity].enabled ===
+          Boolean(ethnicitiesByRace[race][ethnicity].enabled) ===
             gridStates[state][race][ethnicity]
         )
           return;

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -1052,19 +1052,14 @@ class MetricConfigStore {
 
     Object.entries(racesStatusObject).forEach(([race, enabled]) =>
       ethnicities.forEach((ethnicity) => {
+        /**
+         * This must be a boolean because the initial R&E states are `null` and we need to do a boolean to boolean comparison
+         * between the current R&E enabled value and the `gridStates` enabled values (which are exclusively boolean)
+         */
         const isCurrentRaceEthnicityEnabled = Boolean(
           ethnicitiesByRace[race][ethnicity].enabled
         );
-        console.log(race, ethnicity);
-        console.log("enabled", enabled);
-        console.log(
-          "ethnicitiesByRace[race][ethnicity].enabled",
-          isCurrentRaceEthnicityEnabled
-        );
-        console.log(
-          "gridStates[state][race][ethnicity]",
-          gridStates[state][race][ethnicity]
-        );
+
         /** No update if intended update matches the current state (e.g. enabling an already enabled dimension) */
         if (isCurrentRaceEthnicityEnabled === enabled) return;
         /** No update if enabling a disabled dimension that is not available to the user to edit (determined by current grid state) */


### PR DESCRIPTION
## Description of the change

Fix Race & Ethnicities grid displaying and saving incorrect enabled/disabled dimension states when set for the first time.

Matt surfaced an issue where when setting the Race & Ethnicities dimensions for the first time via Metric Settings page, the saved results do not align properly with the expected output based on the user's input in the R&E modal form. This seems to only happen when the R&E dimensions have never been set before and are being set for the first time.

When doing a comparison to decide whether or not a particular dimension needs to be updated, It appears that the FE is not properly handling the BE sending `null` for these dimensions' initial state, and it's stumbles when it does a comparison of the current state (initially `null`) against the what the dimension state should be per the `gridState` (which only has boolean values). So, it's running into situations where it's doing a `null === false` check (`null` representing the current dimension state, and `false` representing the `gridState` - what the user's input should map to for that dimension). Remember `null` and `false` both mean the dimension is disabled - in these cases, we can safely coerce the `null` value to a boolean to get the desired comparison and resolve the erroneous output after initially configuring and saving.

Demo'ing before & after this change:


https://github.com/Recidiviz/justice-counts/assets/59492998/6374a61c-15dd-4397-b82c-36c3b469ad27

[Ack - it's still showing the `null` at the end there in the browser console because I forgot to add the Boolean coercion in the console.log statement - but it is indeed now a boolean! I just didn't have it in me to create a new agency again and find untouched R&E breakdowns and rerecord.]

## Related issues

Closes [#26990](https://github.com/Recidiviz/recidiviz-data/issues/26990)

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
