### PR TITLE
[Publisher] Agency Settings: Adds offset date picker for email notifications

### DIFF
--- a/publisher/src/components/Settings/AgencySettings.styles.tsx
+++ b/publisher/src/components/Settings/AgencySettings.styles.tsx
@@ -593,7 +593,13 @@ export const AddIcon = styled.img`
 `;
 
 export const DescriptionSection = styled.div`
-  margin-top: 24px;
+  &:not(:first-child) {
+    margin-top: 24px;
+  }
+
+  ul {
+    margin-left: 24px;
+  }
 `;
 
 export const InputWrapper = styled.span<{ error?: boolean }>`

--- a/publisher/src/components/Settings/AgencySettings.styles.tsx
+++ b/publisher/src/components/Settings/AgencySettings.styles.tsx
@@ -591,3 +591,24 @@ export const AddIcon = styled.img`
   width: 16px;
   margin-right: 0;
 `;
+
+export const DescriptionSection = styled.div`
+  margin-top: 24px;
+`;
+
+export const InputWrapper = styled.span<{ error?: boolean }>`
+  input {
+    width: 59px;
+    padding: 8px 0;
+    text-align: center;
+    border: 1px solid
+      ${({ error }) => (error ? palette.solid.red : palette.highlight.grey4)};
+    border-radius: 2px;
+  }
+`;
+
+export const ErrorMessage = styled.div`
+  ${typography.sizeCSS.small}
+  color: ${palette.solid.red};
+  margin-top: 8px;
+`;

--- a/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
+++ b/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
@@ -17,20 +17,33 @@
 
 import { ToggleSwitch } from "@justice-counts/common/components/ToggleSwitch";
 import { observer } from "mobx-react-lite";
-import React from "react";
+import React, { useState } from "react";
 
 import { useStore } from "../../stores";
 import {
   AgencySettingsBlock,
   AgencySettingsBlockDescription,
   AgencySettingsBlockTitle,
+  DescriptionSection,
   EditButtonContainer,
+  ErrorMessage,
+  InputWrapper,
 } from "./AgencySettings.styles";
 
 export const AgencySettingsEmailNotifications: React.FC = observer(() => {
   const { agencyStore } = useStore();
   const { updateIsUserSubscribedToEmails, isUserSubscribedToEmails } =
     agencyStore;
+
+  const [reminderEmailOffsetDays, setReminderEmailOffsetDays] = useState("1");
+
+  const offsetDate = new Date();
+  offsetDate.setDate(offsetDate.getDate() + Number(reminderEmailOffsetDays));
+
+  const inputError =
+    Number.isNaN(Number(reminderEmailOffsetDays)) ||
+    Number(reminderEmailOffsetDays) <= 0 ||
+    Number(reminderEmailOffsetDays) > 1000;
 
   const handleSubscribeUnsubscribe = () => {
     updateIsUserSubscribedToEmails(!isUserSubscribedToEmails);
@@ -56,10 +69,30 @@ export const AgencySettingsEmailNotifications: React.FC = observer(() => {
         agency.
         <br />
         <br />
-        Emails from Justice Counts include 1) an email on the 15th of each month
-        listing the metrics you have enabled which still need data uploaded and
-        2) confirmation emails that your Automated Bulk Upload attempts were
-        processed by Publisher.
+        Emails from Justice Counts will include a list of the metrics you have
+        enabled which still need data uploaded and confirmation emails that your
+        Automated Bulk Upload attempts were processed by Publisher.
+        <DescriptionSection>
+          Schedule metric upload reminder emails{" "}
+          <InputWrapper error={Boolean(inputError)}>
+            <input
+              type="text"
+              value={reminderEmailOffsetDays}
+              onChange={(e) => setReminderEmailOffsetDays(e.target.value)}
+            />
+          </InputWrapper>{" "}
+          days after the end of the most recent reporting period.
+        </DescriptionSection>
+        {inputError && (
+          <ErrorMessage>Please enter a number between 1-1000</ErrorMessage>
+        )}
+        {!inputError && (
+          <DescriptionSection>
+            Your next email is scheduled to send on{" "}
+            {offsetDate.toLocaleDateString("en-US")}.
+          </DescriptionSection>
+        )}
+        {}
       </AgencySettingsBlockDescription>
     </AgencySettingsBlock>
   );

--- a/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
+++ b/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
@@ -45,7 +45,8 @@ export const AgencySettingsEmailNotifications: React.FC = observer(() => {
   const currentOffsetDays =
     reminderEmailOffsetDays || daysAfterTimePeriodToSendEmail || "";
   const offsetDate = new Date();
-  offsetDate.setDate(offsetDate.getDate() + Number(currentOffsetDays));
+  offsetDate.setDate(0); // Set to end of previous month (end of previous reporting period)
+  offsetDate.setDate(offsetDate.getDate() + Number(currentOffsetDays)); // Set offset days
 
   const isValidInput = (value: string | number | null) =>
     Number(value) > 0 && Number(value) <= 1000;
@@ -80,35 +81,47 @@ export const AgencySettingsEmailNotifications: React.FC = observer(() => {
         </EditButtonContainer>
       </AgencySettingsBlockTitle>
       <AgencySettingsBlockDescription>
-        This toggle will only affect your email settings for{" "}
-        {agencyStore.currentAgency?.name ??
-          "the agency you are currently viewing"}
-        . When you unsubscribe you will no longer receive any emails for this
-        agency.
-        <br />
-        <br />
-        Emails from Justice Counts will include a list of the metrics you have
-        enabled which still need data uploaded and confirmation emails that your
-        Automated Bulk Upload attempts were processed by Publisher.
+        <DescriptionSection>
+          This toggle affects your email settings for{" "}
+          {agencyStore.currentAgency?.name ??
+            "the agency you are currently viewing"}
+          . If you subscribe, you will receive the following emails:
+          <ul>
+            <li>Reminders to upload data to Publisher each month</li>
+            <li>
+              Confirmations that Automated Bulk Upload attempts were processed
+              by Publisher
+            </li>
+          </ul>
+        </DescriptionSection>
+
         {isUserSubscribedToEmails && (
-          <DescriptionSection>
-            Schedule metric upload reminder emails{" "}
-            <InputWrapper error={!isValidInput(currentOffsetDays)}>
-              <input
-                type="text"
-                value={currentOffsetDays}
-                onChange={(e) => {
-                  const currentValueOrDefault = e.target.value || "15";
-                  setReminderEmailOffsetDays(currentValueOrDefault);
-                  debouncedSaveOffsetDays(
-                    currentValueOrDefault,
-                    !isValidInput(currentValueOrDefault)
-                  );
-                }}
-              />
-            </InputWrapper>{" "}
-            days after the end of the most recent reporting period.
-          </DescriptionSection>
+          <>
+            <DescriptionSection>
+              Below, you can choose how soon after the end of each reporting
+              period to receive an upload data reminder email. For instance, if
+              you enter 15, you would receive a reminder to upload any missing
+              data for the month of March on April 15th.
+            </DescriptionSection>
+            <DescriptionSection>
+              Enter the number of days after the end of the reporting period to
+              receive a reminder email:
+              <InputWrapper error={!isValidInput(currentOffsetDays)}>
+                <input
+                  type="text"
+                  value={currentOffsetDays}
+                  onChange={(e) => {
+                    const currentValueOrDefault = e.target.value || "15";
+                    setReminderEmailOffsetDays(currentValueOrDefault);
+                    debouncedSaveOffsetDays(
+                      currentValueOrDefault,
+                      !isValidInput(currentValueOrDefault)
+                    );
+                  }}
+                />
+              </InputWrapper>
+            </DescriptionSection>
+          </>
         )}
         {isUserSubscribedToEmails && !isValidInput(currentOffsetDays) && (
           <ErrorMessage>Please enter a number between 1-1000</ErrorMessage>

--- a/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
+++ b/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
@@ -54,7 +54,7 @@ export const AgencySettingsEmailNotifications: React.FC = observer(() => {
   const handleSubscribeUnsubscribe = () => {
     updateEmailSubscriptionDetails(
       !isUserSubscribedToEmails,
-      Number(currentOffsetDays)
+      Number(currentOffsetDays) || 15
     );
   };
 

--- a/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
+++ b/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
@@ -43,10 +43,9 @@ export const AgencySettingsEmailNotifications: React.FC = observer(() => {
     useState<string>();
 
   const currentOffsetDays =
-    reminderEmailOffsetDays || daysAfterTimePeriodToSendEmail || "";
-  const offsetDate = new Date();
-  offsetDate.setDate(0); // Set to end of previous month (end of previous reporting period)
-  offsetDate.setDate(offsetDate.getDate() + Number(currentOffsetDays)); // Set offset days
+    reminderEmailOffsetDays === ""
+      ? ""
+      : reminderEmailOffsetDays || daysAfterTimePeriodToSendEmail;
 
   const isValidInput = (value: string | number | null) =>
     Number(value) > 0 && Number(value) <= 1000;
@@ -54,7 +53,7 @@ export const AgencySettingsEmailNotifications: React.FC = observer(() => {
   const handleSubscribeUnsubscribe = () => {
     updateEmailSubscriptionDetails(
       !isUserSubscribedToEmails,
-      Number(currentOffsetDays) || 15
+      Number(currentOffsetDays)
     );
   };
 
@@ -109,9 +108,9 @@ export const AgencySettingsEmailNotifications: React.FC = observer(() => {
               <InputWrapper error={!isValidInput(currentOffsetDays)}>
                 <input
                   type="text"
-                  value={currentOffsetDays}
+                  value={currentOffsetDays || ""}
                   onChange={(e) => {
-                    const currentValueOrDefault = e.target.value || "15";
+                    const currentValueOrDefault = e.target.value;
                     setReminderEmailOffsetDays(currentValueOrDefault);
                     debouncedSaveOffsetDays(
                       currentValueOrDefault,

--- a/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
+++ b/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
@@ -47,8 +47,8 @@ export const AgencySettingsEmailNotifications: React.FC = observer(() => {
   const offsetDate = new Date();
   offsetDate.setDate(offsetDate.getDate() + Number(currentOffsetDays));
 
-  const isInvalidInput = (value: string | number | null) =>
-    Number.isNaN(Number(value)) || Number(value) <= 0 || Number(value) > 1000;
+  const isValidInput = (value: string | number | null) =>
+    Number(value) > 0 && Number(value) <= 1000;
 
   const handleSubscribeUnsubscribe = () => {
     updateEmailSubscriptionDetails(
@@ -58,6 +58,7 @@ export const AgencySettingsEmailNotifications: React.FC = observer(() => {
   };
 
   const saveOffsetDays = (offsetDays: string, inputError: boolean) => {
+    console.log("inputError", inputError);
     if (!inputError) {
       updateEmailSubscriptionDetails(true, Number(offsetDays));
     }
@@ -93,7 +94,7 @@ export const AgencySettingsEmailNotifications: React.FC = observer(() => {
         {isUserSubscribedToEmails && (
           <DescriptionSection>
             Schedule metric upload reminder emails{" "}
-            <InputWrapper error={Boolean(isInvalidInput(currentOffsetDays))}>
+            <InputWrapper error={!isValidInput(currentOffsetDays)}>
               <input
                 type="text"
                 value={currentOffsetDays}
@@ -102,7 +103,7 @@ export const AgencySettingsEmailNotifications: React.FC = observer(() => {
                   setReminderEmailOffsetDays(currentValueOrDefault);
                   debouncedSaveOffsetDays(
                     currentValueOrDefault,
-                    isInvalidInput(currentValueOrDefault)
+                    !isValidInput(currentValueOrDefault)
                   );
                 }}
               />
@@ -110,10 +111,10 @@ export const AgencySettingsEmailNotifications: React.FC = observer(() => {
             days after the end of the most recent reporting period.
           </DescriptionSection>
         )}
-        {isUserSubscribedToEmails && isInvalidInput(currentOffsetDays) && (
+        {isUserSubscribedToEmails && !isValidInput(currentOffsetDays) && (
           <ErrorMessage>Please enter a number between 1-1000</ErrorMessage>
         )}
-        {isUserSubscribedToEmails && !isInvalidInput(currentOffsetDays) && (
+        {isUserSubscribedToEmails && isValidInput(currentOffsetDays) && (
           <DescriptionSection>
             Your next email is scheduled to send on{" "}
             {offsetDate.toLocaleDateString("en-US")}.

--- a/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
+++ b/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
@@ -126,13 +126,6 @@ export const AgencySettingsEmailNotifications: React.FC = observer(() => {
         {isUserSubscribedToEmails && !isValidInput(currentOffsetDays) && (
           <ErrorMessage>Please enter a number between 1-1000</ErrorMessage>
         )}
-        {isUserSubscribedToEmails && isValidInput(currentOffsetDays) && (
-          <DescriptionSection>
-            Your next email is scheduled to send on{" "}
-            {offsetDate.toLocaleDateString("en-US")}.
-          </DescriptionSection>
-        )}
-        {}
       </AgencySettingsBlockDescription>
     </AgencySettingsBlock>
   );

--- a/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
+++ b/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
@@ -110,11 +110,10 @@ export const AgencySettingsEmailNotifications: React.FC = observer(() => {
                   type="text"
                   value={currentOffsetDays || ""}
                   onChange={(e) => {
-                    const currentValueOrDefault = e.target.value;
-                    setReminderEmailOffsetDays(currentValueOrDefault);
+                    setReminderEmailOffsetDays(e.target.value);
                     debouncedSaveOffsetDays(
-                      currentValueOrDefault,
-                      !isValidInput(currentValueOrDefault)
+                      e.target.value,
+                      !isValidInput(e.target.value)
                     );
                   }}
                 />

--- a/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
+++ b/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
@@ -58,7 +58,6 @@ export const AgencySettingsEmailNotifications: React.FC = observer(() => {
   };
 
   const saveOffsetDays = (offsetDays: string, inputError: boolean) => {
-    console.log("inputError", inputError);
     if (!inputError) {
       updateEmailSubscriptionDetails(true, Number(offsetDays));
     }

--- a/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
+++ b/publisher/src/components/Settings/AgencySettingsEmailNotifications.tsx
@@ -16,6 +16,7 @@
 // =============================================================================
 
 import { ToggleSwitch } from "@justice-counts/common/components/ToggleSwitch";
+import { debounce } from "lodash";
 import { observer } from "mobx-react-lite";
 import React, { useRef, useState } from "react";
 
@@ -29,7 +30,6 @@ import {
   ErrorMessage,
   InputWrapper,
 } from "./AgencySettings.styles";
-import { debounce } from "lodash";
 
 export const AgencySettingsEmailNotifications: React.FC = observer(() => {
   const { agencyStore } = useStore();

--- a/publisher/src/stores/AgencyStore.ts
+++ b/publisher/src/stores/AgencyStore.ts
@@ -266,7 +266,7 @@ class AgencyStore {
 
   updateEmailSubscriptionDetails = async (
     isUserSubscribedToEmails: boolean,
-    daysAfterTimePeriodToSendEmail: number
+    daysAfterTimePeriodToSendEmail: number | null
   ): Promise<void> => {
     const response = (await this.api.request({
       path: `/api/agency/${this.currentAgencyId}/subscription/${this.userStore.userId}`,

--- a/publisher/src/stores/AgencyStore.ts
+++ b/publisher/src/stores/AgencyStore.ts
@@ -48,6 +48,8 @@ class AgencyStore {
 
   isUserSubscribedToEmails: boolean;
 
+  daysAfterTimePeriodToSendEmail: number | null;
+
   constructor(userStore: UserStore, api: API) {
     makeAutoObservable(this);
 
@@ -57,6 +59,7 @@ class AgencyStore {
     this.jurisdictions = { included: [], excluded: [] };
     this.loadingSettings = true;
     this.isUserSubscribedToEmails = false;
+    this.daysAfterTimePeriodToSendEmail = null;
   }
 
   get currentAgency(): UserAgency | undefined {
@@ -116,12 +119,15 @@ class AgencyStore {
           excluded: string[];
         };
         is_subscribed_to_emails: boolean;
+        days_after_time_period_to_send_email: number;
       };
       runInAction(() => {
         if (this.currentAgency) {
           this.currentAgency.settings = responseJson.settings;
           this.jurisdictions = responseJson.jurisdictions;
           this.isUserSubscribedToEmails = responseJson.is_subscribed_to_emails;
+          this.daysAfterTimePeriodToSendEmail =
+            responseJson.days_after_time_period_to_send_email;
         }
       });
     } catch (error) {
@@ -258,12 +264,16 @@ class AgencyStore {
     return { jurisdictions };
   };
 
-  updateIsUserSubscribedToEmails = async (
-    isUserSubscribedToEmails: boolean
+  updateEmailSubscriptionDetails = async (
+    isUserSubscribedToEmails: boolean,
+    daysAfterTimePeriodToSendEmail: number
   ): Promise<void> => {
     const response = (await this.api.request({
       path: `/api/agency/${this.currentAgencyId}/subscription/${this.userStore.userId}`,
-      body: { is_subscribed: isUserSubscribedToEmails },
+      body: {
+        is_subscribed: isUserSubscribedToEmails,
+        days_after_time_period_to_send_email: daysAfterTimePeriodToSendEmail,
+      },
       method: "PUT",
     })) as Response;
     if (response.status !== 200) {
@@ -277,6 +287,7 @@ class AgencyStore {
 
     runInAction(() => {
       this.isUserSubscribedToEmails = isUserSubscribedToEmails;
+      this.daysAfterTimePeriodToSendEmail = daysAfterTimePeriodToSendEmail;
     });
     showToast({
       message: `Email settings updated`,


### PR DESCRIPTION
## Description of the change

Implements the frontend for the e-mail notification offset date picker by adding an input with copy that displays the offset date.

I included an error state for when the user input is out of bounds and cleaned up the copy before the date picker a little bit. This was done consistent with the current design and not in the style of the upcoming Agency Settings design update so things don't look super off.

https://github.com/Recidiviz/justice-counts/assets/59492998/1e21cba3-492a-4b0b-9048-a4c79047b68c


## Related issues

Closes [#27978](https://github.com/Recidiviz/recidiviz-data/pull/27978)

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
