### PR TITLE
[Justice Counts] Replace curly with straight apostrophe in agency name

### DIFF
--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -511,7 +511,7 @@ class AdminPanelStore {
       | User
       | UserWithAgenciesByID
       | AgencyWithTeamByID
-      | AgencyTeamMember,
+      | AgencyTeamMember
   >(list: T[], order: "ascending" | "descending" = "ascending"): T[] {
     return list.sort((a, b) => {
       if (order === "descending") {
@@ -556,7 +556,7 @@ class AdminPanelStore {
       | Agency
       | AgencyWithTeamByID
       | UserWithAgenciesByID
-      | AgencyTeamMember,
+      | AgencyTeamMember
   >(obj: Record<string, T[]>) {
     return AdminPanelStore.sortListByName(
       Object.values(obj).flatMap((item) => item)

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -394,7 +394,10 @@ class AdminPanelStore {
   }
 
   saveAgencyName(name: string) {
-    this.agencyProvisioningUpdates.name = name.trim().replaceAll(/\s+/gi, " ");
+    this.agencyProvisioningUpdates.name = name
+      .trim()
+      .replaceAll(/\s+/gi, " ")
+      .replaceAll("’", "'");
   }
 
   updateStateCode(stateCode: StateCodeKey | null) {
@@ -508,7 +511,7 @@ class AdminPanelStore {
       | User
       | UserWithAgenciesByID
       | AgencyWithTeamByID
-      | AgencyTeamMember
+      | AgencyTeamMember,
   >(list: T[], order: "ascending" | "descending" = "ascending"): T[] {
     return list.sort((a, b) => {
       if (order === "descending") {
@@ -553,7 +556,7 @@ class AdminPanelStore {
       | Agency
       | AgencyWithTeamByID
       | UserWithAgenciesByID
-      | AgencyTeamMember
+      | AgencyTeamMember,
   >(obj: Record<string, T[]>) {
     return AdminPanelStore.sortListByName(
       Object.values(obj).flatMap((item) => item)


### PR DESCRIPTION
## Description of the change

Replace curly apostrophes (`’`) with straight apostrophes (`'`) in agency names upon creation/editing in the admin panel.

#### How I Tested
I created a new agency that contained curly apostrophes within the agency name. The agency was properly saved in the database with straight apostrophes. I also attempted to edit the agency name and add in a curly apostrophe. I confirmed that this was saved with the expected straight apostrophe.

<img width="876" alt="Screenshot 2024-05-13 at 4 07 14 PM" src="https://github.com/Recidiviz/justice-counts/assets/82831800/b495a2a0-9c3f-4c94-bd58-7d0eb3932d5f">

<img width="877" alt="Screenshot 2024-05-13 at 4 07 49 PM" src="https://github.com/Recidiviz/justice-counts/assets/82831800/b6488d2f-009b-455a-8f43-78f821649f5c">


## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Related to #28872

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
