### PR TITLE
Exclude @babel packages from dependabot auto-merge

### DIFF
--- a/.github/workflows/auto-merge-dependabot.yml
+++ b/.github/workflows/auto-merge-dependabot.yml
@@ -15,14 +15,30 @@ jobs:
         uses: dependabot/fetch-metadata@v1
         with:
           github-token: "${{ secrets.HELPERBOT_TOKEN }}"
+      - name: Check if auto-merge is allowed
+        id: check-auto-merge
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch' &&
+          steps.metadata.outputs.dependency-names != ''
+        run: |
+          echo "Dependencies:"
+          echo "${{ steps.metadata.outputs.dependency-names }}"
+          if echo "${{ steps.metadata.outputs.dependency-names }}" | grep -q 'babel'; then
+            echo "@babel packages found. Skipping auto-merge."
+            echo "::set-output name=allow_auto_merge::false"
+          else
+            echo "No babel packages found. Continuing auto-merge."
+            echo "::set-output name=allow_auto_merge::true"
+          fi
       - name: Auto-approve for Dependabot PRs
-        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        if: steps.check-auto-merge.outputs.allow_auto_merge == 'true'
         run: gh pr review --approve -b "@Recidiviz/justice-counts - HelperBot is automatically approving this Dependabot PR since it is a patch or minor version update." "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
           GITHUB_TOKEN: ${{secrets.HELPERBOT_TOKEN}}
       - name: Enable auto-merge for Dependabot PRs
-        if: steps.metadata.outputs.update-type == 'version-update:semver-minor' || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        if: steps.check-auto-merge.outputs.allow_auto_merge == 'true'
         run: gh pr merge --auto --squash "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}


### PR DESCRIPTION
## Description of the change

Exclude @babel packages from dependabot auto-merge. 

This one is tough to test because `uses: dependabot/fetch-metadata@v1` will throw an error if the PR's author is not `dependabot`. So, I passed in a string in lieu of `steps.metadata.outputs.dependency-names` with a comma separated list of dependency names - just to test the `if` and `grep` logic - and it properly skipped the auto-merge steps.

![Screenshot 2024-06-11 at 5 08 04 PM](https://github.com/Recidiviz/justice-counts/assets/59492998/d881f859-41bb-47a5-bec2-6fc539106d9e)


It won't hurt anything if this doesn't work, so I'm open to trying it and waiting for a dependabot `babel` package, if folks are OK with that. I've searched high and low for a way to simulate or manually trigger a dependabot package upgrade PR, to no reasonable avail (there was a discussion of a potential way to trigger it via an endpoint, but it didn't seem worth diving into that rabbit hole for this 😄).

Update: there is a way to have it check for updates, but not target a specific package. I'm going to try this after this is merged in and hope for a `babel` package.

![Screenshot 2024-06-11 at 5 22 58 PM](https://github.com/Recidiviz/justice-counts/assets/59492998/716f4cca-6716-4782-91a4-d7923bceb26d)


## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Closes #1377

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
