### PR TITLE
[Justice Counts] un-gate emails subscription toggle for superagencies

### DIFF
--- a/publisher/src/components/Settings/AgencySettings.tsx
+++ b/publisher/src/components/Settings/AgencySettings.tsx
@@ -83,10 +83,9 @@ export const AgencySettings: React.FC = observer(() => {
       <AgencySettingsContent>
         <AgencySettingsBasicInfo />
         {/* TODO(#26632) Un-gate toggle once functionality for superagencies / child agencies is implemented  */}
-        {agencyStore.currentAgency?.is_superagency !== true &&
-          agencyStore.currentAgency?.super_agency_id === null && (
-            <AgencySettingsEmailNotifications />
-          )}
+        {agencyStore.currentAgency?.super_agency_id === null && (
+          <AgencySettingsEmailNotifications />
+        )}
         <AgencySettingsDescription
           settingProps={generateSettingProps(ActiveSetting.Description)}
         />


### PR DESCRIPTION
## Description of the change

This PR un-gates email subscription toggle for superagencies, now that publisher notification emails are supported for them.

Note: child agencies will not receive any upload notifications, so the toggle will not appear on the agency settings page for child agencies. 

Here's a reminder of what the toggle looks like! I tested locally to confirm that the toggle appeared for a superagency but not a child agency. 

<img width="1728" alt="Screenshot 2024-03-04 at 6 37 04 PM" src="https://github.com/Recidiviz/justice-counts/assets/19961693/beead58e-eb8f-4dd1-805b-44fb35c32f44">

## Related issues

Closes #1222 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
