### PR TITLE
[Publisher][Bug] Fix Help Center routing bug to allow relevant guides to link properly

### DIFF
--- a/publisher/src/components/HelpCenter/HelpCenterGuideLayout.tsx
+++ b/publisher/src/components/HelpCenter/HelpCenterGuideLayout.tsx
@@ -44,9 +44,9 @@ const RelevantGuides: React.FC<{ appKey: AppGuideKey; guideKey: string }> = ({
             : key.split("/")[1];
           const guide =
             helpCenterGuideStructure[appGuideKey].guides[guideKeyBasedOnApp];
-          const pathToGuide = `${
-            isGuideWithinCurrentAppGuide ? `../` : `../../${appGuideKey}/`
-          }${guide.path}`;
+          const pathToGuide = `../${
+            isGuideWithinCurrentAppGuide ? "" : "../"
+          }help/${appGuideKey}/${guide.path}`;
 
           return (
             <Styled.RelevantPageBox


### PR DESCRIPTION
## Description of the change

Fix Help Center `pathToGuide` route string to allow relevant guides to link properly.

Demo (`main` branch -> `mahmoud/bug-help-center-links` branch):

https://github.com/Recidiviz/justice-counts/assets/59492998/ee1ef0a5-248e-46c4-88b0-ad253d6f5b45

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
