### PR TITLE
[Publisher] Metric Settings - Adjust "Starting Month" section to read from `customOrDefaultFrequency` instead of `customFrequency`.

### DIFF
--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -525,7 +525,7 @@ function MetricAvailability({
           </Styled.Setting>
 
           {/* Annual Frequency Starting Month */}
-          {metricEnabled && customFrequency === "ANNUAL" && (
+          {metricEnabled && customOrDefaultFrequency === "ANNUAL" && (
             <Styled.Setting>
               <Styled.SettingName>
                 Starting Month{" "}


### PR DESCRIPTION
## Description of the change

Adjust "Starting Month" rendering conditional to read from `customOrDefaultFrequency` instead of `customFrequency`.

This is a companion to Nichelle's PR [#28018](https://github.com/Recidiviz/recidiviz-data/pull/28018). Prior to this FE PR - despite Nichelle's BE changes sending the correct starting month for the disaggregated supervision subpopulation systems, it looks like the FE is still blocked on rendering the Starting Month section because it's only reading from `customFrequency` (long story short - it looks like on the FE, any manual updates to the frequency gets saved in the store as `customFrequency` - and we've gotten away with this because the supervision subpopulation behavior is the only thing that takes a metric from a `null` state to pre-setting these values - everything else requires user interaction to select a frequency). Now, in this case - when the supervision system is disaggregated into subsystems, the frequency is set as the `defaultFrequency` and this adjustment reads from that as well (if `customFrequency` is not set).

Demo (Nichelle's PR for backend and this PR for FE):

https://github.com/Recidiviz/justice-counts/assets/59492998/ddbc2719-d02f-4128-b554-9ae69b9dd65a

## Type of change

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
