### PR TITLE
[Publisher][Bug] Remove additional context logic from FormStore and DataEntryFormComponents

### DIFF
--- a/publisher/src/components/Reports/DataEntryForm.test.tsx
+++ b/publisher/src/components/Reports/DataEntryForm.test.tsx
@@ -223,25 +223,3 @@ test("expect negative number value to add field error (formErrors should contain
     rootStore.formStore.metricsValues[0].PROSECUTION_STAFF.error?.message
   ).toBe("Please enter a valid number.");
 });
-
-test("expect empty value in metric field to add field error when there is a value in other fields such as contexts", async () => {
-  render(
-    <StoreProvider>
-      <MemoryRouter initialEntries={[`/agency/0/${REPORTS_LOWERCASE}/0`]}>
-        <Routes>
-          <Route
-            path={`/agency/:agencyId/${REPORTS_LOWERCASE}/:id`}
-            element={<ReportDataEntry />}
-          />
-        </Routes>
-      </MemoryRouter>
-    </StoreProvider>
-  );
-
-  const labels = await screen.findAllByLabelText("Total Staff");
-  fireEvent.change(labels[0], { target: { value: "" } });
-
-  expect(
-    rootStore.formStore.metricsValues[0].PROSECUTION_STAFF.error?.message
-  ).toBe("You are also required to enter a value for this field.");
-});

--- a/publisher/src/components/Reports/DataEntryFormComponents.tsx
+++ b/publisher/src/components/Reports/DataEntryFormComponents.tsx
@@ -18,7 +18,6 @@
 import { Input } from "@justice-counts/common/components/Input";
 import {
   Metric,
-  MetricContext,
   MetricDisaggregationDimensions,
   MetricDisaggregations,
 } from "@justice-counts/common/types";
@@ -154,71 +153,6 @@ export const DisaggregationDimensionTextInput = observer(
           tooltipLinkLabel: "Settings",
           tooltipLink: () => navigate(`/agency/${agencyId}/metric-config`),
         }}
-      />
-    );
-  }
-);
-
-interface AdditionalContextInputsProps extends MetricTextInputProps {
-  context: MetricContext;
-  contextIndex: number;
-}
-
-export const AdditionalContextInput = observer(
-  ({
-    reportID,
-    metric,
-    context,
-    contextIndex,
-    disabled,
-    updateFieldDescription,
-    clearFieldDescription,
-  }: AdditionalContextInputsProps) => {
-    const { formStore } = useStore();
-    const { contexts, updateContextValue } = formStore;
-    const getContextValue = () => {
-      if (
-        contexts?.[reportID]?.[metric.key]?.[context.key]?.value !== undefined
-      ) {
-        return context.type === "NUMBER"
-          ? formatNumberInput(
-              contexts[reportID]?.[metric.key][context.key].value
-            )
-          : contexts[reportID]?.[metric.key][context.key].value;
-      }
-
-      return metric.contexts[contextIndex].value?.toString() || "";
-    };
-    const contextValue = getContextValue();
-
-    const handleContextChange = (
-      e: React.ChangeEvent<HTMLTextAreaElement | HTMLInputElement>
-    ) =>
-      updateContextValue(
-        reportID,
-        metric.key,
-        context.key,
-        e.target.value,
-        context.required,
-        context.type,
-        metric.enabled
-      );
-
-    return (
-      <Input
-        type="text"
-        metricKey={metric.key}
-        name={context.key}
-        id={context.key}
-        label="Type here..."
-        onChange={handleContextChange}
-        value={contextValue}
-        multiline={context.type === "TEXT"}
-        error={contexts?.[reportID]?.[metric.key]?.[context.key]?.error}
-        required={context.required}
-        onFocus={updateFieldDescription}
-        onBlur={clearFieldDescription}
-        disabled={disabled}
       />
     );
   }

--- a/publisher/src/stores/FormStore.test.tsx
+++ b/publisher/src/stores/FormStore.test.tsx
@@ -137,31 +137,13 @@ test("disaggregation dimension value handler updates the disaggregation dimensio
   expect.hasAssertions();
 });
 
-test("context value handler updates the context value", () => {
-  formStore.updateContextValue(
-    0,
-    "PROSECUTION_STAFF",
-    "PROGRAMMATIC_OR_MEDICAL_STAFF",
-    "100",
-    false,
-    "NUMBER",
-    true
-  );
-
-  expect(
-    formStore.contexts[0].PROSECUTION_STAFF.PROGRAMMATIC_OR_MEDICAL_STAFF.value
-  ).toEqual("100");
-
-  expect.hasAssertions();
-});
-
 test("updatedReportValues maps all updated (and not updated) input values into required data structure", () => {
   expect(JSON.stringify(formStore.reportUpdatedValuesForBackend(0))).toEqual(
     JSON.stringify([
       {
         key: "PROSECUTION_STAFF",
         value: 2000,
-        contexts: [{ key: "PROGRAMMATIC_OR_MEDICAL_STAFF", value: 100 }],
+        contexts: [],
         disaggregations: [
           {
             key: "PROSECUTION_STAFF_TYPE",


### PR DESCRIPTION
## Description of the change

Remove additional context logic from FormStore and DataEntryFormComponents as contexts are no longer handled by the record page.

There was a bug reported in staging for agency 11 where opening up a monthly record resulted in a crash. The crash was a result of the record page validation of previously saved inputs attempting to delete an error on the `metricsValues` object (in the FormStore - this object keeps track of the metric values and error state for each metric value) for a metric that did not exist in this object.

How is this happening? 
I'm not entirely sure when this happened or if it's always been this way, but it appears that when you add a value to the additional context field in the Metric Settings definition for a top-level metric, save it, and then delete the value and save it (so an empty string is saved) -- the empty string slips through this check here, and gets unnecessarily validated through `this.updateContextValue`:

https://github.com/Recidiviz/justice-counts/blob/c7bea896e57415e894b3a31a6fa8a5bc75ded3db/publisher/src/stores/FormStore.ts#L87-L88

It's still unclear whether this bug was here the entire time, or whether there was a relatively recent change in how empty string contexts are saved and later retrieved from the BE. But, I think the right move here would be to avoid running unnecessary logic for contexts in the FormStore and record page all together because they are not used in any way on the record page as they now live within the Metric Settings definitions and are handled by the `MetricConfigStore`.

Steps to repro:
1. Switch to the commit before the temporary fix via `git switch e695ea5cda6c015e5982f86853cbd579b74e061c --detach`
2. Choose any agency in staging
3. Go to Metric Settings and choose an available metric (or make one available)
4. Update the top-level metric definition by adding text in the additional context box, then save
5. Go back to the same metric definition and delete everything in the additional context box, then save
6. Find a record with matching frequency as the metric you just edited
7. Observe the unglamorous crash, with the following similar message in the console: `TypeError: Cannot read properties of undefined (reading 'SUPERVISION_FUNDING') at updateFieldErrorMessage (FormStore.ts:341:1)`

I tested this using the agencies in our playbook, going through the repro steps and ensuring there are no issues in the record page, going through and adding data to the records, reloading, and publishing, and really any areas that involve the FormStore.

## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Closes Recidiviz/recidiviz-data#28666

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
