### PR TITLE
[Publisher][Admin Panel][Bug] Fix crash when a user has no role set in the Agency Provisioning Team Member & Roles tab

### DIFF
--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -1202,7 +1202,7 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
                                         removeSnakeCase(
                                           teamMemberRoleUpdates[+member.id] ||
                                             ""
-                                        ) || removeSnakeCase(member.role)
+                                        ) || removeSnakeCase(member.role || "")
                                       }
                                       disabled={selectedTeamMembersToDelete.has(
                                         +member.id


### PR DESCRIPTION
## Description of the change

Fix crash when a user has no role set in the Agency Provisioning Team Member & Roles tab by handling the case when `member.role` is `undefined`/`null` and passing in an empty string to `removeSnakeCase`, if so.


https://github.com/Recidiviz/justice-counts/assets/59492998/f793ba4d-af9e-4129-a40c-c177afb3ff46



## Related issues

Closes #1206

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
