### PR TITLE
Revert "Bump eslint-plugin-storybook from 0.6.13 to 0.8.0"

### DIFF
--- a/common/package.json
+++ b/common/package.json
@@ -53,7 +53,7 @@
     "@storybook/react-webpack5": "^7.6.12",
     "@storybook/testing-library": "^0.2.2",
     "babel-jest": "^29.2.1",
-    "eslint-plugin-storybook": "^0.8.0",
+    "eslint-plugin-storybook": "^0.6.13",
     "jest": "^29.2.1",
     "prop-types": "^15.8.1",
     "react-test-renderer": "^18.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6125,7 +6125,7 @@
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
-"@typescript-eslint/utils@5.62.0", "@typescript-eslint/utils@^5.13.0", "@typescript-eslint/utils@^5.62.0":
+"@typescript-eslint/utils@5.62.0", "@typescript-eslint/utils@^5.13.0", "@typescript-eslint/utils@^5.45.0":
   version "5.62.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.62.0.tgz#141e809c71636e4a75daa39faed2fb5f4b10df86"
   integrity sha512-n8oxjeb5aIbPFEtmQxQYOLI0i9n5ySBEY/ZEHHZqKQSFnxio1rv6dthascc9dLuwrL0RC5mPCxB7vnAVGAYWAQ==
@@ -9449,14 +9449,14 @@ eslint-plugin-simple-import-sort@^8.0.0:
   resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-8.0.0.tgz#9d9a2372b0606e999ea841b10458a370a6ccc160"
   integrity sha512-bXgJQ+lqhtQBCuWY/FUWdB27j4+lqcvXv5rUARkzbeWLwea+S5eBZEQrhnO+WgX3ZoJHVj0cn943iyXwByHHQw==
 
-eslint-plugin-storybook@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-storybook/-/eslint-plugin-storybook-0.8.0.tgz#23185ecabdc289cae55248c090f0c1d8fbae6c41"
-  integrity sha512-CZeVO5EzmPY7qghO2t64oaFM+8FTaD4uzOEjHKp516exyTKo+skKAL9GI3QALS2BXhyALJjNtwbmr1XinGE8bA==
+eslint-plugin-storybook@^0.6.13:
+  version "0.6.13"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-storybook/-/eslint-plugin-storybook-0.6.13.tgz#897a9f6a9bb88c63b02f05850f30c28a9848a3f7"
+  integrity sha512-smd+CS0WH1jBqUEJ3znGS7DU4ayBE9z6lkQAK2yrSUv1+rq8BT/tiI5C/rKE7rmiqiAfojtNYZRhzo5HrulccQ==
   dependencies:
     "@storybook/csf" "^0.0.1"
-    "@typescript-eslint/utils" "^5.62.0"
-    requireindex "^1.2.0"
+    "@typescript-eslint/utils" "^5.45.0"
+    requireindex "^1.1.0"
     ts-dedent "^2.2.0"
 
 eslint-plugin-testing-library@^5.0.1:
@@ -14805,7 +14805,7 @@ require-from-string@^2.0.2:
   resolved "https://registry.yarnpkg.com/require-from-string/-/require-from-string-2.0.2.tgz#89a7fdd938261267318eafe14f9c32e598c36909"
   integrity sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
 
-requireindex@^1.2.0:
+requireindex@^1.1.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
   integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==


### PR DESCRIPTION
Reverts Recidiviz/justice-counts#1200 as it required a different node version than the one we have configured - and causing an issue with our staging deploy:

```
Step #1: [2/4] Fetching packages...
Step #1: error eslint-plugin-storybook@0.8.0: The engine "node" is incompatible with this module. Expected version ">= 18". Got "16.20.2"
Step #1: error Found incompatible module.
Step #1: info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Step #1: error building image: error building stage: failed to execute command: waiting for process to exit: exit status 1
Finished Step #1
ERROR
ERROR: build step 1 "gcr.io/kaniko-project/executor:v1.8.1" failed: step exited with non-zero status: 1
```