### PR TITLE
Update CI to fail frontend test when incompatible node versions detected in a new package upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/setup-node@v3
         with:
+          node-version: "16"
           # This clones the repo and checks out the SHA that triggered this action.
           # We set fetch-depth 0 to fetch all branches and history so that merge-base
           # is guaranteed to be able to find the common ancestor with the base branch.

--- a/agency-dashboard/package.json
+++ b/agency-dashboard/package.json
@@ -67,5 +67,8 @@
     "moduleNameMapper": {
       "^d3-(.*)$": "d3-$1/dist/d3-$1"
     }
+  },
+  "engines": {
+    "node": ">=16.0.0 <17.0.0"
   }
 }

--- a/common/package.json
+++ b/common/package.json
@@ -58,5 +58,8 @@
     "prop-types": "^15.8.1",
     "react-test-renderer": "^18.2.0",
     "storybook": "^7.6.4"
+  },
+  "engines": {
+    "node": ">=16.0.0 <17.0.0"
   }
 }

--- a/common/package.json
+++ b/common/package.json
@@ -53,7 +53,7 @@
     "@storybook/react-webpack5": "^7.6.12",
     "@storybook/testing-library": "^0.2.2",
     "babel-jest": "^29.2.1",
-    "eslint-plugin-storybook": "^0.6.13",
+    "eslint-plugin-storybook": "^0.8.0",
     "jest": "^29.2.1",
     "prop-types": "^15.8.1",
     "react-test-renderer": "^18.2.0",

--- a/common/package.json
+++ b/common/package.json
@@ -53,7 +53,7 @@
     "@storybook/react-webpack5": "^7.6.12",
     "@storybook/testing-library": "^0.2.2",
     "babel-jest": "^29.2.1",
-    "eslint-plugin-storybook": "^0.8.0",
+    "eslint-plugin-storybook": "^0.6.13",
     "jest": "^29.2.1",
     "prop-types": "^15.8.1",
     "react-test-renderer": "^18.2.0",

--- a/publisher/package.json
+++ b/publisher/package.json
@@ -111,5 +111,8 @@
       "^d3-(.*)$": "d3-$1/dist/d3-$1"
     }
   },
-  "config-overrides-path": "../config-overrides.js"
+  "config-overrides-path": "../config-overrides.js",
+  "engines": {
+    "node": ">=16.0.0 <17.0.0"
+  }
 }


### PR DESCRIPTION
## Description of the change

Update CI to fail frontend test when incompatible node versions are detected in a new package upgrade by explicitly setting the node version in the `package.json` and updating the `ci.yml` file to use the same node version.

Last week, HelperBot auto-merged in a package that required `node` version `>= 18`, which caused a staging deploy attempt to fail with the following error:
```
Step #1: [2/4] Fetching packages...
Step #1: error eslint-plugin-storybook@0.8.0: The engine "node" is incompatible with this module. Expected version ">= 18". Got "16.20.2"
Step #1: error Found incompatible module.
Step #1: info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
Step #1: error building image: error building stage: failed to execute command: waiting for process to exit: exit status 1
Finished Step #1
ERROR
ERROR: build step 1 "gcr.io/kaniko-project/executor:v1.8.1" failed: step exited with non-zero status: 1
```

Reverting this package upgrade allowed the subsequent staging deploy attempt to succeed. Though we don't use `node` directly, some of the packages we use appear to require a version of `node` that exceeds the version in our docker building flow. 

Since HelperBot automatically handles the merging of these packages based on all CI tests passing, it would be helpful if the CI test could fail if there ever comes a situation where a package requires an incompatible version of `node` so the auto-merge could be halted.

This required two steps:
* Explicitly define a required `node` version in the `package.json` of all three packages (`publisher`, `common`, and `agency-dashboard`)
* Explicitly define a required `node` version in our CI (currently it defaults to 18.19.1 when one is not set) - otherwise, the test will always fail because the packages are requiring the `node` version to be in the 16.x but the CI has `node` version set to 18.19.1 (see error screenshot below)
<img width="1728" alt="Screenshot 2024-02-21 at 11 16 03 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/08c714c8-235a-414c-9556-a1087fae439f">

---

How I tested:
* After setting the node versions in all packages and the CI, I reinstalled the package that failed the staging deploy, and it successfully failed the test in the CI (see screenshot below)
* [You can repro by trying to update the `eslint-plugin-storybook` package in the `common` repo's `package.json` to: `"^0.8.0"` and push up your commit]

<img width="1728" alt="Screenshot 2024-02-26 at 3 36 44 PM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/1eaec70f-c5a2-4abd-a190-3a645f477361">


## Related issues

Closes #1205

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
