### PR TITLE
[Publisher] Improve handling of `/users` PUT errors by displaying a generic error message

### DIFF
--- a/publisher/src/App.tsx
+++ b/publisher/src/App.tsx
@@ -32,6 +32,7 @@ import { GuideLayoutWithBreadcrumbs } from "./components/HelpCenter/HelpCenterGu
 import { HelpCenterInterstitial } from "./components/HelpCenter/HelpCenterInterstitial";
 import { helpCenterRoutes } from "./components/HelpCenter/HelpCenterSetup";
 import { Loading } from "./components/Loading";
+import { LoadingError } from "./components/Loading/LoadingError";
 import { NoAgencies } from "./pages/NoAgencies";
 import { Router } from "./router";
 import { useStore } from "./stores";
@@ -55,6 +56,14 @@ const App: React.FC = (): ReactElement => {
 
   if (DOWN_FOR_MAINTENANCE) {
     return <MaintenancePage />;
+  }
+
+  if (userStore.loadingError) {
+    return (
+      <PageWrapper>
+        <LoadingError />
+      </PageWrapper>
+    );
   }
 
   if (!userStore.userInfoLoaded)

--- a/publisher/src/components/Loading/Loading.styles.tsx
+++ b/publisher/src/components/Loading/Loading.styles.tsx
@@ -1,0 +1,84 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2023 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import {
+  palette,
+  typography,
+} from "@justice-counts/common/components/GlobalStyles";
+import styled from "styled-components/macro";
+
+export const Wrapper = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+`;
+export const Content = styled.div`
+  width: 100%;
+  max-width: 660px;
+  height: 100%;
+  max-height: 400px;
+  display: flex;
+  flex-direction: column;
+  justify-content: start;
+  align-items: start;
+`;
+
+export const LogoBlock = styled.div`
+  height: 60px;
+  width: 175px;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 42px;
+`;
+
+export const Logo = styled.img`
+  width: 60px;
+  height: 60px;
+`;
+
+export const LogoText = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+export const LogoBigText = styled.div`
+  ${typography.sizeCSS.large}
+`;
+
+export const LogoSmallText = styled.div`
+  font-weight: 600;
+  font-size: 9.1px;
+  line-height: 14px;
+`;
+
+export const TitleBlock = styled.div`
+  ${typography.sizeCSS.large};
+  margin-bottom: 24px;
+`;
+
+export const InfoBlock = styled.div`
+  ${typography.sizeCSS.medium};
+`;
+
+export const SupportLink = styled.a`
+  ${palette.solid.blue}
+`;

--- a/publisher/src/components/Loading/LoadingError.tsx
+++ b/publisher/src/components/Loading/LoadingError.tsx
@@ -1,0 +1,48 @@
+// Recidiviz - a data platform for criminal justice reform
+// Copyright (C) 2023 Recidiviz, Inc.
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+// =============================================================================
+
+import React from "react";
+
+import logo from "../assets/jc-logo-green-vector.png";
+import * as Styled from "./Loading.styles";
+
+export const LoadingError = () => {
+  return (
+    <Styled.Wrapper>
+      <Styled.Content>
+        <Styled.LogoBlock>
+          <Styled.Logo src={logo} />
+          <Styled.LogoText>
+            <Styled.LogoBigText>Publisher</Styled.LogoBigText>{" "}
+            <Styled.LogoSmallText>By Justice Counts</Styled.LogoSmallText>
+          </Styled.LogoText>
+        </Styled.LogoBlock>
+        <Styled.TitleBlock>
+          Something went wrong while loading Publisher.
+        </Styled.TitleBlock>
+        <Styled.InfoBlock>
+          Please try refreshing your browser and/or email the Justice Counts
+          team at{" "}
+          <Styled.SupportLink href="mailto:justice-counts-support@csg.org?subject=Account has no agencies">
+            justice-counts-support@csg.org
+          </Styled.SupportLink>{" "}
+          for support.
+        </Styled.InfoBlock>
+      </Styled.Content>
+    </Styled.Wrapper>
+  );
+};

--- a/publisher/src/stores/UserStore.ts
+++ b/publisher/src/stores/UserStore.ts
@@ -37,6 +37,8 @@ class UserStore {
 
   userInfoLoaded: boolean;
 
+  loadingError: boolean;
+
   constructor(authStore: AuthStore, api: API) {
     makeAutoObservable(this, {}, { autoBind: true });
 
@@ -45,6 +47,7 @@ class UserStore {
     this.userAgencies = undefined;
     this.userInfoLoaded = false;
     this.userId = undefined;
+    this.loadingError = false;
 
     when(
       () => api.isSessionInitialized,
@@ -237,12 +240,11 @@ class UserStore {
         this.userId = userId;
       });
     } catch (error) {
+      runInAction(() => {
+        this.loadingError = true;
+      });
       if (error instanceof Error) return error.message;
       return String(error);
-    } finally {
-      runInAction(() => {
-        this.userInfoLoaded = true;
-      });
     }
   }
 

--- a/publisher/src/stores/UserStore.ts
+++ b/publisher/src/stores/UserStore.ts
@@ -238,6 +238,7 @@ class UserStore {
       runInAction(() => {
         this.userAgencies = userAgencies;
         this.userId = userId;
+        this.userInfoLoaded = true;
       });
     } catch (error) {
       runInAction(() => {


### PR DESCRIPTION
## Description of the change

Improve handling of /users PUT errors by displaying a generic error page.

Currently, when the `updateAndRetrieveUserPermissionsAndAgencies` errors (indicating something went wrong with the `/api/users` request), it displays the "No agencies found" page because the `initialAgency` in `App.tsx` ends up being `undefined` as a consequence of the above method erroring. The problem is - this isn't an accurate error page/message for users in this state. 

Instead, we can update the behavior to show a generic error page when `updateAndRetrieveUserPermissionsAndAgencies` errors:

<img width="1728" alt="Screenshot 2024-03-07 at 4 04 24 PM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/2623ae56-6c61-420c-b097-ad984b0003a5">

## Related issues

Closes #1114

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
