### PR TITLE
[Publisher] Metric Settings: Moves "Disaggregated by Supervision Type" tooltip copy to description body of "Metric Disaggregation"

### DIFF
--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -322,24 +322,21 @@ function MetricAvailability({
           <Styled.SettingsContainer>
             <Styled.Header>Metric Disaggregation</Styled.Header>
             <Styled.Description>
-              Disaggregate your metrics by sector
+              <p>Disaggregate your metrics by sector</p>
+              <p>
+                For Supervision metrics, you can choose to share the data for
+                your supervision operations as a whole, or disaggregated by your
+                supervision populations (parole, probation, dual, etc).
+              </p>
             </Styled.Description>
+
             {systemSearchParam &&
               hasSupervisionSubsystems &&
               (systemSearchParam === SupervisionSystem ||
                 SupervisionSubsystems.includes(systemSearchParam)) && (
                 <Styled.Setting>
                   <Styled.SettingName>
-                    Disaggregated by Supervision Type{" "}
-                    <Styled.InfoIconWrapper>
-                      <img src={infoIcon} alt="" width="12px" />
-                      <Styled.SettingTooltip>
-                        For Supervision metrics, you can choose to share the
-                        data for your supervision operations as a whole, or
-                        disaggregated by your supervision populations (parole,
-                        probation, dual, etc).
-                      </Styled.SettingTooltip>
-                    </Styled.InfoIconWrapper>
+                    Disaggregated by Supervision Type
                   </Styled.SettingName>
                   <RadioButtonsWrapper disabled={isReadOnly}>
                     <RadioButton


### PR DESCRIPTION
## Description of the change

Moves "Disaggregated by Supervision Type" tooltip copy to description body of "Metric Disaggregation" for clarity as suggested by Matt from CSG. 

<img width="1728" alt="Screenshot 2024-03-18 at 11 09 57 AM" src="https://github.com/Recidiviz/justice-counts/assets/59492998/54fd1e2d-f258-47af-a426-9a6672adf624">

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
