### PR TITLE
[Publisher] refetch agencies every time that they are edited in the admin panel

### DIFF
--- a/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/AgencyProvisioning.tsx
@@ -310,7 +310,10 @@ export const AgencyProvisioning: React.FC<ProvisioningProps> = observer(
       }
 
       /** Refetch when changes are made to superagency or child agencies so all related agencies are updated */
-      const shouldRefetch = hasSuperagencyUpdate || hasChildAgencyUpdates;
+      const shouldRefetch =
+        hasSuperagencyUpdate ||
+        hasChildAgencyUpdates ||
+        hasTeamMemberOrRoleUpdates;
       const response = await saveAgencyProvisioningUpdates(shouldRefetch);
 
       setShowSaveConfirmation({

--- a/publisher/src/components/AdminPanel/UserProvisioning.tsx
+++ b/publisher/src/components/AdminPanel/UserProvisioning.tsx
@@ -231,7 +231,11 @@ export const UserProvisioning: React.FC<ProvisioningProps> = observer(
           (id) => !deletedAgenciesIDs.has(id)
         ),
       ]);
-      const response = await adminPanelStore.saveUserProvisioningUpdates();
+
+      const shouldRefetch = hasAgencyUpdates;
+      const response = await adminPanelStore.saveUserProvisioningUpdates(
+        shouldRefetch
+      );
 
       setShowSaveConfirmation({
         show: true,

--- a/publisher/src/stores/AdminPanelStore.ts
+++ b/publisher/src/stores/AdminPanelStore.ts
@@ -331,7 +331,7 @@ class AdminPanelStore {
     this.usersByID[user.id] = [userWithGroupedAgencies];
   }
 
-  async saveUserProvisioningUpdates() {
+  async saveUserProvisioningUpdates(refetch?: boolean) {
     try {
       const response = (await this.api.request({
         path: `/admin/user`,
@@ -347,6 +347,11 @@ class AdminPanelStore {
           this.updateUsers(userResponse as UserResponse);
           this.setCreatedUserResponse(userResponse as UserResponse);
         });
+
+        if (refetch) {
+          await this.fetchUsersAndAgencies();
+        }
+
         return response;
       }
 


### PR DESCRIPTION
## Description of the change

This update updates the front-end functionality to refetch agency data after any updates to an agency via the admin panel. This ensures that any changes made to a super agency are accurately reflected in its child agencies ([BE PR](https://github.com/Recidiviz/recidiviz-data/pull/31147/files)).


https://github.com/Recidiviz/justice-counts/assets/19961693/2c566fbf-fd13-4f5b-bb18-17ba491c552b



### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
