### PR TITLE
[Publisher][Design Updates] Update Supervision subpopulation layout and behavior in Metric Settings

### DIFF
--- a/common/components/CheckboxOptions/CheckboxOptions.styles.tsx
+++ b/common/components/CheckboxOptions/CheckboxOptions.styles.tsx
@@ -19,6 +19,8 @@ import styled from "styled-components/macro";
 
 import { typography } from "../GlobalStyles";
 
+export const CheckboxContainer = styled.div``;
+
 export const CheckboxOptionsWrapper = styled.div`
   display: flex;
   align-items: center;
@@ -31,6 +33,7 @@ export const CheckboxLabel = styled.div`
   display: flex;
   align-items: center;
   gap: 8px;
+  text-transform: capitalize;
 `;
 
 export const Checkbox = styled.input`

--- a/common/components/CheckboxOptions/CheckboxOptions.tsx
+++ b/common/components/CheckboxOptions/CheckboxOptions.tsx
@@ -39,22 +39,28 @@ export const CheckboxOptions: React.FC<CheckboxOptionsProps> = ({
   options,
   onChange,
 }) => {
-  return options.map(
-    ({ key, label, checked, disabled, icon, onChangeOverride }) => (
-      <Styled.CheckboxOptionsWrapper key={key}>
-        <Styled.Checkbox
-          id={key}
-          type="checkbox"
-          checked={checked}
-          onChange={() =>
-            onChangeOverride ? onChangeOverride() : onChange({ key, checked })
-          }
-          disabled={disabled}
-        />
-        <Styled.CheckboxLabel>
-          {label} {icon}
-        </Styled.CheckboxLabel>
-      </Styled.CheckboxOptionsWrapper>
-    )
+  return (
+    <Styled.CheckboxContainer>
+      {options.map(
+        ({ key, label, checked, disabled, icon, onChangeOverride }) => (
+          <Styled.CheckboxOptionsWrapper key={key}>
+            <Styled.Checkbox
+              id={key}
+              type="checkbox"
+              checked={checked}
+              onChange={() =>
+                onChangeOverride
+                  ? onChangeOverride()
+                  : onChange({ key, checked })
+              }
+              disabled={disabled}
+            />
+            <Styled.CheckboxLabel>
+              {label} {icon}
+            </Styled.CheckboxLabel>
+          </Styled.CheckboxOptionsWrapper>
+        )
+      )}
+    </Styled.CheckboxContainer>
   );
 };

--- a/common/components/TabbedBar/TabbedBar.styled.tsx
+++ b/common/components/TabbedBar/TabbedBar.styled.tsx
@@ -53,7 +53,7 @@ export const Tab = styled.div<{
   }}
 
   &:hover {
-    cursor: ${({ enabled }) => (enabled ? `pointer` : `default`)};
+    cursor: ${({ enabled }) => (enabled === false ? `default` : `pointer`)};
     color: ${({ enabled, selected }) => {
       if (enabled !== undefined && !selected)
         return enabled ? palette.solid.blue : palette.highlight.grey8;

--- a/common/components/TabbedBar/TabbedBar.styled.tsx
+++ b/common/components/TabbedBar/TabbedBar.styled.tsx
@@ -53,10 +53,10 @@ export const Tab = styled.div<{
   }}
 
   &:hover {
-    cursor: pointer;
+    cursor: ${({ enabled }) => (enabled ? `pointer` : `default`)};
     color: ${({ enabled, selected }) => {
       if (enabled !== undefined && !selected)
-        return enabled ? palette.solid.blue : palette.solid.darkgrey;
+        return enabled ? palette.solid.blue : palette.highlight.grey8;
       return palette.solid.blue;
     }};
   }

--- a/publisher/src/components/DataViz/MetricsDataChart.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.tsx
@@ -28,7 +28,12 @@ import {
 } from "@justice-counts/common/components/Dropdown";
 import { MIN_DESKTOP_WIDTH } from "@justice-counts/common/components/GlobalStyles";
 import { useWindowWidth } from "@justice-counts/common/hooks";
-import { AgencySystem, ReportFrequency } from "@justice-counts/common/types";
+import {
+  AgencySystem,
+  AgencySystems,
+  ReportFrequency,
+  SupervisionSubsystems,
+} from "@justice-counts/common/types";
 import { downloadMetricData } from "@justice-counts/common/utils";
 import { frequencyString } from "@justice-counts/common/utils/helperUtils";
 import FileSaver from "file-saver";
@@ -70,6 +75,23 @@ export const MetricsDataChart: React.FC = observer(() => {
 
   const { system: systemSearchParam, metric: metricSearchParam } =
     settingsSearchParams;
+  /**
+   * When navigating from Explore Data to Metric Settings, if it is a supervision subsystem,
+   * then use the "SUPERVISION" system and metric params to redirect to the correct Metric Settings page
+   *
+   * Context: supervision subsystems no longer have their own metric settings page and are now configured
+   * under the "SUPERVISION" system metric settings page
+   */
+  const supervisionSubsystemRedirectSearchParams =
+    systemSearchParam && SupervisionSubsystems.includes(systemSearchParam)
+      ? {
+          system: AgencySystems.SUPERVISION,
+          metric: metricSearchParam?.replaceAll(
+            systemSearchParam,
+            AgencySystems.SUPERVISION
+          ),
+        }
+      : settingsSearchParams;
   const enabledMetrics = agencyMetrics.filter((metric) => metric.enabled);
   const currentSystem = systemSearchParam || currentAgency?.systems[0];
   const currentMetric = currentSystem
@@ -364,7 +386,9 @@ export const MetricsDataChart: React.FC = observer(() => {
               onClick={() => {
                 navigate({
                   pathname: "../metric-config",
-                  search: `?${createSearchParams(settingsSearchParams)}`,
+                  search: `?${createSearchParams(
+                    supervisionSubsystemRedirectSearchParams
+                  )}`,
                 });
               }}
             >
@@ -395,7 +419,9 @@ export const MetricsDataChart: React.FC = observer(() => {
               onClick={() => {
                 navigate({
                   pathname: "../metric-config",
-                  search: `?${createSearchParams(settingsSearchParams)}`,
+                  search: `?${createSearchParams(
+                    supervisionSubsystemRedirectSearchParams
+                  )}`,
                 });
               }}
             >

--- a/publisher/src/components/MetricsConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricsConfiguration/Configuration.tsx
@@ -18,13 +18,12 @@
 import { Button } from "@justice-counts/common/components/Button";
 import { TabbedBar } from "@justice-counts/common/components/TabbedBar";
 import { useIsFooterVisible } from "@justice-counts/common/hooks";
+import { SupervisionSubsystems } from "@justice-counts/common/types";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
-import { useParams } from "react-router-dom";
 
 import { NotFound } from "../../pages/NotFound";
 import { useStore } from "../../stores";
-import { formatSystemName } from "../../utils";
 import { getActiveSystemMetricKey, useSettingsSearchParams } from "../Settings";
 import * as Styled from "./Configuration.styled";
 import MetricAvailability from "./MetricAvailability";
@@ -32,12 +31,11 @@ import MetricDefinitions from "./MetricDefinitions";
 import RaceEthnicitiesModalForm from "./RaceEthnicitiesModalForm";
 
 function Configuration() {
-  const { agencyId } = useParams() as { agencyId: string };
   const [isFooterVisible, setIsFooterVisible] = useIsFooterVisible();
   const [settingsSearchParams, setSettingsSearchParams] =
     useSettingsSearchParams();
   const { system: systemSearchParam } = settingsSearchParams;
-  const { metricConfigStore, userStore } = useStore();
+  const { metricConfigStore } = useStore();
   const { metrics } = metricConfigStore;
   const [metricConfigPage, setMetricConfigPage] = useState<
     "availability" | "definitions"
@@ -45,7 +43,6 @@ function Configuration() {
   const [isRaceEthnicityModalOpen, setIsRaceEthnicityModalOpen] =
     useState(false);
 
-  const currentAgency = userStore.getAgency(agencyId);
   const systemMetricKey = getActiveSystemMetricKey(settingsSearchParams);
 
   useEffect(() => {
@@ -60,7 +57,11 @@ function Configuration() {
       : "unset";
   }, [isRaceEthnicityModalOpen]);
 
-  if (!metrics[systemMetricKey]) return <NotFound />;
+  if (
+    !metrics[systemMetricKey] ||
+    (systemSearchParam && SupervisionSubsystems.includes(systemSearchParam)) // Case: when user types in supervision subsystem in params
+  )
+    return <NotFound />;
 
   const configurationOptions = [
     {
@@ -101,13 +102,7 @@ function Configuration() {
           </Styled.MetricName>
           <Styled.Description>
             {metrics[systemMetricKey]?.description}
-            <span>
-              Sector:{" "}
-              {systemSearchParam &&
-                formatSystemName(systemSearchParam, {
-                  allUserSystems: currentAgency?.systems,
-                })}
-            </span>
+            <span>Sector: {systemSearchParam?.toLocaleLowerCase()}</span>
           </Styled.Description>
 
           <TabbedBar options={configurationOptions} />

--- a/publisher/src/components/MetricsConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricsConfiguration/Configuration.tsx
@@ -19,6 +19,7 @@ import { Button } from "@justice-counts/common/components/Button";
 import { TabbedBar } from "@justice-counts/common/components/TabbedBar";
 import { useIsFooterVisible } from "@justice-counts/common/hooks";
 import { SupervisionSubsystems } from "@justice-counts/common/types";
+import { removeSnakeCase } from "@justice-counts/common/utils";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
 
@@ -102,7 +103,10 @@ function Configuration() {
           </Styled.MetricName>
           <Styled.Description>
             {metrics[systemMetricKey]?.description}
-            <span>Sector: {systemSearchParam?.toLocaleLowerCase()}</span>
+            <span>
+              Sector:{" "}
+              {removeSnakeCase(systemSearchParam?.toLocaleLowerCase() || "")}
+            </span>
           </Styled.Description>
 
           <TabbedBar options={configurationOptions} />

--- a/publisher/src/components/MetricsConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricsConfiguration/Configuration.tsx
@@ -74,8 +74,10 @@ function Configuration() {
     {
       key: "define_metrics",
       label: "Define Metrics",
-      onClick: () => setMetricConfigPage("definitions"),
+      onClick: () =>
+        metrics[systemMetricKey].enabled && setMetricConfigPage("definitions"),
       selected: metricConfigPage === "definitions",
+      enabled: Boolean(metrics[systemMetricKey].enabled),
     },
   ];
 

--- a/publisher/src/components/MetricsConfiguration/Configuration.tsx
+++ b/publisher/src/components/MetricsConfiguration/Configuration.tsx
@@ -62,7 +62,7 @@ function Configuration() {
         systemMetricKey,
         system
       );
-      return Boolean(metrics[currentSystemMetricKey].enabled);
+      return Boolean(metrics[currentSystemMetricKey]?.enabled);
     });
   const hasSupervisionMetricAndEnabledSubsystems =
     systemSearchParam === AgencySystems.SUPERVISION &&

--- a/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
+++ b/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
@@ -19,6 +19,7 @@ import { Button } from "@justice-counts/common/components/Button";
 import { CheckboxOptions } from "@justice-counts/common/components/CheckboxOptions";
 import { NewInput } from "@justice-counts/common/components/Input";
 import {
+  AgencySystem,
   MetricConfigurationSettings,
   MetricConfigurationSettingsOptions,
 } from "@justice-counts/common/types";
@@ -27,7 +28,7 @@ import React, { ChangeEvent, Fragment, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import { useStore } from "../../stores";
-import { getActiveSystemMetricKey, useSettingsSearchParams } from "../Settings";
+import MetricConfigStore from "../../stores/MetricConfigStore";
 import * as Styled from "./ModalForm.styled";
 import {
   ContextsByContextKey,
@@ -38,16 +39,17 @@ import {
 type DefinitionModalFormProps = {
   activeDisaggregationKey?: string;
   activeDimensionKey?: string;
+  systemMetricKey: string;
   closeModal: () => void;
 };
 
 function DefinitionModalForm({
   activeDisaggregationKey,
   activeDimensionKey,
+  systemMetricKey,
   closeModal,
 }: DefinitionModalFormProps) {
   const { agencyId } = useParams() as { agencyId: string };
-  const [settingsSearchParams] = useSettingsSearchParams();
   const { metricConfigStore, userStore } = useStore();
   const {
     metrics,
@@ -67,9 +69,11 @@ function DefinitionModalForm({
   const isReadOnly = userStore.isUserReadOnly(agencyId);
 
   // system and metric keys
-  const { system: systemSearchParam, metric: metricSearchParam } =
-    settingsSearchParams;
-  const systemMetricKey = getActiveSystemMetricKey(settingsSearchParams);
+  const { system: systemSearchParam, metricKey: metricSearchParam } =
+    MetricConfigStore.splitSystemMetricKey(systemMetricKey) as {
+      system: AgencySystem;
+      metricKey: string;
+    };
 
   // definitions
   const isMetricDefinitionSettings = !activeDimensionKey;

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.styled.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.styled.tsx
@@ -49,6 +49,9 @@ export const Header = styled.div`
 
 export const Description = styled.div`
   ${typography.body};
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
   color: ${palette.highlight.grey8};
   margin-bottom: 48px;
 `;
@@ -58,18 +61,19 @@ export const MetricSettingsSectionTitle = styled.div`
   margin-bottom: 16px;
 `;
 
-export const SettingsContainer = styled.div`
+export const SettingsContainer = styled.div<{ borderTop?: boolean }>`
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  ${({ borderTop }) =>
+    borderTop && `border-top: 1px solid ${palette.solid.lightgrey4};`}
 `;
 
 export const Setting = styled.div`
   width: 100%;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 8px;
   margin-bottom: 48px;
 `;
 
@@ -108,13 +112,15 @@ export const SettingTooltip = styled.div`
   }
 `;
 
-export const MonthSelectionDropdownContainer = styled.div<{
+export const DropdownV2Container = styled.div<{
   checked?: boolean;
+  marginTop?: boolean;
 }>`
-  max-width: 275px;
+  width: 275px;
   display: flex;
   flex: 1 1 0;
   border-radius: 3px;
+  ${({ marginTop }) => marginTop && "margin-top: 8px;"};
 
   & ${CustomDropdown} {
     border: 1px solid ${palette.highlight.grey4};
@@ -127,6 +133,7 @@ export const MonthSelectionDropdownContainer = styled.div<{
 
   & ${CustomDropdownToggleLabel} {
     ${typography.body}
+    text-transform: capitalize;
     gap: 8px;
   }
 
@@ -172,12 +179,16 @@ export const BreakdownsSectionDescription = styled(Description)`
   color: ${palette.highlight.grey8};
 `;
 
-export const BreakdownsOptionsContainer = styled.div`
+export const BreakdownsOptionsContainer = styled.div<{
+  disaggregatedBySupervisionSubsystems?: boolean;
+}>`
   width: 100%;
   display: flex;
   flex-direction: row;
   gap: 8px;
   margin-bottom: 32px;
+  ${({ disaggregatedBySupervisionSubsystems }) =>
+    disaggregatedBySupervisionSubsystems ? `margin-top: 32px` : 0};
 `;
 
 export const BreakdownsOption = styled.div<{ active: boolean }>`
@@ -200,12 +211,18 @@ export const BreakdownsOption = styled.div<{ active: boolean }>`
   }
 `;
 
-export const DimensionsContainer = styled.div`
+export const DimensionsContainer = styled.div<{
+  isDisaggregatedBySupervisionSubsystemsSingleDisaggregation?: boolean;
+}>`
   width: 100%;
   display: flex;
   flex-direction: column;
   align-items: start;
   margin-bottom: 48px;
+  margin-top: ${({
+    isDisaggregatedBySupervisionSubsystemsSingleDisaggregation,
+  }) =>
+    isDisaggregatedBySupervisionSubsystemsSingleDisaggregation ? `48px` : 0};
 
   &:last-child {
     margin-bottom: 38px;

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -141,7 +141,7 @@ function MetricAvailability({
   } = MetricConfigStore.splitSystemMetricKey(
     activeBreakdownSystemMetricKey
   ) as { system: AgencySystem; metricKey: string };
-  console.log(activeAvailabilitySystemMetricKey);
+
   const {
     defaultFrequency,
     customFrequency,

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -110,7 +110,6 @@ function MetricAvailability({
   );
 
   const systemMetricKey = getActiveSystemMetricKey(settingsSearchParams);
-  console.log("systemMetricKey", systemMetricKey);
   const activeAvailabilitySystemMetricKey =
     hasSupervisionSubsystems &&
     systemSearchParam &&
@@ -143,23 +142,13 @@ function MetricAvailability({
     activeBreakdownSystemMetricKey
   ) as { system: AgencySystem; metricKey: string };
 
-  console.log(
-    "activeAvailabilitySystemMetricKey",
-    activeAvailabilitySystemMetricKey
-  );
-  console.log("activeBreakdownSystemMetricKey", activeBreakdownSystemMetricKey);
+  const { defaultFrequency, customFrequency, startingMonth } =
+    metrics[activeAvailabilitySystemMetricKey];
 
-  const {
-    defaultFrequency,
-    customFrequency,
-    startingMonth,
-    disaggregatedBySupervisionSubsystems,
-  } = metrics[activeAvailabilitySystemMetricKey];
-
-  const isSupervisionMetricAndDisaggregatedBySupervisionSubsystems =
-    disaggregatedBySupervisionSubsystems &&
-    systemSearchParam &&
-    !SupervisionSubsystems.includes(systemSearchParam);
+  // Note: check the main overall Supervision system (via the original `systemMetricKey`) to determine whether or not it is disaggregated
+  const isSupervisionSystemDisaggregatedBySubsystems =
+    systemSearchParam === AgencySystems.SUPERVISION &&
+    metrics[systemMetricKey].disaggregatedBySupervisionSubsystems;
 
   const metricEnabled = metrics[activeAvailabilitySystemMetricKey]?.enabled;
   const customOrDefaultFrequency = customFrequency || defaultFrequency;
@@ -208,11 +197,6 @@ function MetricAvailability({
         onClick: () => {
           setShowCustomYearDropdownOverride(undefined);
           setSelectedSupervisionSubsystemAvailability(system);
-          setTimeout(
-            () =>
-              console.log(metrics[activeAvailabilitySystemMetricKey], system),
-            1000
-          );
         },
         highlight: selectedSupervisionSubsystemAvailability === system,
       };
@@ -366,7 +350,7 @@ function MetricAvailability({
                       onChange={() =>
                         handleSupervisionDisaggregationSelection(false)
                       }
-                      checked={!disaggregatedBySupervisionSubsystems}
+                      checked={!isSupervisionSystemDisaggregatedBySubsystems}
                     />
                     <RadioButton
                       type="radio"
@@ -377,12 +361,14 @@ function MetricAvailability({
                       onChange={() =>
                         handleSupervisionDisaggregationSelection(true)
                       }
-                      checked={Boolean(disaggregatedBySupervisionSubsystems)}
+                      checked={Boolean(
+                        isSupervisionSystemDisaggregatedBySubsystems
+                      )}
                     />
                   </RadioButtonsWrapper>
                 </Styled.Setting>
               )}
-            {disaggregatedBySupervisionSubsystems &&
+            {isSupervisionSystemDisaggregatedBySubsystems &&
               hasSupervisionSubsystems && (
                 <Styled.Setting>
                   <Styled.SettingName>
@@ -430,11 +416,11 @@ function MetricAvailability({
           <Styled.Header>Metric Availability</Styled.Header>
           <Styled.Description>
             Select how frequently data will be shared
-            {isSupervisionMetricAndDisaggregatedBySupervisionSubsystems &&
+            {isSupervisionSystemDisaggregatedBySubsystems &&
               `. Select which subpopulation you are configuring through the dropdown.`}
             {isSupervisionSystem &&
               hasSupervisionSubsystems &&
-              isSupervisionMetricAndDisaggregatedBySupervisionSubsystems && (
+              isSupervisionSystemDisaggregatedBySubsystems && (
                 <Styled.DropdownV2Container>
                   <Dropdown
                     label={removeSnakeCase(
@@ -468,7 +454,7 @@ function MetricAvailability({
               id="availability-buttons-wrapper"
               disabled={
                 isReadOnly ||
-                (isSupervisionMetricAndDisaggregatedBySupervisionSubsystems &&
+                (isSupervisionSystemDisaggregatedBySubsystems &&
                   selectedSupervisionSubsystemAvailability ===
                     systemSearchParam)
               }
@@ -515,7 +501,7 @@ function MetricAvailability({
                 }
               />
             </RadioButtonsWrapper>
-            {isSupervisionMetricAndDisaggregatedBySupervisionSubsystems &&
+            {isSupervisionSystemDisaggregatedBySubsystems &&
               activeAvailabilitySystemKey === AgencySystems.SUPERVISION && (
                 <Tooltip
                   anchorId="availability-buttons-wrapper"
@@ -624,11 +610,11 @@ function MetricAvailability({
             <Styled.BreakdownsSectionDescription>
               Select the categories that your agency will share as breakdowns of{" "}
               {metrics[systemMetricKey]?.label}
-              {isSupervisionMetricAndDisaggregatedBySupervisionSubsystems &&
+              {isSupervisionSystemDisaggregatedBySubsystems &&
                 `. Select which subpopulation you are configuring through the dropdown.`}
             </Styled.BreakdownsSectionDescription>
 
-            {disaggregatedBySupervisionSubsystems && (
+            {isSupervisionSystemDisaggregatedBySubsystems && (
               <Styled.DropdownV2Container>
                 <Dropdown
                   label={removeSnakeCase(
@@ -648,7 +634,7 @@ function MetricAvailability({
             {disaggregationsOptions.length > 1 && (
               <Styled.BreakdownsOptionsContainer
                 disaggregatedBySupervisionSubsystems={Boolean(
-                  disaggregatedBySupervisionSubsystems
+                  isSupervisionSystemDisaggregatedBySubsystems
                 )}
               >
                 <TabbedBar options={disaggregationsOptions} />
@@ -678,7 +664,7 @@ function MetricAvailability({
                 <Styled.DimensionsContainer
                   key={disaggregationKey}
                   isDisaggregatedBySupervisionSubsystemsSingleDisaggregation={
-                    disaggregatedBySupervisionSubsystems &&
+                    isSupervisionSystemDisaggregatedBySubsystems &&
                     disaggregationsOptions.length <= 1
                   }
                 >
@@ -700,9 +686,9 @@ function MetricAvailability({
                       <Styled.DimensionsListFieldset
                         disabled={
                           isReadOnly ||
-                          (!disaggregatedBySupervisionSubsystems &&
+                          (!isSupervisionSystemDisaggregatedBySubsystems &&
                             !metricEnabled) ||
-                          (disaggregatedBySupervisionSubsystems &&
+                          (isSupervisionSystemDisaggregatedBySubsystems &&
                             !metrics[activeBreakdownSystemMetricKey].enabled)
                         }
                       >

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -691,6 +691,7 @@ function MetricAvailability({
                   </Styled.DimensionsHeader>
                   {disaggregationKey === RACE_ETHNICITY_DISAGGREGATION_KEY ? (
                     <RaceEthnicitiesGrid
+                      isMetricEnabled={Boolean(metricEnabled)}
                       disaggregationEnabled={!isReadOnly}
                       onClick={() => {
                         if (!isReadOnly) {

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -29,6 +29,8 @@ import {
 import { TabbedBar } from "@justice-counts/common/components/TabbedBar";
 import { Tooltip } from "@justice-counts/common/components/Tooltip";
 import {
+  AgencySystem,
+  AgencySystems,
   SupervisionSubsystems,
   SupervisionSystem,
 } from "@justice-counts/common/types";
@@ -37,8 +39,13 @@ import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 
 import { useStore } from "../../stores";
+import MetricConfigStore from "../../stores/MetricConfigStore";
 import { monthsByName, removeSnakeCase } from "../../utils";
-import { getActiveSystemMetricKey, useSettingsSearchParams } from "../Settings";
+import {
+  getActiveSystemMetricKey,
+  replaceSystemMetricKeyWithNewSystem,
+  useSettingsSearchParams,
+} from "../Settings";
 import { RACE_ETHNICITY_DISAGGREGATION_KEY } from "./constants";
 import * as Styled from "./MetricAvailability.styled";
 import { RaceEthnicitiesGrid } from "./RaceEthnicitiesGrid";
@@ -72,126 +79,83 @@ function MetricAvailability({
   } = metricConfigStore;
   const [activeDisaggregationKey, setActiveDisaggregationKey] =
     useState<string>();
+  // For when a user selects "Other" for Starting Month and has made no dropdown selection
+  const [showCustomYearDropdownOverride, setShowCustomYearDropdownOverride] =
+    useState<boolean>();
+  const [
+    selectedSupervisionSubsystemAvailability,
+    setSelectedSupervisionSubsystemAvailability,
+  ] = useState(systemSearchParam);
+  const [
+    selectedSupervisionSubsystemBreakdown,
+    setSelectedSupervisionSubsystemBreakdown,
+  ] = useState(systemSearchParam);
 
   const isReadOnly = userStore.isUserReadOnly(agencyId);
+  const currentAgency = userStore.getAgency(agencyId);
+  const agencySupervisionSubsystems = currentAgency?.systems.filter((system) =>
+    SupervisionSubsystems.includes(system)
+  );
+  const isSupervisionSystem = systemSearchParam === AgencySystems.SUPERVISION;
+  const hasSupervisionSubsystems =
+    agencySupervisionSubsystems && agencySupervisionSubsystems.length > 0;
 
   const systemMetricKey = getActiveSystemMetricKey(settingsSearchParams);
-  const activeDisaggregationKeys =
-    disaggregations[systemMetricKey] &&
-    Object.keys(disaggregations[systemMetricKey]);
+  const activeAvailabilitySystemMetricKey =
+    hasSupervisionSubsystems &&
+    systemSearchParam &&
+    selectedSupervisionSubsystemAvailability
+      ? replaceSystemMetricKeyWithNewSystem(
+          systemMetricKey,
+          selectedSupervisionSubsystemAvailability
+        )
+      : systemMetricKey;
+  const {
+    system: activeAvailabilitySystemKey,
+    metricKey: activeAvailabilityMetricKey,
+  } = MetricConfigStore.splitSystemMetricKey(
+    activeAvailabilitySystemMetricKey
+  ) as { system: AgencySystem; metricKey: string };
+
+  const activeBreakdownSystemMetricKey =
+    hasSupervisionSubsystems &&
+    systemSearchParam &&
+    selectedSupervisionSubsystemBreakdown
+      ? replaceSystemMetricKeyWithNewSystem(
+          systemMetricKey,
+          selectedSupervisionSubsystemBreakdown
+        )
+      : systemMetricKey;
+  const {
+    system: activeBreakdownSystemKey,
+    metricKey: activeBreakdownMetricKey,
+  } = MetricConfigStore.splitSystemMetricKey(
+    activeBreakdownSystemMetricKey
+  ) as { system: AgencySystem; metricKey: string };
+
   const {
     defaultFrequency,
     customFrequency,
     startingMonth,
     disaggregatedBySupervisionSubsystems,
-  } = metrics[systemMetricKey];
+  } = metrics[activeAvailabilitySystemMetricKey];
 
-  const [showCustomYearDropdown, setShowCustomYearDropdown] = useState<boolean>(
-    startingMonth ? ![1, 7].includes(startingMonth) : false
-  );
-
-  const metricEnabled = metrics[systemMetricKey]?.enabled;
-  const customOrDefaultFrequency = customFrequency || defaultFrequency;
-  const startingMonthNotJanuaryJuly =
-    startingMonth !== null && startingMonth !== 1 && startingMonth !== 7;
-
-  const currentAgency = userStore.getAgency(agencyId);
-  const enabledSupervisionSubsystems = currentAgency?.systems
-    .filter((system) => SupervisionSubsystems.includes(system))
-    .map((system) => system.toLowerCase());
-  const hasEnabledSupervisionSubsystems =
-    enabledSupervisionSubsystems && enabledSupervisionSubsystems.length > 0;
   const isSupervisionMetricAndDisaggregatedBySupervisionSubsystems =
     disaggregatedBySupervisionSubsystems &&
     systemSearchParam &&
     !SupervisionSubsystems.includes(systemSearchParam);
-  const isSupervisionSubsystemMetricAndSubsystemsCombined =
-    !disaggregatedBySupervisionSubsystems &&
-    systemSearchParam &&
-    SupervisionSubsystems.includes(systemSearchParam);
 
-  const getDisaggregatedBySupervisionSubtypeTooltipMsg = () => {
-    if (isSupervisionMetricAndDisaggregatedBySupervisionSubsystems) {
-      return `This metric is marked as 'Disaggregated'. Please adjust the availability on the disaggregated metrics or update the 'Disaggregated by Supervision Type' to 'Combined'.`;
-    }
-    if (isSupervisionSubsystemMetricAndSubsystemsCombined) {
-      return `This metric is marked as 'Combined'. Please adjust the availability on the combined metric or update the 'Disaggregated by Supervision Type' to 'Disaggregated'.`;
-    }
-  };
+  const metricEnabled = metrics[activeAvailabilitySystemMetricKey]?.enabled;
+  const customOrDefaultFrequency = customFrequency || defaultFrequency;
+  const startingMonthNotJanuaryJuly =
+    startingMonth !== null && startingMonth !== 1 && startingMonth !== 7;
+  const showCustomYearDropdown =
+    showCustomYearDropdownOverride ||
+    (startingMonth ? ![1, 7].includes(startingMonth) : false);
 
-  const handleUpdateMetricEnabledStatus = (enabledStatus: boolean) => {
-    if (systemSearchParam && metricSearchParam) {
-      const updatedSetting = updateMetricEnabledStatus(
-        systemSearchParam,
-        metricSearchParam,
-        enabledStatus
-      );
-      saveMetricSettings(updatedSetting, agencyId);
-    }
-  };
-
-  const handleUpdateMetricReportFrequency = (
-    frequencyUpdate: ReportFrequencyUpdate
-  ) => {
-    if (systemSearchParam && metricSearchParam) {
-      const updatedSetting = updateMetricReportFrequency(
-        systemSearchParam,
-        metricSearchParam,
-        frequencyUpdate
-      );
-      saveMetricSettings(updatedSetting, agencyId);
-    }
-  };
-
-  const handleSupervisionDisaggregationSelection = async (status: boolean) => {
-    if (systemSearchParam && metricSearchParam) {
-      const updatedSetting = updateDisaggregatedBySupervisionSubsystems(
-        systemSearchParam,
-        metricSearchParam,
-        status
-      );
-
-      await saveMetricSettings(updatedSetting, agencyId);
-
-      // After saving disaggregation selection, re-fetch metric settings
-      // because changing this setting causes other supervision combined / disaggregegated metrics to update
-      initializeMetricConfigStoreValues(agencyId);
-    }
-  };
-
-  const handleDisaggregationSelection = (
-    disaggregationKey: string,
-    status: boolean
-  ) => {
-    if (systemSearchParam && metricSearchParam) {
-      const updatedSetting = updateDisaggregationEnabledStatus(
-        systemSearchParam,
-        metricSearchParam,
-        disaggregationKey,
-        status
-      );
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      saveMetricSettings(updatedSetting, agencyId!);
-    }
-  };
-
-  const handleDimensionEnabledStatus = (
-    status: boolean,
-    dimensionKey: string,
-    disaggregationKey: string
-  ) => {
-    if (systemSearchParam && metricSearchParam) {
-      const updatedSetting = updateDimensionEnabledStatus(
-        systemSearchParam,
-        metricSearchParam,
-        disaggregationKey,
-        dimensionKey,
-        status
-      );
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      saveMetricSettings(updatedSetting, agencyId!);
-    }
-  };
+  const activeDisaggregationKeys =
+    disaggregations[systemMetricKey] &&
+    Object.keys(disaggregations[systemMetricKey]);
 
   const monthSelectionDropdownOptions: DropdownOption[] = monthsByName
     .filter((month) => !["January", "July"].includes(month))
@@ -208,6 +172,48 @@ function MetricAvailability({
         highlight: monthNumber === startingMonth,
       };
     });
+
+  const supervisionSubsystemBreakdownDropdownOptions = [
+    {
+      key: "SUPERVISION",
+      label: "Supervision (Combined)",
+      onClick: () => setSelectedSupervisionSubsystemBreakdown("SUPERVISION"),
+      highlight: selectedSupervisionSubsystemBreakdown === "SUPERVISION",
+    },
+    ...(agencySupervisionSubsystems?.map((system) => {
+      return {
+        key: system,
+        label: removeSnakeCase(system.toLocaleLowerCase()),
+        onClick: () => setSelectedSupervisionSubsystemBreakdown(system),
+        highlight: selectedSupervisionSubsystemBreakdown === system,
+      };
+    }) || []),
+  ];
+
+  const supervisionSubsystemAvailabilityDropdownOptions = [
+    {
+      key: "SUPERVISION",
+      label: "Supervision (Combined)",
+      onClick: () => {
+        setShowCustomYearDropdownOverride(undefined);
+        setSelectedSupervisionSubsystemAvailability("SUPERVISION");
+      },
+      highlight: selectedSupervisionSubsystemAvailability === "SUPERVISION",
+    },
+    ...(agencySupervisionSubsystems?.map((system) => {
+      return {
+        key: system,
+        label: removeSnakeCase(system.toLocaleLowerCase()),
+        onClick: () => {
+          setShowCustomYearDropdownOverride(undefined);
+          setSelectedSupervisionSubsystemAvailability(system);
+        },
+        highlight:
+          selectedSupervisionSubsystemAvailability?.toLocaleLowerCase() ===
+          system,
+      };
+    }) || []),
+  ];
 
   const disaggregationsOptions = [
     ...(activeDisaggregationKeys?.length > 1
@@ -237,6 +243,84 @@ function MetricAvailability({
   const hasDisaggregations =
     disaggregationsOptions && disaggregationsOptions.length > 0;
 
+  const handleUpdateMetricEnabledStatus = (
+    enabledStatus: boolean,
+    systemKey?: AgencySystem,
+    metricKey?: string
+  ) => {
+    if (systemSearchParam && metricSearchParam) {
+      const updatedSetting = updateMetricEnabledStatus(
+        systemKey || activeAvailabilitySystemKey,
+        metricKey || activeAvailabilityMetricKey,
+        enabledStatus
+      );
+      saveMetricSettings(updatedSetting, agencyId);
+    }
+  };
+
+  const handleUpdateMetricReportFrequency = (
+    frequencyUpdate: ReportFrequencyUpdate
+  ) => {
+    if (systemSearchParam && metricSearchParam) {
+      const updatedSetting = updateMetricReportFrequency(
+        activeAvailabilitySystemKey,
+        activeAvailabilityMetricKey,
+        frequencyUpdate
+      );
+      saveMetricSettings(updatedSetting, agencyId);
+    }
+  };
+
+  const handleSupervisionDisaggregationSelection = async (status: boolean) => {
+    if (systemSearchParam && metricSearchParam) {
+      const updatedSetting = updateDisaggregatedBySupervisionSubsystems(
+        systemSearchParam,
+        metricSearchParam,
+        status
+      );
+
+      await saveMetricSettings(updatedSetting, agencyId);
+
+      // After saving disaggregation selection, re-fetch metric settings
+      // because changing this setting causes other supervision combined / disaggregegated metrics to update
+      initializeMetricConfigStoreValues(agencyId);
+    }
+  };
+
+  const handleDisaggregationSelection = (
+    disaggregationKey: string,
+    status: boolean
+  ) => {
+    if (systemSearchParam && metricSearchParam) {
+      const updatedSetting = updateDisaggregationEnabledStatus(
+        activeBreakdownSystemKey,
+        activeBreakdownMetricKey,
+        disaggregationKey,
+        status
+      );
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      saveMetricSettings(updatedSetting, agencyId!);
+    }
+  };
+
+  const handleDimensionEnabledStatus = (
+    status: boolean,
+    dimensionKey: string,
+    disaggregationKey: string
+  ) => {
+    if (systemSearchParam && metricSearchParam) {
+      const updatedSetting = updateDimensionEnabledStatus(
+        activeBreakdownSystemKey,
+        activeBreakdownMetricKey,
+        disaggregationKey,
+        dimensionKey,
+        status
+      );
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      saveMetricSettings(updatedSetting, agencyId!);
+    }
+  };
+
   useEffect(() => {
     window.scrollTo(0, 0);
   }, []);
@@ -244,12 +328,131 @@ function MetricAvailability({
   return (
     <Styled.Wrapper>
       <Styled.InnerWrapper>
-        <Styled.Header>Metric Availability</Styled.Header>
-        <Styled.Description>
-          Select how frequently data will be shared
-        </Styled.Description>
+        {/* Metric Disaggregation */}
+        {isSupervisionSystem && hasSupervisionSubsystems && (
+          <Styled.SettingsContainer>
+            <Styled.Header>Metric Disaggregation</Styled.Header>
+            <Styled.Description>
+              Disaggregate your metrics by sector
+            </Styled.Description>
+            {systemSearchParam &&
+              hasSupervisionSubsystems &&
+              (systemSearchParam === SupervisionSystem ||
+                SupervisionSubsystems.includes(systemSearchParam)) && (
+                <Styled.Setting>
+                  <Styled.SettingName>
+                    Disaggregated by Supervision Type{" "}
+                    <Styled.InfoIconWrapper>
+                      <img src={infoIcon} alt="" width="12px" />
+                      <Styled.SettingTooltip>
+                        For Supervision metrics, you can choose to share the
+                        data for your supervision operations as a whole, or
+                        disaggregated by your supervision populations (parole,
+                        probation, dual, etc).
+                      </Styled.SettingTooltip>
+                    </Styled.InfoIconWrapper>
+                  </Styled.SettingName>
+                  <RadioButtonsWrapper disabled={isReadOnly}>
+                    <RadioButton
+                      type="radio"
+                      id="supervision-subsystem-combined"
+                      name="supervision-subsystem"
+                      label="Combined"
+                      value="All Populations / Combined"
+                      onChange={() =>
+                        handleSupervisionDisaggregationSelection(false)
+                      }
+                      checked={!disaggregatedBySupervisionSubsystems}
+                    />
+                    <RadioButton
+                      type="radio"
+                      id="supervision-subsystem-disaggregated"
+                      name="supervision-subsystem"
+                      label="Disaggregated"
+                      value="Disaggregated"
+                      onChange={() =>
+                        handleSupervisionDisaggregationSelection(true)
+                      }
+                      checked={disaggregatedBySupervisionSubsystems}
+                    />
+                  </RadioButtonsWrapper>
+                </Styled.Setting>
+              )}
+            {disaggregatedBySupervisionSubsystems &&
+              hasSupervisionSubsystems && (
+                <Styled.Setting>
+                  <Styled.SettingName>
+                    Subpopulations{" "}
+                    <Styled.InfoIconWrapper>
+                      <img src={infoIcon} alt="" width="12px" />
+                      <Styled.SettingTooltip>
+                        Select the subpopulations supervised by your agency.
+                        Metrics can be reported as either combined or
+                        disaggregated by subpopulation.
+                      </Styled.SettingTooltip>
+                    </Styled.InfoIconWrapper>
+                  </Styled.SettingName>
+                  <CheckboxOptions
+                    options={agencySupervisionSubsystems?.map((subsystem) => {
+                      const subsystemMetricKey =
+                        replaceSystemMetricKeyWithNewSystem(
+                          systemMetricKey,
+                          subsystem
+                        );
 
-        <Styled.SettingsContainer>
+                      return {
+                        key: subsystemMetricKey,
+                        label: removeSnakeCase(subsystem.toLocaleLowerCase()),
+                        checked: Boolean(metrics[subsystemMetricKey]?.enabled),
+                      };
+                    })}
+                    onChange={({ key, checked }) => {
+                      const { metricKey, system: systemKey } =
+                        MetricConfigStore.splitSystemMetricKey(key);
+                      handleUpdateMetricEnabledStatus(
+                        !checked,
+                        systemKey as AgencySystem,
+                        metricKey
+                      );
+                    }}
+                  />
+                </Styled.Setting>
+              )}
+          </Styled.SettingsContainer>
+        )}
+
+        {/* Metric Availability */}
+        <Styled.SettingsContainer borderTop>
+          <Styled.Header>Metric Availability</Styled.Header>
+          <Styled.Description>
+            Select how frequently data will be shared
+            {isSupervisionMetricAndDisaggregatedBySupervisionSubsystems &&
+              `. Select which subpopulation you are configuring through the dropdown.`}
+            {isSupervisionSystem &&
+              hasSupervisionSubsystems &&
+              isSupervisionMetricAndDisaggregatedBySupervisionSubsystems && (
+                <Styled.DropdownV2Container>
+                  <Dropdown
+                    label={
+                      selectedSupervisionSubsystemAvailability === "SUPERVISION"
+                        ? "Supervision (Combined)"
+                        : removeSnakeCase(
+                            selectedSupervisionSubsystemAvailability?.toLocaleLowerCase() ||
+                              ""
+                          )
+                    }
+                    options={supervisionSubsystemAvailabilityDropdownOptions}
+                    size="small"
+                    hover="background"
+                    alignment="right"
+                    caretPosition="right"
+                    fullWidth
+                  />
+                </Styled.DropdownV2Container>
+              )}
+          </Styled.Description>
+
+          {/* Metric Reporting Frequency */}
           <Styled.Setting>
             <Styled.SettingName>
               Availability{" "}
@@ -265,8 +468,9 @@ function MetricAvailability({
               id="availability-buttons-wrapper"
               disabled={
                 isReadOnly ||
-                isSupervisionMetricAndDisaggregatedBySupervisionSubsystems ||
-                isSupervisionSubsystemMetricAndSubsystemsCombined
+                (isSupervisionMetricAndDisaggregatedBySupervisionSubsystems &&
+                  selectedSupervisionSubsystemAvailability ===
+                    systemSearchParam)
               }
             >
               <RadioButton
@@ -311,15 +515,17 @@ function MetricAvailability({
                 }
               />
             </RadioButtonsWrapper>
-            {(isSupervisionMetricAndDisaggregatedBySupervisionSubsystems ||
-              isSupervisionSubsystemMetricAndSubsystemsCombined) && (
-              <Tooltip
-                anchorId="availability-buttons-wrapper"
-                position="top"
-                content={getDisaggregatedBySupervisionSubtypeTooltipMsg()}
-              />
-            )}
+            {isSupervisionMetricAndDisaggregatedBySupervisionSubsystems &&
+              activeAvailabilitySystemKey === AgencySystems.SUPERVISION && (
+                <Tooltip
+                  anchorId="availability-buttons-wrapper"
+                  position="top"
+                  content={`This metric is marked as 'Disaggregated'. Please adjust the availability on the subpopulations or update the 'Disaggregated by Supervision Type' to 'Combined'.`}
+                />
+              )}
           </Styled.Setting>
+
+          {/* Annual Frequency Starting Month */}
           {metricEnabled && customFrequency === "ANNUAL" && (
             <Styled.Setting>
               <Styled.SettingName>
@@ -346,7 +552,7 @@ function MetricAvailability({
                     (startingMonth === 1 || !startingMonth)
                   }
                   onChange={() => {
-                    setShowCustomYearDropdown(false);
+                    setShowCustomYearDropdownOverride(undefined);
                     handleUpdateMetricReportFrequency({
                       customFrequency: "ANNUAL",
                       startingMonth: 1,
@@ -365,7 +571,7 @@ function MetricAvailability({
                     startingMonth === 7
                   }
                   onChange={() => {
-                    setShowCustomYearDropdown(false);
+                    setShowCustomYearDropdownOverride(undefined);
                     handleUpdateMetricReportFrequency({
                       customFrequency: "ANNUAL",
                       startingMonth: 7,
@@ -379,12 +585,13 @@ function MetricAvailability({
                   label="Other"
                   value="Other"
                   checked={metricEnabled && showCustomYearDropdown}
-                  onChange={() => setShowCustomYearDropdown(true)}
+                  onChange={() => setShowCustomYearDropdownOverride(true)}
                 />
               </RadioButtonsWrapper>
               {showCustomYearDropdown && (
-                <Styled.MonthSelectionDropdownContainer
+                <Styled.DropdownV2Container
                   checked={startingMonthNotJanuaryJuly}
+                  marginTop
                 >
                   <Dropdown
                     label={
@@ -402,73 +609,62 @@ function MetricAvailability({
                     caretPosition="right"
                     fullWidth
                   />
-                </Styled.MonthSelectionDropdownContainer>
+                </Styled.DropdownV2Container>
               )}
             </Styled.Setting>
           )}
-          {systemSearchParam &&
-            hasEnabledSupervisionSubsystems &&
-            (systemSearchParam === SupervisionSystem ||
-              SupervisionSubsystems.includes(systemSearchParam)) && (
-              <Styled.Setting>
-                <Styled.SettingName>
-                  Disaggregated by Supervision Type{" "}
-                  <Styled.InfoIconWrapper>
-                    <img src={infoIcon} alt="" width="12px" />
-                    <Styled.SettingTooltip>
-                      For Supervision metrics, you can choose to share the data
-                      for your supervision operations as a whole, or
-                      disaggregated by your supervision populations (parole,
-                      probation, dual, etc).
-                    </Styled.SettingTooltip>
-                  </Styled.InfoIconWrapper>
-                </Styled.SettingName>
-                <RadioButtonsWrapper disabled={isReadOnly || !metricEnabled}>
-                  <RadioButton
-                    type="radio"
-                    id="supervision-subsystem-combined"
-                    name="supervision-subsystem"
-                    label="Combined"
-                    value="All Populations / Combined"
-                    onChange={() =>
-                      handleSupervisionDisaggregationSelection(false)
-                    }
-                    checked={!disaggregatedBySupervisionSubsystems}
-                  />
-                  <RadioButton
-                    type="radio"
-                    id="supervision-subsystem-disaggregated"
-                    name="supervision-subsystem"
-                    label="Disaggregated"
-                    value="Disaggregated"
-                    onChange={() =>
-                      handleSupervisionDisaggregationSelection(true)
-                    }
-                    checked={disaggregatedBySupervisionSubsystems}
-                  />
-                </RadioButtonsWrapper>
-              </Styled.Setting>
-            )}
         </Styled.SettingsContainer>
+
+        {/* Metric Breakdowns */}
         {hasDisaggregations && (
-          <Styled.BreakdownsSection disabled={!metricEnabled}>
+          <Styled.BreakdownsSection disabled={false}>
             <Styled.BreakdownsSectionTitle>
               Metric Breakdowns
             </Styled.BreakdownsSectionTitle>
             <Styled.BreakdownsSectionDescription>
               Select the categories that your agency will share as breakdowns of{" "}
-              {metrics[systemMetricKey]?.label}.
+              {metrics[systemMetricKey]?.label}
+              {isSupervisionMetricAndDisaggregatedBySupervisionSubsystems &&
+                `. Select which subpopulation you are configuring through the dropdown.`}
             </Styled.BreakdownsSectionDescription>
+
+            {disaggregatedBySupervisionSubsystems && (
+              <Styled.DropdownV2Container>
+                <Dropdown
+                  label={
+                    selectedSupervisionSubsystemBreakdown === "SUPERVISION"
+                      ? "Supervision (Combined)"
+                      : removeSnakeCase(
+                          selectedSupervisionSubsystemBreakdown?.toLocaleLowerCase() ||
+                            ""
+                        )
+                  }
+                  options={supervisionSubsystemBreakdownDropdownOptions}
+                  size="small"
+                  hover="background"
+                  alignment="right"
+                  caretPosition="right"
+                  fullWidth
+                />
+              </Styled.DropdownV2Container>
+            )}
+
             {disaggregationsOptions.length > 1 && (
-              <Styled.BreakdownsOptionsContainer>
+              <Styled.BreakdownsOptionsContainer
+                disaggregatedBySupervisionSubsystems={Boolean(
+                  disaggregatedBySupervisionSubsystems
+                )}
+              >
                 <TabbedBar options={disaggregationsOptions} />
               </Styled.BreakdownsOptionsContainer>
             )}
             {activeDisaggregationKeys?.map((disaggregationKey) => {
               const currentDisaggregation =
-                disaggregations[systemMetricKey][disaggregationKey];
+                disaggregations[activeBreakdownSystemMetricKey][
+                  disaggregationKey
+                ];
               const currentDimensions =
-                dimensions[systemMetricKey][disaggregationKey];
+                dimensions[activeBreakdownSystemMetricKey][disaggregationKey];
               const currentEnabledDimensions = Object.values(
                 currentDimensions
               ).filter((dimension) => dimension.enabled);
@@ -483,7 +679,13 @@ function MetricAvailability({
                 return null;
 
               return (
-                <Styled.DimensionsContainer key={disaggregationKey}>
+                <Styled.DimensionsContainer
+                  key={disaggregationKey}
+                  isDisaggregatedBySupervisionSubsystemsSingleDisaggregation={
+                    disaggregatedBySupervisionSubsystems &&
+                    disaggregationsOptions.length <= 1
+                  }
+                >
                   <Styled.DimensionsHeader>
                     {currentDisaggregation.display_name}
                   </Styled.DimensionsHeader>
@@ -498,7 +700,15 @@ function MetricAvailability({
                     />
                   ) : (
                     <Styled.DimensionsList>
-                      <Styled.DimensionsListFieldset disabled={isReadOnly}>
+                      <Styled.DimensionsListFieldset
+                        disabled={
+                          isReadOnly ||
+                          (!disaggregatedBySupervisionSubsystems &&
+                            !metricEnabled) ||
+                          (disaggregatedBySupervisionSubsystems &&
+                            !metrics[activeBreakdownSystemMetricKey].enabled)
+                        }
+                      >
                         <CheckboxOptions
                           options={[
                             ...Object.values(currentDimensions).map(

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -96,7 +96,7 @@ function MetricAvailability({
     selectedSupervisionSubsystemAvailability,
     setSelectedSupervisionSubsystemAvailability,
   ] = useState(
-    hasSupervisionSubsystems
+    isSupervisionSystem && hasSupervisionSubsystems
       ? agencySupervisionSubsystems[0]
       : systemSearchParam
   );
@@ -104,7 +104,7 @@ function MetricAvailability({
     selectedSupervisionSubsystemBreakdown,
     setSelectedSupervisionSubsystemBreakdown,
   ] = useState(
-    hasSupervisionSubsystems
+    isSupervisionSystem && hasSupervisionSubsystems
       ? agencySupervisionSubsystems[0]
       : systemSearchParam
   );
@@ -141,7 +141,7 @@ function MetricAvailability({
   } = MetricConfigStore.splitSystemMetricKey(
     activeBreakdownSystemMetricKey
   ) as { system: AgencySystem; metricKey: string };
-
+  console.log(activeAvailabilitySystemMetricKey);
   const {
     defaultFrequency,
     customFrequency,
@@ -202,9 +202,7 @@ function MetricAvailability({
           setShowCustomYearDropdownOverride(undefined);
           setSelectedSupervisionSubsystemAvailability(system);
         },
-        highlight:
-          selectedSupervisionSubsystemAvailability?.toLocaleLowerCase() ===
-          system,
+        highlight: selectedSupervisionSubsystemAvailability === system,
       };
     }) || []),
   ];

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -110,6 +110,7 @@ function MetricAvailability({
   );
 
   const systemMetricKey = getActiveSystemMetricKey(settingsSearchParams);
+  console.log("systemMetricKey", systemMetricKey);
   const activeAvailabilitySystemMetricKey =
     hasSupervisionSubsystems &&
     systemSearchParam &&
@@ -141,6 +142,12 @@ function MetricAvailability({
   } = MetricConfigStore.splitSystemMetricKey(
     activeBreakdownSystemMetricKey
   ) as { system: AgencySystem; metricKey: string };
+
+  console.log(
+    "activeAvailabilitySystemMetricKey",
+    activeAvailabilitySystemMetricKey
+  );
+  console.log("activeBreakdownSystemMetricKey", activeBreakdownSystemMetricKey);
 
   const {
     defaultFrequency,
@@ -201,6 +208,11 @@ function MetricAvailability({
         onClick: () => {
           setShowCustomYearDropdownOverride(undefined);
           setSelectedSupervisionSubsystemAvailability(system);
+          setTimeout(
+            () =>
+              console.log(metrics[activeAvailabilitySystemMetricKey], system),
+            1000
+          );
         },
         highlight: selectedSupervisionSubsystemAvailability === system,
       };
@@ -365,7 +377,7 @@ function MetricAvailability({
                       onChange={() =>
                         handleSupervisionDisaggregationSelection(true)
                       }
-                      checked={disaggregatedBySupervisionSubsystems}
+                      checked={Boolean(disaggregatedBySupervisionSubsystems)}
                     />
                   </RadioButtonsWrapper>
                 </Styled.Setting>

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -82,14 +82,6 @@ function MetricAvailability({
   // For when a user selects "Other" for Starting Month and has made no dropdown selection
   const [showCustomYearDropdownOverride, setShowCustomYearDropdownOverride] =
     useState<boolean>();
-  const [
-    selectedSupervisionSubsystemAvailability,
-    setSelectedSupervisionSubsystemAvailability,
-  ] = useState(systemSearchParam);
-  const [
-    selectedSupervisionSubsystemBreakdown,
-    setSelectedSupervisionSubsystemBreakdown,
-  ] = useState(systemSearchParam);
 
   const isReadOnly = userStore.isUserReadOnly(agencyId);
   const currentAgency = userStore.getAgency(agencyId);
@@ -99,6 +91,23 @@ function MetricAvailability({
   const isSupervisionSystem = systemSearchParam === AgencySystems.SUPERVISION;
   const hasSupervisionSubsystems =
     agencySupervisionSubsystems && agencySupervisionSubsystems.length > 0;
+
+  const [
+    selectedSupervisionSubsystemAvailability,
+    setSelectedSupervisionSubsystemAvailability,
+  ] = useState(
+    hasSupervisionSubsystems
+      ? agencySupervisionSubsystems[0]
+      : systemSearchParam
+  );
+  const [
+    selectedSupervisionSubsystemBreakdown,
+    setSelectedSupervisionSubsystemBreakdown,
+  ] = useState(
+    hasSupervisionSubsystems
+      ? agencySupervisionSubsystems[0]
+      : systemSearchParam
+  );
 
   const systemMetricKey = getActiveSystemMetricKey(settingsSearchParams);
   const activeAvailabilitySystemMetricKey =
@@ -174,12 +183,6 @@ function MetricAvailability({
     });
 
   const supervisionSubsystemBreakdownDropdownOptions = [
-    {
-      key: "SUPERVISION",
-      label: "Supervision (Combined)",
-      onClick: () => setSelectedSupervisionSubsystemBreakdown("SUPERVISION"),
-      highlight: selectedSupervisionSubsystemBreakdown === "SUPERVISION",
-    },
     ...(agencySupervisionSubsystems?.map((system) => {
       return {
         key: system,
@@ -191,15 +194,6 @@ function MetricAvailability({
   ];
 
   const supervisionSubsystemAvailabilityDropdownOptions = [
-    {
-      key: "SUPERVISION",
-      label: "Supervision (Combined)",
-      onClick: () => {
-        setShowCustomYearDropdownOverride(undefined);
-        setSelectedSupervisionSubsystemAvailability("SUPERVISION");
-      },
-      highlight: selectedSupervisionSubsystemAvailability === "SUPERVISION",
-    },
     ...(agencySupervisionSubsystems?.map((system) => {
       return {
         key: system,
@@ -433,14 +427,10 @@ function MetricAvailability({
               isSupervisionMetricAndDisaggregatedBySupervisionSubsystems && (
                 <Styled.DropdownV2Container>
                   <Dropdown
-                    label={
-                      selectedSupervisionSubsystemAvailability === "SUPERVISION"
-                        ? "Supervision (Combined)"
-                        : removeSnakeCase(
-                            selectedSupervisionSubsystemAvailability?.toLocaleLowerCase() ||
-                              ""
-                          )
-                    }
+                    label={removeSnakeCase(
+                      selectedSupervisionSubsystemAvailability?.toLocaleLowerCase() ||
+                        ""
+                    )}
                     options={supervisionSubsystemAvailabilityDropdownOptions}
                     size="small"
                     hover="background"
@@ -631,14 +621,10 @@ function MetricAvailability({
             {disaggregatedBySupervisionSubsystems && (
               <Styled.DropdownV2Container>
                 <Dropdown
-                  label={
-                    selectedSupervisionSubsystemBreakdown === "SUPERVISION"
-                      ? "Supervision (Combined)"
-                      : removeSnakeCase(
-                          selectedSupervisionSubsystemBreakdown?.toLocaleLowerCase() ||
-                            ""
-                        )
-                  }
+                  label={removeSnakeCase(
+                    selectedSupervisionSubsystemBreakdown?.toLocaleLowerCase() ||
+                      ""
+                  )}
                   options={supervisionSubsystemBreakdownDropdownOptions}
                   size="small"
                   hover="background"

--- a/publisher/src/components/MetricsConfiguration/MetricDefinitions.styled.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricDefinitions.styled.tsx
@@ -51,8 +51,8 @@ export const SectionItem = styled(MetricsOverview.MetricItem)`
   padding-right: 0;
 
   &:hover {
-    background: none;
-    cursor: unset;
+    background-color: ${palette.solid.lightgrey2};
+    cursor: pointer;
   }
 `;
 
@@ -66,9 +66,4 @@ export const DropdownSpacer = styled.div`
 export const EditButton = styled.div`
   ${typography.body}
   color: ${palette.solid.blue};
-
-  &:hover {
-    color: ${palette.solid.darkblue};
-    cursor: pointer;
-  }
 `;

--- a/publisher/src/components/MetricsConfiguration/MetricDefinitions.styled.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricDefinitions.styled.tsx
@@ -58,6 +58,11 @@ export const SectionItem = styled(MetricsOverview.MetricItem)`
 
 export const SectionItemLabel = styled(MetricsOverview.MetricItemName)``;
 
+export const DropdownSpacer = styled.div`
+  padding: 16px 0;
+  border-bottom: 1px solid ${palette.solid.lightgrey4};
+`;
+
 export const EditButton = styled.div`
   ${typography.body}
   color: ${palette.solid.blue};

--- a/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
@@ -163,15 +163,16 @@ function MetricDefinitions() {
           )}
           <Styled.Section>
             <Styled.SectionTitle>Primary Metric</Styled.SectionTitle>
-            <Styled.SectionItem id="metric-total">
+            <Styled.SectionItem
+              id="metric-total"
+              onClick={() => setIsSettingsModalOpen(true)}
+            >
               <Styled.SectionItemLabel
                 actionRequired={!metricHasDefinitionSelected()}
               >
                 {metrics[activeSystemMetricKey]?.label} (Total)
               </Styled.SectionItemLabel>
-              <Styled.EditButton onClick={() => setIsSettingsModalOpen(true)}>
-                Edit
-              </Styled.EditButton>
+              <Styled.EditButton>Edit</Styled.EditButton>
               <Tooltip
                 anchorId="metric-total"
                 position="top-end"
@@ -255,21 +256,18 @@ function MetricDefinitions() {
                     <Styled.SectionItem
                       id={replaceSymbolsWithDash(key)}
                       key={key}
+                      onClick={() => {
+                        setActiveDisaggregationKey(disaggregationKey);
+                        setActiveDimensionKey(key);
+                        setIsSettingsModalOpen(true);
+                      }}
                     >
                       <Styled.SectionItemLabel
                         actionRequired={!hasEnabledDefinition}
                       >
                         {dimension.label}
                       </Styled.SectionItemLabel>
-                      <Styled.EditButton
-                        onClick={() => {
-                          setActiveDisaggregationKey(disaggregationKey);
-                          setActiveDimensionKey(key);
-                          setIsSettingsModalOpen(true);
-                        }}
-                      >
-                        Edit
-                      </Styled.EditButton>
+                      <Styled.EditButton>Edit</Styled.EditButton>
                       <Tooltip
                         anchorId={replaceSymbolsWithDash(key)}
                         position="top-end"

--- a/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
@@ -63,7 +63,7 @@ function MetricDefinitions() {
         systemMetricKey,
         system
       );
-      return Boolean(metrics[currentSystemMetricKey].enabled);
+      return Boolean(metrics[currentSystemMetricKey]?.enabled);
     });
 
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);

--- a/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
@@ -54,10 +54,17 @@ function MetricDefinitions() {
     contexts,
     dimensionContexts,
   } = metricConfigStore;
+  const systemMetricKey = getActiveSystemMetricKey(settingsSearchParams);
   const currentAgency = userStore.getAgency(agencyId);
-  const agencySupervisionSubsystems = currentAgency?.systems.filter((system) =>
-    SupervisionSubsystems.includes(system)
-  );
+  const agencySupervisionSubsystems = currentAgency?.systems
+    .filter((system) => SupervisionSubsystems.includes(system))
+    .filter((system) => {
+      const currentSystemMetricKey = replaceSystemMetricKeyWithNewSystem(
+        systemMetricKey,
+        system
+      );
+      return Boolean(metrics[currentSystemMetricKey].enabled);
+    });
 
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
   const [activeDisaggregationKey, setActiveDisaggregationKey] = useState<
@@ -73,12 +80,10 @@ function MetricDefinitions() {
         : settingsSearchParams.system
     );
 
-  const systemMetricKey = getActiveSystemMetricKey(settingsSearchParams);
   const activeSystemMetricKey = replaceSystemMetricKeyWithNewSystem(
     systemMetricKey,
     selectedSupervisionSubsystem as AgencySystem
   );
-
   const activeDisaggregationKeys =
     disaggregations[activeSystemMetricKey] &&
     Object.keys(disaggregations[activeSystemMetricKey]);
@@ -134,8 +139,7 @@ function MetricDefinitions() {
       )}
       <Styled.Wrapper>
         <Styled.InnerWrapper>
-          {metrics[activeSystemMetricKey]
-            .disaggregatedBySupervisionSubsystems && (
+          {metrics[systemMetricKey].disaggregatedBySupervisionSubsystems && (
             <Styled.DropdownSpacer>
               <MetricAvailability.DropdownV2Container>
                 <Dropdown

--- a/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
@@ -15,21 +15,36 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
+import { Dropdown } from "@justice-counts/common/components/Dropdown";
 import { Tooltip } from "@justice-counts/common/components/Tooltip";
-import { MetricConfigurationSettings } from "@justice-counts/common/types";
-import { replaceSymbolsWithDash } from "@justice-counts/common/utils";
+import {
+  AgencySystem,
+  MetricConfigurationSettings,
+  SupervisionSubsystems,
+} from "@justice-counts/common/types";
+import {
+  removeSnakeCase,
+  replaceSymbolsWithDash,
+} from "@justice-counts/common/utils";
 import { observer } from "mobx-react-lite";
 import React, { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
 
 import { useStore } from "../../stores";
-import { getActiveSystemMetricKey, useSettingsSearchParams } from "../Settings";
+import {
+  getActiveSystemMetricKey,
+  replaceSystemMetricKeyWithNewSystem,
+  useSettingsSearchParams,
+} from "../Settings";
 import { RACE_ETHNICITY_DISAGGREGATION_KEY } from "./constants";
 import DefinitionModalForm from "./DefinitionModalForm";
+import * as MetricAvailability from "./MetricAvailability.styled";
 import * as Styled from "./MetricDefinitions.styled";
 
 function MetricDefinitions() {
   const [settingsSearchParams] = useSettingsSearchParams();
-  const { metricConfigStore } = useStore();
+  const { agencyId } = useParams() as { agencyId: string };
+  const { metricConfigStore, userStore } = useStore();
   const {
     metrics,
     dimensions,
@@ -46,23 +61,32 @@ function MetricDefinitions() {
   const [activeDimensionKey, setActiveDimensionKey] = useState<
     string | undefined
   >(undefined);
+  const [
+    selectedSupervisionSubsystemBreakdown,
+    setSelectedSupervisionSubsystemBreakdown,
+  ] = useState(settingsSearchParams.system);
 
   const systemMetricKey = getActiveSystemMetricKey(settingsSearchParams);
+  const activeSystemMetricKey = replaceSystemMetricKeyWithNewSystem(
+    systemMetricKey,
+    selectedSupervisionSubsystemBreakdown as AgencySystem
+  );
+
   const activeDisaggregationKeys =
-    disaggregations[systemMetricKey] &&
-    Object.keys(disaggregations[systemMetricKey]);
+    disaggregations[activeSystemMetricKey] &&
+    Object.keys(disaggregations[activeSystemMetricKey]);
 
   const metricHasDefinitionSelected = () => {
     /** Top-level Metric Definitions */
-    if (!metricDefinitionSettings[systemMetricKey]) return true;
+    if (!metricDefinitionSettings[activeSystemMetricKey]) return true;
     const metricSettings = Object.values(
-      metricDefinitionSettings[systemMetricKey]
+      metricDefinitionSettings[activeSystemMetricKey]
     ).reduce((acc, metricSetting) => {
       return { ...acc, ...metricSetting.settings };
     }, {} as { [settingKey: string]: Partial<MetricConfigurationSettings> });
     /** Top-level metric context key will always be "INCLUDES_EXCLUDES_DESCRIPTION" */
     const hasContextValue = Boolean(
-      contexts[systemMetricKey].INCLUDES_EXCLUDES_DESCRIPTION.value
+      contexts[activeSystemMetricKey].INCLUDES_EXCLUDES_DESCRIPTION.value
     );
     return (
       hasContextValue ||
@@ -71,6 +95,28 @@ function MetricDefinitions() {
       )
     );
   };
+
+  const currentAgency = userStore.getAgency(agencyId);
+  const agencySupervisionSubsystems = currentAgency?.systems.filter((system) =>
+    SupervisionSubsystems.includes(system)
+  );
+
+  const supervisionSubsystemDropdownOptions = [
+    {
+      key: "SUPERVISION",
+      label: "Supervision (Combined)",
+      onClick: () => setSelectedSupervisionSubsystemBreakdown("SUPERVISION"),
+      highlight: selectedSupervisionSubsystemBreakdown === "SUPERVISION",
+    },
+    ...(agencySupervisionSubsystems?.map((system) => {
+      return {
+        key: system,
+        label: removeSnakeCase(system.toLocaleLowerCase()),
+        onClick: () => setSelectedSupervisionSubsystemBreakdown(system),
+        highlight: selectedSupervisionSubsystemBreakdown === system,
+      };
+    }) || []),
+  ];
 
   useEffect(() => {
     document.body.style.overflow = isSettingsModalOpen ? "hidden" : "unset";
@@ -87,17 +133,41 @@ function MetricDefinitions() {
             setActiveDisaggregationKey(undefined);
             setActiveDimensionKey(undefined);
           }}
+          systemMetricKey={activeSystemMetricKey}
         />
       )}
       <Styled.Wrapper>
         <Styled.InnerWrapper>
+          {metrics[activeSystemMetricKey]
+            .disaggregatedBySupervisionSubsystems && (
+            <Styled.DropdownSpacer>
+              <MetricAvailability.DropdownV2Container>
+                <Dropdown
+                  label={
+                    selectedSupervisionSubsystemBreakdown === "SUPERVISION"
+                      ? "Supervision (Combined)"
+                      : removeSnakeCase(
+                          selectedSupervisionSubsystemBreakdown?.toLocaleLowerCase() ||
+                            ""
+                        )
+                  }
+                  options={supervisionSubsystemDropdownOptions}
+                  size="small"
+                  hover="background"
+                  alignment="right"
+                  caretPosition="right"
+                  fullWidth
+                />
+              </MetricAvailability.DropdownV2Container>
+            </Styled.DropdownSpacer>
+          )}
           <Styled.Section>
             <Styled.SectionTitle>Primary Metric</Styled.SectionTitle>
             <Styled.SectionItem id="metric-total">
               <Styled.SectionItemLabel
                 actionRequired={!metricHasDefinitionSelected()}
               >
-                {metrics[systemMetricKey]?.label} (Total)
+                {metrics[activeSystemMetricKey]?.label} (Total)
               </Styled.SectionItemLabel>
               <Styled.EditButton onClick={() => setIsSettingsModalOpen(true)}>
                 Edit
@@ -105,18 +175,18 @@ function MetricDefinitions() {
               <Tooltip
                 anchorId="metric-total"
                 position="top"
-                content={metrics[systemMetricKey]?.description}
-                title={`${metrics[systemMetricKey]?.label} (Total)`}
+                content={metrics[activeSystemMetricKey]?.description}
+                title={`${metrics[activeSystemMetricKey]?.label} (Total)`}
                 noArrow
-                offset={-115}
+                offset={-113}
               />
             </Styled.SectionItem>
           </Styled.Section>
           {activeDisaggregationKeys?.map((disaggregationKey) => {
             const currentDisaggregation =
-              disaggregations[systemMetricKey][disaggregationKey];
+              disaggregations[activeSystemMetricKey][disaggregationKey];
             const currentEnabledDimensions = Object.entries(
-              dimensions[systemMetricKey][disaggregationKey]
+              dimensions[activeSystemMetricKey][disaggregationKey]
             ).filter(([_, dimension]) => dimension.enabled);
 
             if (
@@ -134,14 +204,16 @@ function MetricDefinitions() {
                 {currentEnabledDimensions.map(([key, dimension]) => {
                   let hasEnabledDefinition = false;
                   const currentDimensionDefinitionSettings =
-                    dimensionDefinitionSettings[systemMetricKey][
+                    dimensionDefinitionSettings[activeSystemMetricKey][
                       disaggregationKey
                     ][key];
                   const hasSettings = Boolean(
                     currentDimensionDefinitionSettings
                   );
                   const dimensionContext =
-                    dimensionContexts[systemMetricKey][disaggregationKey][key];
+                    dimensionContexts[activeSystemMetricKey][disaggregationKey][
+                      key
+                    ];
                   const hasContext = Boolean(dimensionContext);
                   /**
                    * Dimension-level context key will be either "INCLUDES_EXCLUDES_DESCRIPTION"

--- a/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
@@ -54,6 +54,11 @@ function MetricDefinitions() {
     contexts,
     dimensionContexts,
   } = metricConfigStore;
+  const currentAgency = userStore.getAgency(agencyId);
+  const agencySupervisionSubsystems = currentAgency?.systems.filter((system) =>
+    SupervisionSubsystems.includes(system)
+  );
+
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
   const [activeDisaggregationKey, setActiveDisaggregationKey] = useState<
     string | undefined
@@ -61,15 +66,17 @@ function MetricDefinitions() {
   const [activeDimensionKey, setActiveDimensionKey] = useState<
     string | undefined
   >(undefined);
-  const [
-    selectedSupervisionSubsystemBreakdown,
-    setSelectedSupervisionSubsystemBreakdown,
-  ] = useState(settingsSearchParams.system);
+  const [selectedSupervisionSubsystem, setSelectedSupervisionSubsystem] =
+    useState(
+      agencySupervisionSubsystems && agencySupervisionSubsystems.length > 0
+        ? agencySupervisionSubsystems[0]
+        : settingsSearchParams.system
+    );
 
   const systemMetricKey = getActiveSystemMetricKey(settingsSearchParams);
   const activeSystemMetricKey = replaceSystemMetricKeyWithNewSystem(
     systemMetricKey,
-    selectedSupervisionSubsystemBreakdown as AgencySystem
+    selectedSupervisionSubsystem as AgencySystem
   );
 
   const activeDisaggregationKeys =
@@ -96,24 +103,13 @@ function MetricDefinitions() {
     );
   };
 
-  const currentAgency = userStore.getAgency(agencyId);
-  const agencySupervisionSubsystems = currentAgency?.systems.filter((system) =>
-    SupervisionSubsystems.includes(system)
-  );
-
   const supervisionSubsystemDropdownOptions = [
-    {
-      key: "SUPERVISION",
-      label: "Supervision (Combined)",
-      onClick: () => setSelectedSupervisionSubsystemBreakdown("SUPERVISION"),
-      highlight: selectedSupervisionSubsystemBreakdown === "SUPERVISION",
-    },
     ...(agencySupervisionSubsystems?.map((system) => {
       return {
         key: system,
         label: removeSnakeCase(system.toLocaleLowerCase()),
-        onClick: () => setSelectedSupervisionSubsystemBreakdown(system),
-        highlight: selectedSupervisionSubsystemBreakdown === system,
+        onClick: () => setSelectedSupervisionSubsystem(system),
+        highlight: selectedSupervisionSubsystem === system,
       };
     }) || []),
   ];
@@ -144,10 +140,10 @@ function MetricDefinitions() {
               <MetricAvailability.DropdownV2Container>
                 <Dropdown
                   label={
-                    selectedSupervisionSubsystemBreakdown === "SUPERVISION"
+                    selectedSupervisionSubsystem === "SUPERVISION"
                       ? "Supervision (Combined)"
                       : removeSnakeCase(
-                          selectedSupervisionSubsystemBreakdown?.toLocaleLowerCase() ||
+                          selectedSupervisionSubsystem?.toLocaleLowerCase() ||
                             ""
                         )
                   }

--- a/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
@@ -174,11 +174,11 @@ function MetricDefinitions() {
               </Styled.EditButton>
               <Tooltip
                 anchorId="metric-total"
-                position="top"
+                position="top-end"
                 content={metrics[activeSystemMetricKey]?.description}
                 title={`${metrics[activeSystemMetricKey]?.label} (Total)`}
                 noArrow
-                offset={-113}
+                offset={0}
               />
             </Styled.SectionItem>
           </Styled.Section>
@@ -272,11 +272,11 @@ function MetricDefinitions() {
                       </Styled.EditButton>
                       <Tooltip
                         anchorId={replaceSymbolsWithDash(key)}
-                        position="top"
+                        position="top-end"
                         content={dimension.description}
                         title={dimension.label}
                         noArrow
-                        offset={-115}
+                        offset={0}
                       />
                     </Styled.SectionItem>
                   );

--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
@@ -16,7 +16,10 @@
 // =============================================================================
 
 import { TabbedBar } from "@justice-counts/common/components/TabbedBar";
-import { AgencySystem } from "@justice-counts/common/types";
+import {
+  AgencySystem,
+  SupervisionSubsystems,
+} from "@justice-counts/common/types";
 import { frequencyString } from "@justice-counts/common/utils/helperUtils";
 import { observer } from "mobx-react-lite";
 import React from "react";
@@ -89,6 +92,7 @@ export const MetricsOverview = observer(() => {
   const systemTabOptions =
     currentAgency?.systems
       .filter((system) => getMetricsBySystem(system)?.length !== 0)
+      .filter((system) => !SupervisionSubsystems.includes(system))
       .map((system) => {
         return {
           key: system,

--- a/publisher/src/components/MetricsConfiguration/ModalForm.styled.tsx
+++ b/publisher/src/components/MetricsConfiguration/ModalForm.styled.tsx
@@ -44,9 +44,9 @@ export const Wrapper = styled.div`
 
 export const Content = styled.div`
   width: 480px;
-  height: 640px;
-  max-height: 640px;
-  padding: 32px 0;
+  height: fit-content;
+  max-height: 750px;
+  padding: 16px 0;
   background-color: ${palette.solid.white};
   position: relative;
   border-radius: 3px;
@@ -54,11 +54,12 @@ export const Content = styled.div`
 
 export const ScrollableInnerWrapper = styled.div`
   width: 100%;
-  height: 100%;
+  max-height: 624px;
   display: flex;
   flex-direction: column;
   overflow-y: auto;
-  padding: 0 40px 64px 40px;
+  padding: 24px 40px 64px 40px;
+  border-top: 1px solid ${palette.highlight.grey3};
 `;
 
 export const CloseButton = styled.div`
@@ -76,7 +77,7 @@ export const Header = styled.div`
   display: flex;
   justify-content: space-between;
   align-items: center;
-  margin-bottom: 8px;
+  margin-bottom: 16px;
   padding: 0 40px;
 `;
 
@@ -124,7 +125,7 @@ export const BottomButtonsContainer = styled.div`
   position: absolute;
   bottom: 0;
   width: 100%;
-  padding: 32px;
+  padding: 16px 40px;
   display: flex;
   flex-direction: row;
   justify-content: end;
@@ -132,6 +133,7 @@ export const BottomButtonsContainer = styled.div`
   align-items: center;
   background-color: ${palette.solid.white};
   z-index: 2;
+  border-top: 1px solid ${palette.highlight.grey3};
 `;
 
 // race ethnicities

--- a/publisher/src/components/MetricsConfiguration/RaceEthnicitiesGrid.styled.tsx
+++ b/publisher/src/components/MetricsConfiguration/RaceEthnicitiesGrid.styled.tsx
@@ -47,7 +47,7 @@ export const RaceEthnicitiesBreakdownContainer = styled.div<{
   }
 `;
 
-export const CalloutBox = styled.div`
+export const CalloutBox = styled.div<{ isMetricEnabled: boolean }>`
   width: 100%;
   height: 100%;
   display: flex;
@@ -67,6 +67,17 @@ export const CalloutBox = styled.div`
     cursor: pointer;
     background-color: ${palette.solid.lightgrey2};
   }
+
+  ${({ isMetricEnabled }) =>
+    !isMetricEnabled &&
+    `
+      opacity: 0.7;
+
+      &:hover {
+        cursor: unset;  
+        background-color: unset;
+      }
+  `}
 `;
 
 export const GridHeaderContainer = styled.div`

--- a/publisher/src/components/MetricsConfiguration/RaceEthnicitiesGrid.tsx
+++ b/publisher/src/components/MetricsConfiguration/RaceEthnicitiesGrid.tsx
@@ -27,8 +27,9 @@ import { sortRaces } from "./utils";
 
 export const RaceEthnicitiesGrid: React.FC<{
   disaggregationEnabled: boolean;
+  isMetricEnabled: boolean;
   onClick: () => void;
-}> = observer(({ disaggregationEnabled, onClick }) => {
+}> = observer(({ disaggregationEnabled, isMetricEnabled, onClick }) => {
   const [settingsSearchParams] = useSettingsSearchParams();
   const { metricConfigStore } = useStore();
   const { getEthnicitiesByRace } = metricConfigStore;
@@ -45,7 +46,14 @@ export const RaceEthnicitiesGrid: React.FC<{
     <Styled.RaceEthnicitiesBreakdownContainer
       disaggregationEnabled={disaggregationEnabled}
     >
-      <Styled.CalloutBox onClick={onClick}>
+      <Styled.CalloutBox
+        onClick={() => {
+          if (isMetricEnabled) {
+            onClick();
+          }
+        }}
+        isMetricEnabled={isMetricEnabled}
+      >
         <Styled.Description>
           Answer the questions on the <span>Race and Ethnicity</span> form; the
           grid below will reflect your responses.

--- a/publisher/src/components/Settings/utils.ts
+++ b/publisher/src/components/Settings/utils.ts
@@ -31,10 +31,12 @@ export const replaceSystemMetricKeyWithNewSystem = (
   systemMetricKey: string,
   newSystem: AgencySystem
 ) => {
-  const { system } = MetricConfigStore.splitSystemMetricKey(systemMetricKey);
-  return systemMetricKey
-    .replace(system.toLocaleUpperCase(), newSystem.toLocaleUpperCase())
-    .replace(system.toLocaleUpperCase(), newSystem.toLocaleUpperCase());
+  const { system, metricKey } =
+    MetricConfigStore.splitSystemMetricKey(systemMetricKey);
+  return getActiveSystemMetricKey({
+    system: newSystem,
+    metric: metricKey.replace(system, newSystem),
+  });
 };
 
 export const getSettingsSearchParams = (

--- a/publisher/src/components/Settings/utils.ts
+++ b/publisher/src/components/Settings/utils.ts
@@ -32,10 +32,9 @@ export const replaceSystemMetricKeyWithNewSystem = (
   newSystem: AgencySystem
 ) => {
   const { system } = MetricConfigStore.splitSystemMetricKey(systemMetricKey);
-  return systemMetricKey.replaceAll(
-    system.toLocaleUpperCase(),
-    newSystem.toLocaleUpperCase()
-  );
+  return systemMetricKey
+    .replace(system.toLocaleUpperCase(), newSystem.toLocaleUpperCase())
+    .replace(system.toLocaleUpperCase(), newSystem.toLocaleUpperCase());
 };
 
 export const getSettingsSearchParams = (

--- a/publisher/src/components/Settings/utils.ts
+++ b/publisher/src/components/Settings/utils.ts
@@ -17,6 +17,7 @@
 
 import { AgencySystem } from "@justice-counts/common/types";
 
+import MetricConfigStore from "../../stores/MetricConfigStore";
 import { SettingsSearchParams } from "./types";
 
 export const getActiveSystemMetricKey = ({
@@ -24,6 +25,17 @@ export const getActiveSystemMetricKey = ({
   metric,
 }: SettingsSearchParams): string => {
   return `${system?.toUpperCase()}-${metric}`;
+};
+
+export const replaceSystemMetricKeyWithNewSystem = (
+  systemMetricKey: string,
+  newSystem: AgencySystem
+) => {
+  const { system } = MetricConfigStore.splitSystemMetricKey(systemMetricKey);
+  return systemMetricKey.replaceAll(
+    system.toLocaleUpperCase(),
+    newSystem.toLocaleUpperCase()
+  );
 };
 
 export const getSettingsSearchParams = (


### PR DESCRIPTION
## Description of the change

Update Supervision subpopulation layout and behavior in Metric Settings as outlined in [Figma designs](https://www.figma.com/file/dvX3yg7FMGJSWFaqHWrWgQ/Justice-Counts-Publisher?type=design&node-id=10616%3A14191&mode=design&t=Cn4CLfBljs6GVvji-1) 

Instead of separate Metric Settings views for each supervision subpopulation type, now there is one view for configuring both Supervision and subpopulation metrics. 

Quick tour:

https://github.com/Recidiviz/justice-counts/assets/59492998/dfa6cf94-908f-463f-b2d9-8c5cd362af62

[Note: it looks like there's a bug that appears in our existing Metric Settings page that I just noticed recording this demo when you disaggregate a supervision metric, the default frequency is set to "Annual" for the subpopulation types with `starting_month` set to `null` - will file a ticket]

Demo: https://mahmoudtest---publisher-web-b47yvyxs3q-uc.a.run.app/



## Related issues

Closes #1168 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
