### PR TITLE
[Justice Counts] Update dashboard URLs to have agencyID 

### DIFF
--- a/agency-dashboard/src/App.tsx
+++ b/agency-dashboard/src/App.tsx
@@ -29,7 +29,7 @@ function App() {
     <Routes>
       <Route path="/" element={<Home />} />
       <Route
-        path="/agency/:slug"
+        path="/agency/:agencyId/:slug"
         element={
           <Protected>
             <AgencyOverview />
@@ -37,7 +37,7 @@ function App() {
         }
       />
       <Route
-        path="/agency/:slug/:category"
+        path="/agency/:agencyId/:slug/:category"
         element={
           <Protected>
             <CategoryOverview />

--- a/agency-dashboard/src/Home/Home.tsx
+++ b/agency-dashboard/src/Home/Home.tsx
@@ -66,7 +66,9 @@ export const Home = observer(() => {
         {agenciesMetadataSortedByName.map((agency) => (
           <Styled.AgencyDetailsWrapper
             key={agency.id}
-            onClick={() => navigate(`/agency/${encodeURI(agency.name)}`)}
+            onClick={() =>
+              navigate(`/agency/${agency.id}/${encodeURI(agency.name)}`)
+            }
           >
             <Styled.AgencyName>{agency.name}</Styled.AgencyName>
             <Styled.NumberOfPublishedMetrics>

--- a/agency-dashboard/src/Protected/Protected.tsx
+++ b/agency-dashboard/src/Protected/Protected.tsx
@@ -30,27 +30,39 @@ export const Protected: React.FC<PropsWithChildren> = observer(
   ({ children }) => {
     const navigate = useNavigate();
     const { agencyDataStore, api } = useStore();
-    const { slug } = useParams();
+    const { agencyId, slug } = useParams();
     const isProductionEnv = api.environment === environment.PRODUCTION;
     const isDenied =
-      agencyDataStore.agency &&
-      agencyDataStore.agency.is_dashboard_enabled !== true;
-
+      (agencyDataStore.agency &&
+        agencyDataStore.agency.is_dashboard_enabled !== true) ||
+      !agencyId;
     const [loading, setLoading] = useState(true);
 
     useAsyncEffect(async () => {
       try {
-        await agencyDataStore.fetchAgencyData(slug as string);
-        setLoading(false);
+        if (!agencyId) {
+          setLoading(false);
+          showToast({
+            message: `No agency ID was specified in the URL path.`,
+            color: "red",
+            timeout: 4000,
+          });
+        } else {
+          await agencyDataStore.fetchAgencyData(
+            parseInt(agencyId),
+            slug as string
+          );
+          setLoading(false);
+        }
       } catch (error) {
         navigate("/404");
         showToast({
-          message: `No agency found with path /${slug}.`,
+          message: `No agency found with path ${agencyId}/${slug}.`,
           color: "red",
           timeout: 4000,
         });
       }
-    }, [slug]);
+    }, [agencyId, slug]);
 
     if (loading) {
       return <Loading />;

--- a/agency-dashboard/src/stores/AgencyDataStore.ts
+++ b/agency-dashboard/src/stores/AgencyDataStore.ts
@@ -196,13 +196,16 @@ class AgencyDataStore {
     return result;
   }
 
-  async fetchAgencyData(agencySlug: string): Promise<void | Error> {
+  async fetchAgencyData(
+    agencyId: number,
+    agencySlug: string
+  ): Promise<void | Error> {
     try {
       runInAction(() => {
         this.loading = true;
       });
       const response = (await API.request({
-        path: `/api/v2/agencies/${encodeURIComponent(
+        path: `/api/agencies/${agencyId}/${encodeURIComponent(
           agencySlug
         )}/published_data`,
         method: "GET",

--- a/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
+++ b/publisher/src/components/HelpCenter/LinkToPublisherDashboard.tsx
@@ -49,7 +49,7 @@ export const LinkToDashboard: React.FC<
 
   if (!agencyName) return <>{children}</>;
 
-  const url = generateDashboardURL(api.environment, agencyName);
+  const url = generateDashboardURL(api.environment, agencyId, agencyName);
 
   return (
     <a href={url} target="_blank" rel="noreferrer noopener">
@@ -60,8 +60,9 @@ export const LinkToDashboard: React.FC<
 
 export const generateDashboardURL = (
   env: string | undefined,
+  agencyId: string | undefined,
   agencyName: string | undefined
 ) =>
   `https://dashboard-${
     env !== "production" ? "staging" : "demo"
-  }.justice-counts.org/agency/${encodeURI(agencyName || "")}`;
+  }.justice-counts.org/agency/${agencyId}/${encodeURI(agencyName || "")}`;

--- a/publisher/src/components/Menu/Menu.tsx
+++ b/publisher/src/components/Menu/Menu.tsx
@@ -137,7 +137,7 @@ const Menu: React.FC = () => {
             label: "Agency Dashboard",
             onClick: () =>
               window.open(
-                generateDashboardURL(api.environment, agencyName),
+                generateDashboardURL(api.environment, agencyId, agencyName),
                 "_blank"
               ),
           },


### PR DESCRIPTION
## Description of the change

This change is a prerequisite for supporting non-unique agency names. The agency dashboard URLS (and the respective queries to the BE) assume that all agencies have unique names. I update the URLs so that they include the agency IDs, which enables the BE to query by agency ID. This way, agencies can have the same name but distinct dashboard URLs. 

The following video is from me playtesting this branch with my [BE branch](https://github.com/Recidiviz/recidiviz-data/pull/28705)! 

https://github.com/Recidiviz/justice-counts/assets/19961693/e51151a4-155f-44b3-b50f-131716325b3a


## Related issues

Closes #1284 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
