### PR TITLE
[Publisher + Agency Dashboard] Data Charts: Display metric datapoints that match currently set frequency for each metric

### DIFF
--- a/agency-dashboard/src/stores/AgencyDataStore.ts
+++ b/agency-dashboard/src/stores/AgencyDataStore.ts
@@ -131,6 +131,7 @@ class AgencyDataStore {
         disaggregations: {},
       };
       metric.datapoints
+        // Filter out datapoints that do not match the metric's current frequency
         ?.filter((dp) =>
           datapointMatchingMetricFrequency(dp, metricKeyToFrequencyMap)
         )
@@ -151,6 +152,7 @@ class AgencyDataStore {
         result[metric.key].disaggregations[disaggregation.display_name] = {};
         disaggregation.dimensions.forEach((dimension) => {
           dimension.datapoints?.forEach((dp) => {
+            // Filter out breakdown datapoints that do not match the metric's current frequency
             if (!datapointMatchingMetricFrequency(dp, metricKeyToFrequencyMap))
               return;
             if (dp.dimension_display_name) {

--- a/common/components/DataViz/CategoryOverviewBreakdown.tsx
+++ b/common/components/DataViz/CategoryOverviewBreakdown.tsx
@@ -41,8 +41,8 @@ export const CategoryOverviewBreakdown: FunctionComponent<
   const { displayDate } = getDisplayMonthYearBasedOnStartingMonthStr({
     monthStr: month,
     yearStr: year,
+    isMonthlyFrequency: data.frequency === "MONTHLY",
   });
-
   const totalDimensionValues = dimensions.reduce((acc, dim) => {
     if (data[dim]?.value) {
       const sum = acc + Number(data[dim].value);

--- a/common/components/DataViz/CategoryOverviewLineChart.tsx
+++ b/common/components/DataViz/CategoryOverviewLineChart.tsx
@@ -162,11 +162,16 @@ export function CategoryOverviewLineChart({
         onMouseMove={(e) => {
           if (e.activeLabel) {
             const { activeLabel } = e;
+            const metricFrequency = metric.custom_frequency || metric.frequency;
             const [month, year] = activeLabel.split(" ");
-            const startDate = getShortStartDateStrFromDisplayDate({
-              monthStr: month,
-              yearStr: year,
-            });
+            const startDate =
+              metricFrequency === "MONTHLY"
+                ? activeLabel
+                : getShortStartDateStrFromDisplayDate({
+                    monthStr: month,
+                    yearStr: year,
+                  });
+
             setHoveredDate((prev) => ({
               ...prev,
               [metric.key]: convertShortDateToUTCDateString(startDate),
@@ -182,6 +187,7 @@ export function CategoryOverviewLineChart({
             const { displayDate } = getDisplayMonthYearBasedOnStartingMonthStr({
               monthStr: month,
               yearStr: year,
+              isMonthlyFrequency: datapoint.frequency === "MONTHLY",
             });
             return displayDate;
           }}

--- a/common/components/DataViz/types.ts
+++ b/common/components/DataViz/types.ts
@@ -15,7 +15,7 @@
 // along with this program.  If not, see <https://www.gnu.org/licenses/>.
 // =============================================================================
 
-import { Datapoint } from "../../types";
+import { Datapoint, ReportFrequency } from "../../types";
 
 export interface TickProps {
   y: number;
@@ -88,7 +88,9 @@ export type LineChartBreakdownNumericValue = {
 };
 
 export type LineChartBreakdownProps = {
-  data: Record<keyof Datapoint, LineChartBreakdownValue>;
+  data: Record<keyof Datapoint, LineChartBreakdownValue> & {
+    frequency?: ReportFrequency;
+  };
   isFundingOrExpenses: boolean;
   dimensions: string[];
   hoveredDate: string | null;

--- a/common/components/DataViz/utils.ts
+++ b/common/components/DataViz/utils.ts
@@ -742,7 +742,6 @@ export const datapointMatchingMetricFrequency = (
     (dp.metric_definition_key &&
       new Date(dp.start_date).getUTCMonth() + 1 ===
         metricKeyToFrequency[dp.metric_definition_key].starting_month);
-  console.log("dp", dp);
-  console.log("metricKeyToFrequency", metricKeyToFrequency);
+
   return hasMatchingFrequency && hasMatchingStartingMonth;
 };

--- a/common/components/DataViz/utils.ts
+++ b/common/components/DataViz/utils.ts
@@ -742,6 +742,7 @@ export const datapointMatchingMetricFrequency = (
     (dp.metric_definition_key &&
       new Date(dp.start_date).getUTCMonth() + 1 ===
         metricKeyToFrequency[dp.metric_definition_key].starting_month);
-
+  console.log("dp", dp);
+  console.log("metricKeyToFrequency", metricKeyToFrequency);
   return hasMatchingFrequency && hasMatchingStartingMonth;
 };

--- a/common/components/DataViz/utils.ts
+++ b/common/components/DataViz/utils.ts
@@ -25,6 +25,7 @@ import {
   DataVizTimeRangesMap,
   Metric,
   MetricKeyToFrequency,
+  RawDatapoint,
   ReportFrequency,
 } from "../../types";
 import { formatNumberInput, printDateAsShortMonthYear } from "../../utils";
@@ -117,11 +118,20 @@ export const splitUtcString = (utcString: string) => {
 export const getDisplayMonthYearBasedOnStartingMonthStr = ({
   monthStr,
   yearStr,
+  isMonthlyFrequency,
 }: {
   monthStr: string;
   yearStr: string;
-  monthIndex?: number;
+  isMonthlyFrequency?: boolean;
 }) => {
+  if (isMonthlyFrequency) {
+    return {
+      month: monthStr,
+      year: yearStr,
+      displayDate: `${monthStr} ${yearStr}`,
+    };
+  }
+
   const monthIndex = abbreviatedMonths.indexOf(monthStr);
   const prevMonth = abbreviatedMonths[monthIndex - 1];
   const finalMonth = monthStr !== "Jan" ? prevMonth : monthStr;
@@ -720,7 +730,7 @@ export const getMetricKeyToFrequencyMap = (
 };
 
 export const datapointMatchingMetricFrequency = (
-  dp: Datapoint,
+  dp: Datapoint | RawDatapoint,
   metricKeyToFrequency: MetricKeyToFrequency
 ) => {
   // Filter out datapoints that do not match the currently set metric frequency

--- a/common/components/DataViz/utils.ts
+++ b/common/components/DataViz/utils.ts
@@ -717,6 +717,7 @@ export const getDataVizTimeRangeByFilterByMetricFrequency =
     return DataVizTimeRangesMap.All;
   };
 
+/** Given a list of metrics, returns an object of metric keys and their corresponding frequency & starting month  */
 export const getMetricKeyToFrequencyMap = (
   metrics: Metric[]
 ): MetricKeyToFrequency => {
@@ -729,11 +730,22 @@ export const getMetricKeyToFrequencyMap = (
   }, {} as MetricKeyToFrequency);
 };
 
+/**
+ * Used to filter out datapoints that do not match the metric's current frequency
+ * @returns `true` or `false` based on whether the datapoint matches the metric's frequency
+ */
 export const datapointMatchingMetricFrequency = (
   dp: Datapoint | RawDatapoint,
   metricKeyToFrequency: MetricKeyToFrequency
 ) => {
-  // Filter out datapoints that do not match the currently set metric frequency
+  // Filter out old datapoints from sectors that are no longer a part of the agency (small edge-case)
+  if (
+    dp.metric_definition_key &&
+    !metricKeyToFrequency[dp.metric_definition_key]
+  ) {
+    return false;
+  }
+
   const hasMatchingFrequency =
     dp.metric_definition_key &&
     dp.frequency === metricKeyToFrequency[dp.metric_definition_key].frequency;

--- a/common/stores/BaseDatapointsStore.ts
+++ b/common/stores/BaseDatapointsStore.ts
@@ -19,6 +19,7 @@ import {
   DatapointsByMetric,
   DataVizAggregateName,
   DimensionNamesByMetricAndDisaggregation,
+  Metric,
   RawDatapoint,
   RawDatapointsByMetric,
   UnitedRaceEthnicityKeys,
@@ -160,7 +161,10 @@ abstract class DatapointsStore {
     }, {});
   };
 
-  abstract getDatapoints(agencyId: number): Promise<void | Error>;
+  abstract getDatapoints(
+    agencyId: number,
+    agencyMetrics?: Metric[]
+  ): Promise<void | Error>;
 
   resetState() {
     runInAction(() => {

--- a/common/types.ts
+++ b/common/types.ts
@@ -107,6 +107,10 @@ export type ReportFrequency = "MONTHLY" | "ANNUAL";
 
 export type ReportStatus = "NOT_STARTED" | "DRAFT" | "PUBLISHED";
 
+export type MetricKeyToFrequency = {
+  [key: string]: { frequency?: ReportFrequency; starting_month?: number };
+};
+
 export interface ReportEditor {
   name: string;
   role: AgencyTeamMemberRole;

--- a/publisher/src/components/DataViz/ConnectedDatapointsView.tsx
+++ b/publisher/src/components/DataViz/ConnectedDatapointsView.tsx
@@ -70,6 +70,7 @@ const ConnectedDatapointsView = forwardRef<never, ConnectedDatapointsViewProps>(
       datapointsStore.dimensionNamesByMetricAndDisaggregation[metric];
 
     if (
+      dimensionNamesByDisaggregation &&
       Object.keys(
         datapointsStore.dimensionNamesByMetricAndDisaggregation[metric]
       ).includes("Race / Ethnicity")

--- a/publisher/src/components/DataViz/MetricsDataChart.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.tsx
@@ -165,7 +165,13 @@ export const MetricsDataChart: React.FC = observer(() => {
        * Wait for `initializeReportSettings` so we can look up each metric frequency
        * to filter out datapoints w/ frequencies that do not match the currently set frequency
        */
-      await datapointsStore.getDatapoints(Number(agencyId));
+      const fetchedAgencyMetrics = Object.values(result).flatMap(
+        (metric) => metric
+      );
+      await datapointsStore.getDatapoints(
+        Number(agencyId),
+        fetchedAgencyMetrics
+      );
       setIsLoading(false);
     };
 

--- a/publisher/src/components/DataViz/MetricsDataChart.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.tsx
@@ -156,12 +156,16 @@ export const MetricsDataChart: React.FC = observer(() => {
     const initialize = async () => {
       setIsLoading(true);
       datapointsStore.resetState();
-      await datapointsStore.getDatapoints(Number(agencyId));
       const result = await reportStore.initializeReportSettings(agencyId);
       if (result instanceof Error) {
         setIsLoading(false);
         return setLoadingError(result.message);
       }
+      /**
+       * Wait for `initializeReportSettings` so we can look up each metric frequency
+       * to filter out datapoints w/ frequencies that do not match the currently set frequency
+       */
+      await datapointsStore.getDatapoints(Number(agencyId));
       setIsLoading(false);
     };
 

--- a/publisher/src/stores/DatapointsStore.ts
+++ b/publisher/src/stores/DatapointsStore.ts
@@ -20,7 +20,7 @@ import {
   getMetricKeyToFrequencyMap,
 } from "@justice-counts/common/components/DataViz/utils";
 import BaseDatapointsStore from "@justice-counts/common/stores/BaseDatapointsStore";
-import { Datapoint } from "@justice-counts/common/types";
+import { Datapoint, Metric } from "@justice-counts/common/types";
 import {
   IReactionDisposer,
   makeObservable,
@@ -65,7 +65,10 @@ class DatapointsStore extends BaseDatapointsStore {
     this.disposers.forEach((disposer) => disposer());
   };
 
-  async getDatapoints(agencyId: number): Promise<void | Error> {
+  async getDatapoints(
+    agencyId: number,
+    agencyMetrics: Metric[]
+  ): Promise<void | Error> {
     this.loading = true;
     try {
       const response = (await this.api.request({

--- a/publisher/src/stores/DatapointsStore.ts
+++ b/publisher/src/stores/DatapointsStore.ts
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import BaseDatapointsStore from "@justice-counts/common/stores/BaseDatapointsStore";
-import { ReportFrequency } from "@justice-counts/common/types";
+import { Datapoint, ReportFrequency } from "@justice-counts/common/types";
 import {
   IReactionDisposer,
   makeObservable,
@@ -86,16 +86,18 @@ class DatapointsStore extends BaseDatapointsStore {
       if (response.status === 200) {
         const result = await response.json();
         runInAction(() => {
-          this.rawDatapoints = result.datapoints.filter((dp: any) => {
+          this.rawDatapoints = result.datapoints.filter((dp: Datapoint) => {
             const hasMatchingFrequency =
+              dp.metric_definition_key &&
               dp.frequency ===
-              this.metricKeyToFrequency[dp.metric_definition_key].frequency;
+                this.metricKeyToFrequency[dp.metric_definition_key].frequency;
             const hasMatchingStartingMonth =
               (hasMatchingFrequency && dp.frequency === "MONTHLY") ||
-              new Date(dp.start_date).getUTCMonth() + 1 ===
-                this.metricKeyToFrequency[dp.metric_definition_key]
-                  .starting_month;
-            console.log(hasMatchingFrequency && hasMatchingStartingMonth);
+              (dp.metric_definition_key &&
+                new Date(dp.start_date).getUTCMonth() + 1 ===
+                  this.metricKeyToFrequency[dp.metric_definition_key]
+                    .starting_month);
+
             return hasMatchingFrequency && hasMatchingStartingMonth;
           });
           this.dimensionNamesByMetricAndDisaggregation =

--- a/publisher/src/stores/DatapointsStore.ts
+++ b/publisher/src/stores/DatapointsStore.ts
@@ -61,21 +61,6 @@ class DatapointsStore extends BaseDatapointsStore {
     this.disposers.forEach((disposer) => disposer());
   };
 
-  get metricKeyToFrequency() {
-    return this.reportStore.agencyMetrics.reduce(
-      (acc, metric) => {
-        acc[metric.key] = {
-          frequency: metric.custom_frequency || metric.frequency,
-          starting_month: metric.starting_month,
-        };
-        return acc;
-      },
-      {} as {
-        [key: string]: { frequency?: ReportFrequency; starting_month?: number };
-      }
-    );
-  }
-
   async getDatapoints(agencyId: number): Promise<void | Error> {
     this.loading = true;
     try {
@@ -90,13 +75,15 @@ class DatapointsStore extends BaseDatapointsStore {
             const hasMatchingFrequency =
               dp.metric_definition_key &&
               dp.frequency ===
-                this.metricKeyToFrequency[dp.metric_definition_key].frequency;
+                this.reportStore.metricKeyToFrequency[dp.metric_definition_key]
+                  .frequency;
             const hasMatchingStartingMonth =
               (hasMatchingFrequency && dp.frequency === "MONTHLY") ||
               (dp.metric_definition_key &&
                 new Date(dp.start_date).getUTCMonth() + 1 ===
-                  this.metricKeyToFrequency[dp.metric_definition_key]
-                    .starting_month);
+                  this.reportStore.metricKeyToFrequency[
+                    dp.metric_definition_key
+                  ].starting_month);
 
             return hasMatchingFrequency && hasMatchingStartingMonth;
           });

--- a/publisher/src/stores/DatapointsStore.ts
+++ b/publisher/src/stores/DatapointsStore.ts
@@ -78,14 +78,9 @@ class DatapointsStore extends BaseDatapointsStore {
           const metricKeyToFrequency = getMetricKeyToFrequencyMap(
             this.reportStore.agencyMetrics
           );
-          this.rawDatapoints = result.datapoints.filter((dp: Datapoint) => {
-            if (
-              dp.metric_definition_key &&
-              !metricKeyToFrequency[dp.metric_definition_key]
-            )
-              return false; // Filters out datapoints that are a system
-            return datapointMatchingMetricFrequency(dp, metricKeyToFrequency);
-          });
+          this.rawDatapoints = result.datapoints.filter((dp: Datapoint) =>
+            datapointMatchingMetricFrequency(dp, metricKeyToFrequency)
+          );
           this.dimensionNamesByMetricAndDisaggregation =
             result.dimension_names_by_metric_and_disaggregation;
         });

--- a/publisher/src/stores/DatapointsStore.ts
+++ b/publisher/src/stores/DatapointsStore.ts
@@ -16,7 +16,7 @@
 // =============================================================================
 
 import BaseDatapointsStore from "@justice-counts/common/stores/BaseDatapointsStore";
-import { Datapoint, ReportFrequency } from "@justice-counts/common/types";
+import { Datapoint } from "@justice-counts/common/types";
 import {
   IReactionDisposer,
   makeObservable,
@@ -72,13 +72,14 @@ class DatapointsStore extends BaseDatapointsStore {
         const result = await response.json();
         runInAction(() => {
           this.rawDatapoints = result.datapoints.filter((dp: Datapoint) => {
+            // Filter out datapoints that do not match the currently set metric frequency
             const hasMatchingFrequency =
               dp.metric_definition_key &&
               dp.frequency ===
                 this.reportStore.metricKeyToFrequency[dp.metric_definition_key]
                   .frequency;
             const hasMatchingStartingMonth =
-              (hasMatchingFrequency && dp.frequency === "MONTHLY") ||
+              (hasMatchingFrequency && dp.frequency === "MONTHLY") || // If the frequency is "MONTHLY", there is no starting month - so we can consider this a match
               (dp.metric_definition_key &&
                 new Date(dp.start_date).getUTCMonth() + 1 ===
                   this.reportStore.metricKeyToFrequency[

--- a/publisher/src/stores/DatapointsStore.ts
+++ b/publisher/src/stores/DatapointsStore.ts
@@ -78,9 +78,14 @@ class DatapointsStore extends BaseDatapointsStore {
           const metricKeyToFrequency = getMetricKeyToFrequencyMap(
             this.reportStore.agencyMetrics
           );
-          this.rawDatapoints = result.datapoints.filter((dp: Datapoint) =>
-            datapointMatchingMetricFrequency(dp, metricKeyToFrequency)
-          );
+          this.rawDatapoints = result.datapoints.filter((dp: Datapoint) => {
+            if (
+              dp.metric_definition_key &&
+              !metricKeyToFrequency[dp.metric_definition_key]
+            )
+              return false; // Filters out datapoints that are a system
+            return datapointMatchingMetricFrequency(dp, metricKeyToFrequency);
+          });
           this.dimensionNamesByMetricAndDisaggregation =
             result.dimension_names_by_metric_and_disaggregation;
         });

--- a/publisher/src/stores/ReportStore.ts
+++ b/publisher/src/stores/ReportStore.ts
@@ -106,16 +106,6 @@ class ReportStore {
     return Object.values(this.metricsBySystem).flatMap((metric) => metric);
   }
 
-  get metricKeyToFrequency(): MetricKeyToFrequency {
-    return this.agencyMetrics.reduce((acc, metric) => {
-      acc[metric.key] = {
-        frequency: metric.custom_frequency || metric.frequency,
-        starting_month: metric.starting_month,
-      };
-      return acc;
-    }, {} as MetricKeyToFrequency);
-  }
-
   storeMetricDetails(
     reportID: number,
     metrics: Metric[],

--- a/publisher/src/stores/ReportStore.ts
+++ b/publisher/src/stores/ReportStore.ts
@@ -18,7 +18,9 @@
 import {
   AgencySystem,
   Metric,
+  MetricKeyToFrequency,
   Report,
+  ReportFrequency,
   ReportOverview,
   ReportStatus,
   UpdatedMetricsValues,
@@ -103,6 +105,16 @@ class ReportStore {
 
   get agencyMetrics(): Metric[] {
     return Object.values(this.metricsBySystem).flatMap((metric) => metric);
+  }
+
+  get metricKeyToFrequency(): MetricKeyToFrequency {
+    return this.agencyMetrics.reduce((acc, metric) => {
+      acc[metric.key] = {
+        frequency: metric.custom_frequency || metric.frequency,
+        starting_month: metric.starting_month,
+      };
+      return acc;
+    }, {} as MetricKeyToFrequency);
   }
 
   storeMetricDetails(

--- a/publisher/src/stores/ReportStore.ts
+++ b/publisher/src/stores/ReportStore.ts
@@ -20,7 +20,6 @@ import {
   Metric,
   MetricKeyToFrequency,
   Report,
-  ReportFrequency,
   ReportOverview,
   ReportStatus,
   UpdatedMetricsValues,

--- a/publisher/src/stores/ReportStore.ts
+++ b/publisher/src/stores/ReportStore.ts
@@ -18,7 +18,6 @@
 import {
   AgencySystem,
   Metric,
-  MetricKeyToFrequency,
   Report,
   ReportOverview,
   ReportStatus,

--- a/publisher/src/stores/RootStore.ts
+++ b/publisher/src/stores/RootStore.ts
@@ -72,7 +72,11 @@ class RootStore {
     this.userStore = new UserStore(this.authStore, this.api);
     this.reportStore = new ReportStore(this.userStore, this.api);
     this.formStore = new FormStore(this.reportStore);
-    this.datapointsStore = new DatapointsStore(this.userStore, this.api);
+    this.datapointsStore = new DatapointsStore(
+      this.userStore,
+      this.api,
+      this.reportStore
+    );
     this.dataVizStore = new DataVizStore();
     this.metricConfigStore = new MetricConfigStore(this.userStore, this.api);
     this.agencyStore = new AgencyStore(this.userStore, this.api);


### PR DESCRIPTION
## Description of the change

Display metric datapoints that match currently set frequency for each metric in the data charts in both Publisher & Agency Dashboard.

Play with it here (would love a quick sanity check if folks have bandwidth): 
- Publisher: https://mahmoudtest---publisher-web-b47yvyxs3q-uc.a.run.app/
- Agency Dashboard: https://mahmoudtest---agency-dashboard-web-b47yvyxs3q-uc.a.run.app/

Quick visuals -

Publisher:

https://github.com/Recidiviz/justice-counts/assets/59492998/333b954a-8ff5-4786-ad6e-2737c4f1a7b2

Agency Dashboard:

https://github.com/Recidiviz/justice-counts/assets/59492998/a1330d21-940d-4471-a7f4-8f5225372f88




## Related issues

Closes #1202 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
