### PR TITLE
[Publisher][Bug] Set Up Metrics Overview Page: Fix grouping of action required, available, and unavailable for supervision agencies with subpopulations

### DIFF
--- a/common/utils/helperUtils.ts
+++ b/common/utils/helperUtils.ts
@@ -23,8 +23,8 @@ export const slugify = (str: string): string =>
   str?.replace(/\s/g, "-")?.toLowerCase();
 
 export const frequencyString = (frequency?: string) => {
-  if (frequency === "ANNUAL") {
-    return "ANNUALLY";
+  if (frequency?.includes("ANNUAL")) {
+    return frequency.replaceAll("ANNUAL", "ANNUALLY");
   }
   return frequency;
 };

--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
@@ -82,6 +82,40 @@ export const MetricsOverview = observer(() => {
 
   const metricsByCurrentSystem = getMetricsBySystem(currentSystem);
 
+  const getMetricFrequency = (metric: MetricInfo) => {
+    if (
+      !(hasSupervisionSubsystems && metric.disaggregatedBySupervisionSubsystems)
+    ) {
+      return metric.customFrequency || metric.defaultFrequency;
+    }
+
+    const firstEnabledSupervisionSubsystem = agencySupervisionSubsystems?.find(
+      (subsystem) => {
+        const replacedSystemMetricKey = replaceSystemMetricKeyWithNewSystem(
+          `SUPERVISION-${metric.key}`,
+          subsystem
+        );
+        return metrics[replacedSystemMetricKey].enabled;
+      }
+    );
+
+    const firstEnabledSupervisionSubsystemMetricKey =
+      firstEnabledSupervisionSubsystem &&
+      replaceSystemMetricKeyWithNewSystem(
+        `SUPERVISION-${metric.key}`,
+        firstEnabledSupervisionSubsystem
+      );
+    const firstEnabledSupervisionSubsystemMetric =
+      firstEnabledSupervisionSubsystemMetricKey
+        ? metrics[firstEnabledSupervisionSubsystemMetricKey]
+        : {};
+
+    return (
+      firstEnabledSupervisionSubsystemMetric.customFrequency ||
+      firstEnabledSupervisionSubsystemMetric.defaultFrequency
+    );
+  };
+
   const hasSupervisionSubsystemWithEnabledStatus = (
     status: boolean | null,
     metricKey: string | undefined
@@ -263,7 +297,7 @@ export const MetricsOverview = observer(() => {
                       {metric.label}
                       <span>
                         {frequencyString(
-                          metric.customFrequency || metric.defaultFrequency
+                          getMetricFrequency(metric)
                         )?.toLowerCase()}
                       </span>
                     </Styled.MetricItemName>

--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
@@ -123,8 +123,8 @@ export const MetricsOverview = observer(() => {
   };
 
   /**
-   * Returns a boolean that indicates whether or not a supervision subsystem's metric's
-   * enabled status matches the `status` argument provided to the function
+   * Returns a boolean that indicates whether or not a supervision agency has a
+   * subsystem metric with an enabled status matching the `status` argument provided
    */
   const hasSupervisionSubsystemWithEnabledStatus = (
     status: boolean | null,

--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
@@ -96,7 +96,7 @@ export const MetricsOverview = observer(() => {
 
     /**
      * For supervision agencies w/ subsystems and disaggregated metrics, we find all
-     * enabled subsystems and return a list of them by subsystem
+     * enabled subsystems and return a list of their frequency and subsystem name.
      */
     const supervisionSubsystemMetricFrequencies =
       agencySupervisionSubsystems?.reduce((acc, subsystem) => {

--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
@@ -152,10 +152,10 @@ export const MetricsOverview = observer(() => {
         return acc;
       },
       {
-        actionRequiredMetrics: [] as MetricInfo[],
-        availableMetrics: [] as MetricInfo[],
-        unavailableMetrics: [] as MetricInfo[],
-      }
+        actionRequiredMetrics: [],
+        availableMetrics: [],
+        unavailableMetrics: [],
+      } as { [key: string]: MetricInfo[] }
     ) ?? {};
 
   const hasActionRequiredMetrics =

--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
@@ -83,12 +83,17 @@ export const MetricsOverview = observer(() => {
   const metricsByCurrentSystem = getMetricsBySystem(currentSystem);
 
   const getMetricFrequency = (metric: MetricInfo) => {
+    // Default frequencies (custom or default) for agencies without supervision subsystems
     if (
       !(hasSupervisionSubsystems && metric.disaggregatedBySupervisionSubsystems)
     ) {
       return metric.customFrequency || metric.defaultFrequency;
     }
 
+    /**
+     * For supervision agencies w/ subsystems and disaggregated metrics, we find the first
+     * enabled subsystem and use its custom/default frequency.
+     */
     const firstEnabledSupervisionSubsystem = agencySupervisionSubsystems?.find(
       (subsystem) => {
         const replacedSystemMetricKey = replaceSystemMetricKeyWithNewSystem(
@@ -155,7 +160,7 @@ export const MetricsOverview = observer(() => {
         }
 
         /**
-         * For supervision agencies w/ subsystems w/ disaggregated metrics, we need to do
+         * For supervision agencies w/ subsystems and disaggregated metrics, we need to do
          * an extra check of all of the subsystems' metric enabled status.
          *
          * `actionRequiredMetrics` will include the metrics if at least one subsystem has the metric as `null` (untouched)

--- a/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricsOverview.tsx
@@ -82,6 +82,7 @@ export const MetricsOverview = observer(() => {
 
   const metricsByCurrentSystem = getMetricsBySystem(currentSystem);
 
+  // Returns a given metric frequency accounting for supervision agencies disaggregated by subsystems
   const getMetricFrequency = (metric: MetricInfo) => {
     // Default frequencies (custom or default) for agencies without supervision subsystems
     if (
@@ -92,7 +93,7 @@ export const MetricsOverview = observer(() => {
 
     /**
      * For supervision agencies w/ subsystems and disaggregated metrics, we find the first
-     * enabled subsystem and use its custom/default frequency.
+     * enabled subsystem and use its custom/default frequency
      */
     const firstEnabledSupervisionSubsystem = agencySupervisionSubsystems?.find(
       (subsystem) => {
@@ -121,12 +122,16 @@ export const MetricsOverview = observer(() => {
     );
   };
 
+  /**
+   * Returns a boolean that indicates whether or not a supervision subsystem's metric's
+   * enabled status matches the `status` argument provided to the function
+   */
   const hasSupervisionSubsystemWithEnabledStatus = (
     status: boolean | null,
     metricKey: string | undefined
   ) => {
     if (!metricKey) return undefined;
-    return agencySupervisionSubsystems?.find((subsystem) => {
+    return !!agencySupervisionSubsystems?.find((subsystem) => {
       const replacedSystemMetricKey = replaceSystemMetricKeyWithNewSystem(
         `SUPERVISION-${metricKey}`,
         subsystem

--- a/publisher/src/components/MetricsConfiguration/types.ts
+++ b/publisher/src/components/MetricsConfiguration/types.ts
@@ -48,6 +48,7 @@ export type MetricSettings = {
 };
 
 export type MetricInfo = {
+  key?: string;
   enabled?: boolean | null;
   label?: string;
   description?: Metric["description"];

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -25,7 +25,6 @@ import {
   MetricContext,
   MetricDisaggregationDimensions,
   MetricDisaggregations,
-  ReportFrequency,
 } from "@justice-counts/common/types";
 import { makeAutoObservable, runInAction } from "mobx";
 
@@ -184,13 +183,7 @@ class MetricConfigStore {
         },
         [] as {
           key: string;
-          metric: {
-            enabled?: boolean | null;
-            label?: string;
-            description?: Metric["description"];
-            defaultFrequency?: ReportFrequency;
-            customFrequency?: Metric["custom_frequency"];
-          };
+          metric: MetricInfo;
         }[]
       );
 

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -176,15 +176,12 @@ class MetricConfigStore {
             MetricConfigStore.splitSystemMetricKey(systemMetricKey);
 
           if (system.toLowerCase() === systemName.toLowerCase()) {
-            filteredMetrics.push({ key: metricKey, metric });
+            filteredMetrics.push({ key: metricKey, ...metric });
           }
 
           return filteredMetrics;
         },
-        [] as {
-          key: string;
-          metric: MetricInfo;
-        }[]
+        [] as MetricInfo[]
       );
 
       return metrics;


### PR DESCRIPTION
## Description of the change

Fix grouping of action required, available, and unavailable for supervision agencies with subpopulations.

There's an issue in the Set Up Metric's overview page for supervision agencies w/ metrics disaggregated by subpopulations, where they end up in the "Unavailable Metrics" grouping despite the disaggregated metrics being marked as available. Since we've collapsed the Supervision + Subpopulations into one view, the reason the disaggregated metrics are showing up under "Unavailable Metrics" is due to the overview page only referring to the Supervision (Combined) metric (which is naturally disabled when a metric is disaggregated).

This change will do a couple of things in the overview page:
1. If there is a supervision agency metric that's disaggregated by subpopulations, then we'll group things as follows:
   - If there is at least one subpopulation where the metric is enabled, the metric will be grouped under "Available Metrics"
   - If there are no subpopulations where the metric is enabled (aka all subpopulations have the metric marked as Not Available), the metric will be grouped under "Unavailable Metrics"
   - For untouched metrics (we won't run into this case since disaggregating a metric enables the subpopulations) - we can check if there's at least one subpopulation that is untouched, and group the metric under "Action Required"

2. Fix the display of the metric frequency for metrics that are disaggregated to use the first enabled subpopulation metric frequency (open to other thoughts)

    - I noticed that the overview page had inconsistent frequencies for these disaggregated metrics - either they don't show at all or only shows the Combined metric's frequency (despite that Combined metric being disabled)

Here's a preview of the current issue:

https://github.com/Recidiviz/justice-counts/assets/59492998/bb0cc48a-de7d-48c9-bc30-c21a34338808

Here's a preview with the current changes:

https://github.com/Recidiviz/justice-counts/assets/59492998/858e986e-396c-4c3b-a291-3d2bc412586a


How I manually tested:
* Ran this branch against staging
* Ensured the current flow for non-supervision agencies or supervision agencies with no subpopulations was unaffected by picking 5 agencies - one with no supervision system, another supervision w/ no subpopulations, and the rest were supervision agencies with 1 or more subpopulations
* I adjusted the frequencies for all agencies and ensured the overview page displayed the affected metrics under the correct groupings and that the display frequency for disaggregated metric was showing as described above (item 2).

## Related issues

Closes #1323 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
