### PR TITLE
[Agency Dashboard][Bug] Fix linking to Category Overview page

### DIFF
--- a/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
+++ b/agency-dashboard/src/AgencyOverview/AgencyOverview.tsx
@@ -65,6 +65,7 @@ export const AgencyOverview = observer(() => {
   const { slug } = useParams();
   const { agencyDataStore } = useStore();
   const {
+    agency,
     agencyName,
     agencyDescription,
     agencyHomepageUrl,
@@ -91,8 +92,8 @@ export const AgencyOverview = observer(() => {
     category: string,
     currSystem: string | undefined
   ) => {
-    if (isClickable) {
-      navigate(`/agency/${slug}/${slugify(category)}`, {
+    if (isClickable && agency?.id) {
+      navigate(`/agency/${agency.id}/${slug}/${slugify(category)}`, {
         state: { currentSystem: currSystem },
       });
     }


### PR DESCRIPTION
## Description of the change

Fix linking to Category Overview page from an agency's main dashboard page by including the agency `id` in the path.

Tested by running locally against staging env and ensuring linking to the Category Overview page works as intended.

Main vs this branch:

https://github.com/Recidiviz/justice-counts/assets/59492998/750fee9a-c075-4632-9a38-6eacea40960f



## Related issues

Closes #XXXX

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
