### PR TITLE
[Publisher] Admin Panel: Update copy for the copy-superagency-metric-settings checkbox and warning message to add more specificity

### DIFF
--- a/publisher/src/components/AdminPanel/AdminPanel.styles.tsx
+++ b/publisher/src/components/AdminPanel/AdminPanel.styles.tsx
@@ -216,6 +216,7 @@ export const InputLabelContainer = styled.div`
 
 export const InputLabelWrapper = styled.div<{
   flexRow?: boolean;
+  wrapLabelText?: boolean;
   topSpacing?: boolean;
   inputWidth?: number;
   noBottomSpacing?: boolean;
@@ -281,7 +282,8 @@ export const InputLabelWrapper = styled.div<{
     color: ${palette.highlight.grey8};
     margin-top: 5px;
     padding: 0 3px;
-    white-space: nowrap;
+    white-space: ${({ wrapLabelText }) =>
+      wrapLabelText ? "normal" : "nowrap"};
   }
 
   ${({ required }) =>
@@ -822,8 +824,21 @@ export const GraphicLines = styled.div<{ type?: SaveConfirmationType }>`
   }
 `;
 
-export const WarningMessage = styled.p`
+export const WarningMessage = styled.div`
   ${typography.sizeCSS.small}
+  max-width: 350px;
   color: ${palette.solid.red};
   margin-top: 5px;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid ${palette.solid.red};
+  border-radius: 4px;
+  padding: 16px;
+  margin-left: 12px;
+
+  p {
+    text-align: center;
+  }
 `;

--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -15,6 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+import alertIcon from "@justice-counts/common/assets/alert-icon.png";
 import { Button } from "@justice-counts/common/components/Button";
 import { Dropdown } from "@justice-counts/common/components/Dropdown";
 import { MiniLoader } from "@justice-counts/common/components/MiniLoader";
@@ -870,7 +871,7 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                         </Styled.InputLabelWrapper>
 
                         {hasSystems && hasChildAgencies && (
-                          <Styled.InputLabelWrapper flexRow>
+                          <Styled.InputLabelWrapper flexRow wrapLabelText>
                             <input
                               id="copy-superagency-metric-settings"
                               name="copy-superagency-metric-settings"
@@ -883,15 +884,21 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                               checked={isCopySuperagencyMetricSettingsSelected}
                             />
                             <label htmlFor="copy-superagency-metric-settings">
-                              Copy all metric settings to child agencies
+                              Copy all metric settings to child agencies across
+                              all sectors
                             </label>
                             {isCopySuperagencyMetricSettingsSelected && (
                               <Styled.WarningMessage>
-                                Warning! This action cannot be undone. After
-                                clicking <strong>Save</strong>, the copying
-                                process will begin and you will receive an email
-                                confirmation once the metrics settings have been
-                                copied over.
+                                <img src={alertIcon} alt="" width="24px" />
+                                <p>
+                                  WARNING! This action cannot be undone. This
+                                  will OVERWRITE all metric settings in all
+                                  child agencies. After clicking{" "}
+                                  <strong>Save</strong>, the copying process
+                                  will begin and you will receive an email
+                                  confirmation once the metrics settings have
+                                  been copied over.
+                                </p>
                               </Styled.WarningMessage>
                             )}
                           </Styled.InputLabelWrapper>


### PR DESCRIPTION
## Description of the change

Update copy for the copy-superagency-metric-settings checkbox and warning message to add more specificity that the copying process will overwrite existing child agency settings and that it will copy across all sectors.

<img width="1728" alt="Screenshot 2024-02-06 at 11 25 22 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/ed7f5de3-1a9e-4a21-9f1a-b191c78755aa">
(@morden35 - I also updated the styling for the warning message to make it pop out more - lmk what you think!)

## Related issues

Closes #1178

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
