### PR TITLE
[Publisher][Bug] Fix metric definitions display for agencies with supervision + other non-supervision sectors

### DIFF
--- a/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
@@ -19,6 +19,7 @@ import { Dropdown } from "@justice-counts/common/components/Dropdown";
 import { Tooltip } from "@justice-counts/common/components/Tooltip";
 import {
   AgencySystem,
+  AgencySystems,
   MetricConfigurationSettings,
   SupervisionSubsystems,
 } from "@justice-counts/common/types";
@@ -80,10 +81,13 @@ function MetricDefinitions() {
         : settingsSearchParams.system
     );
 
-  const activeSystemMetricKey = replaceSystemMetricKeyWithNewSystem(
-    systemMetricKey,
-    selectedSupervisionSubsystem as AgencySystem
-  );
+  const activeSystemMetricKey =
+    settingsSearchParams.system === AgencySystems.SUPERVISION
+      ? replaceSystemMetricKeyWithNewSystem(
+          systemMetricKey,
+          selectedSupervisionSubsystem as AgencySystem
+        )
+      : systemMetricKey;
   const activeDisaggregationKeys =
     disaggregations[activeSystemMetricKey] &&
     Object.keys(disaggregations[activeSystemMetricKey]);

--- a/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
@@ -102,12 +102,9 @@ function MetricDefinitions() {
     if (!metricDefinitionSettings[activeSystemMetricKey]) return true;
     const metricSettings = Object.values(
       metricDefinitionSettings[activeSystemMetricKey]
-    ).reduce(
-      (acc, metricSetting) => {
-        return { ...acc, ...metricSetting.settings };
-      },
-      {} as { [settingKey: string]: Partial<MetricConfigurationSettings> }
-    );
+    ).reduce((acc, metricSetting) => {
+      return { ...acc, ...metricSetting.settings };
+    }, {} as { [settingKey: string]: Partial<MetricConfigurationSettings> });
     /** Top-level metric context key will always be "INCLUDES_EXCLUDES_DESCRIPTION" */
     const hasContextValue = Boolean(
       contexts[activeSystemMetricKey].INCLUDES_EXCLUDES_DESCRIPTION.value

--- a/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricDefinitions.tsx
@@ -74,18 +74,23 @@ function MetricDefinitions() {
   const [activeDimensionKey, setActiveDimensionKey] = useState<
     string | undefined
   >(undefined);
-  const [selectedSupervisionSubsystem, setSelectedSupervisionSubsystem] =
+  const [selectedSupervisionOrSubsystem, setSelectedSupervisionOrSubsystem] =
     useState(
       agencySupervisionSubsystems && agencySupervisionSubsystems.length > 0
         ? agencySupervisionSubsystems[0]
         : settingsSearchParams.system
     );
 
+  /**
+   * For non-supervision systems, the `activeSystemMetricKey` will match the `systemMetricKey`.
+   * For supervision systems, the `activeSystemMetricKey` will either be the supervision system-metric key
+   * if the metric is combined or a supervision subsystem system-metric key if the metric is disaggregated.
+   */
   const activeSystemMetricKey =
     settingsSearchParams.system === AgencySystems.SUPERVISION
       ? replaceSystemMetricKeyWithNewSystem(
           systemMetricKey,
-          selectedSupervisionSubsystem as AgencySystem
+          selectedSupervisionOrSubsystem as AgencySystem
         )
       : systemMetricKey;
   const activeDisaggregationKeys =
@@ -97,9 +102,12 @@ function MetricDefinitions() {
     if (!metricDefinitionSettings[activeSystemMetricKey]) return true;
     const metricSettings = Object.values(
       metricDefinitionSettings[activeSystemMetricKey]
-    ).reduce((acc, metricSetting) => {
-      return { ...acc, ...metricSetting.settings };
-    }, {} as { [settingKey: string]: Partial<MetricConfigurationSettings> });
+    ).reduce(
+      (acc, metricSetting) => {
+        return { ...acc, ...metricSetting.settings };
+      },
+      {} as { [settingKey: string]: Partial<MetricConfigurationSettings> }
+    );
     /** Top-level metric context key will always be "INCLUDES_EXCLUDES_DESCRIPTION" */
     const hasContextValue = Boolean(
       contexts[activeSystemMetricKey].INCLUDES_EXCLUDES_DESCRIPTION.value
@@ -117,8 +125,8 @@ function MetricDefinitions() {
       return {
         key: system,
         label: removeSnakeCase(system.toLocaleLowerCase()),
-        onClick: () => setSelectedSupervisionSubsystem(system),
-        highlight: selectedSupervisionSubsystem === system,
+        onClick: () => setSelectedSupervisionOrSubsystem(system),
+        highlight: selectedSupervisionOrSubsystem === system,
       };
     }) || []),
   ];
@@ -148,10 +156,10 @@ function MetricDefinitions() {
               <MetricAvailability.DropdownV2Container>
                 <Dropdown
                   label={
-                    selectedSupervisionSubsystem === "SUPERVISION"
+                    selectedSupervisionOrSubsystem === "SUPERVISION"
                       ? "Supervision (Combined)"
                       : removeSnakeCase(
-                          selectedSupervisionSubsystem?.toLocaleLowerCase() ||
+                          selectedSupervisionOrSubsystem?.toLocaleLowerCase() ||
                             ""
                         )
                   }


### PR DESCRIPTION
## Description of the change

Fix metric definitions display for agencies with supervision + other non-supervision sectors with similar metrics (e.g. Funding, Staff, etc.) that are disaggregated by subpopulation in the supervision sector.

Huge shout out to @lilidworkin's playbook, as I stumbled into this while testing another PR going through the various agencies. 

This one is super sneaky... If you are in an agency that has, for example, Law Enforcement & Supervision sectors - both of which have a Funding metric - and within the Supervision sector, you disaggregate the Funding metric by subpopulations; when you look at the Funding metric's definitions within the Law Enforcement sector, you'll unfortunately see the list of definitions for the first disaggregated supervision subpopulation, and NOT the list of Law Enforcement Funding metric definitions. This only affects multi-sector agencies w/ a supervision sector w/ subpopulations and with similar metrics that are disaggregated in the supervision sector.

This change adds a check for the active system before determining which system-metric key to use. I think originally when I worked on this, I must've mistakenly assumed that if you were in a different sector that checks like `agencySupervisionSubsystems` would come up empty, but this is not true because it's scanning all the sectors belonging to an agency and will always come up if an agency has a supervision agency w/ subsectors.

Before: 
![Screenshot 2024-05-30 at 10 52 28 AM](https://github.com/Recidiviz/justice-counts/assets/59492998/c786bee4-b777-4ed6-adad-c1d28af505a9)

After:
![Screenshot 2024-05-30 at 11 05 28 AM](https://github.com/Recidiviz/justice-counts/assets/59492998/63ba5aad-24f1-4549-9701-a0c95100d9e9)

## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Closes #1350 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
