### PR TITLE
[Publisher] Allow users to select starting month when creating an annual record

### DIFF
--- a/publisher/src/components/Reports/CreateReport.styled.tsx
+++ b/publisher/src/components/Reports/CreateReport.styled.tsx
@@ -17,7 +17,10 @@
 
 import {
   CustomDropdown,
+  CustomDropdownMenu,
+  CustomDropdownMenuItem,
   CustomDropdownToggle,
+  CustomDropdownToggleLabel,
 } from "@justice-counts/common/components/Dropdown";
 import {
   palette,
@@ -69,15 +72,36 @@ export const DropdownsWrapper = styled.div`
 
 export const DropdownContainer = styled.div`
   width: 100%;
+  display: flex;
+  flex: 1 1 0;
+  border-radius: 3px;
 
   & ${CustomDropdown} {
-    border-bottom: 1px solid ${palette.highlight.lightblue2};
+    border: 1px solid ${palette.highlight.grey4};
     border-radius: 3px;
-    background-color: ${palette.highlight.lightblue1};
   }
 
   & ${CustomDropdownToggle} {
-    padding: 9px 14px;
+    padding: 8px 16px;
+  }
+
+  & ${CustomDropdownToggleLabel} {
+    ${typography.body}
+    text-transform: capitalize;
+    gap: 8px;
+  }
+
+  & ${CustomDropdownMenu} {
+    max-height: calc(55px * 4);
+    box-shadow: none;
+    border: 1px solid ${palette.highlight.grey4};
+    margin-top: 8px;
+  }
+
+  & ${CustomDropdownMenuItem} {
+    ${typography.body}
+    border: none;
+    padding: 12px 16px;
   }
 `;
 

--- a/publisher/src/components/Reports/CreateReport.tsx
+++ b/publisher/src/components/Reports/CreateReport.tsx
@@ -166,6 +166,9 @@ const CreateReport = () => {
     })
   );
 
+  /** These options are for choosing the ending month in a custom annual frequency
+   * December and June are being filtered out because they represent the ending month of Calendar and Fiscal Year
+   */
   const customMonthOptions: DropdownOption[] = monthsByName
     .filter((monthName) => !["December", "June"].includes(monthName))
     .map((monthName) => {
@@ -325,6 +328,7 @@ const CreateReport = () => {
                   defaultChecked={annualStartMonth === 7}
                   buttonSize="large"
                 />
+                {/* Non-calendar year selections reference the ending month and year */}
                 <RadioButton
                   type="radio"
                   id="custom-year"

--- a/publisher/src/components/Reports/CreateReport.tsx
+++ b/publisher/src/components/Reports/CreateReport.tsx
@@ -169,7 +169,7 @@ const CreateReport = () => {
   const customMonthOptions: DropdownOption[] = monthsByName
     .filter((monthName) => !["January", "July"].includes(monthName))
     .map((monthName) => {
-      const monthNumber = monthsByName.indexOf(monthName) + 1;
+      const monthNumber = monthsByName.indexOf(monthName) + 2;
       return {
         key: monthName,
         label: monthName,
@@ -332,7 +332,13 @@ const CreateReport = () => {
                   label="Other"
                   value={2}
                   defaultChecked={annualStartingMonthNotJanuaryJuly}
-                  onChange={updateYearStandard}
+                  onChange={(e) =>
+                    setCreateReportFormValues((prev) => ({
+                      ...prev,
+                      annualStartMonth: (+e.target.value +
+                        1) as CreateReportFormValuesType["annualStartMonth"],
+                    }))
+                  }
                   buttonSize="large"
                 />
               </RadioButtonsWrapper>
@@ -382,7 +388,7 @@ const CreateReport = () => {
                 {annualStartingMonthNotJanuaryJuly && (
                   <Styled.DropdownContainer>
                     <Dropdown
-                      label={monthsByName[annualStartMonth - 1]}
+                      label={monthsByName[annualStartMonth - 2]}
                       options={customMonthOptions}
                       hover="background"
                       caretPosition="right"

--- a/publisher/src/components/Reports/CreateReport.tsx
+++ b/publisher/src/components/Reports/CreateReport.tsx
@@ -167,7 +167,7 @@ const CreateReport = () => {
   );
 
   const customMonthOptions: DropdownOption[] = monthsByName
-    .filter((monthName) => !["January", "July"].includes(monthName))
+    .filter((monthName) => !["December", "June"].includes(monthName))
     .map((monthName) => {
       const monthNumber = monthsByName.indexOf(monthName) + 2;
       return {
@@ -330,7 +330,7 @@ const CreateReport = () => {
                   id="custom-year"
                   name="yearStandard"
                   label="Other"
-                  value={2}
+                  value={1}
                   defaultChecked={annualStartingMonthNotJanuaryJuly}
                   onChange={(e) =>
                     setCreateReportFormValues((prev) => ({

--- a/publisher/src/components/Reports/CreateReport.tsx
+++ b/publisher/src/components/Reports/CreateReport.tsx
@@ -166,6 +166,22 @@ const CreateReport = () => {
     })
   );
 
+  const customMonthOptions: DropdownOption[] = monthsByName
+    .filter((monthName) => !["January", "July"].includes(monthName))
+    .map((monthName) => {
+      const monthNumber = monthsByName.indexOf(monthName) + 1;
+      return {
+        key: monthName,
+        label: monthName,
+        onClick: () =>
+          setCreateReportFormValues((prev) => ({
+            ...prev,
+            annualStartMonth: monthNumber,
+          })),
+        highlight: monthNumber === annualStartMonth,
+      };
+    });
+
   const yearsOptions: DropdownOption[] = createIntegerRange(
     1970,
     new Date().getFullYear() + 1
@@ -199,6 +215,12 @@ const CreateReport = () => {
     }
     return year;
   };
+
+  const annualStartingMonthNotJanuaryJuly =
+    frequency === "ANNUAL" &&
+    annualStartMonth !== null &&
+    annualStartMonth !== 1 &&
+    annualStartMonth !== 7;
 
   if (userStore.isUserReadOnly(agencyId))
     return <Navigate to={`/agency/${agencyId}/${REPORTS_LOWERCASE}`} />;
@@ -303,6 +325,16 @@ const CreateReport = () => {
                   defaultChecked={annualStartMonth === 7}
                   buttonSize="large"
                 />
+                <RadioButton
+                  type="radio"
+                  id="custom-year"
+                  name="yearStandard"
+                  label="Other"
+                  value={2}
+                  defaultChecked={annualStartingMonthNotJanuaryJuly}
+                  onChange={updateYearStandard}
+                  buttonSize="large"
+                />
               </RadioButtonsWrapper>
             </>
           )}
@@ -340,6 +372,18 @@ const CreateReport = () => {
                     <Dropdown
                       label={monthsByName[month - 1]}
                       options={monthsOptions}
+                      hover="background"
+                      caretPosition="right"
+                      fullWidth
+                    />
+                  </Styled.DropdownContainer>
+                )}
+
+                {annualStartingMonthNotJanuaryJuly && (
+                  <Styled.DropdownContainer>
+                    <Dropdown
+                      label={monthsByName[annualStartMonth - 1]}
+                      options={customMonthOptions}
                       hover="background"
                       caretPosition="right"
                       fullWidth

--- a/publisher/src/utils/dateUtils.ts
+++ b/publisher/src/utils/dateUtils.ts
@@ -149,11 +149,14 @@ export const printDateRangeFromMonthYear = (
     return `${currentMonth} 1, ${year} - ${currentMonth} ${lastDayOfMonth}, ${year}`;
   }
 
+  const currentYear = month === 1 ? year : year + 1;
   const currentMonth = monthsByName[month - 1];
   const prevMonthNumber = month === 1 ? 12 : month - 1;
   const prevMonth = monthsByName[prevMonthNumber - 1];
-  const lastDayOfPrevMonth = new Date(year, prevMonthNumber, 0)?.getDate();
-  return `${currentMonth} 1, ${year} - ${prevMonth} ${lastDayOfPrevMonth}, ${
-    month === 1 ? year : year + 1
-  }`;
+  const lastDayOfPrevMonth = new Date(
+    currentYear,
+    prevMonthNumber,
+    0
+  )?.getDate();
+  return `${currentMonth} 1, ${year} - ${prevMonth} ${lastDayOfPrevMonth}, ${currentYear}`;
 };


### PR DESCRIPTION
## Description of the change

This change allows users to select starting month when creating an annual record and also updates dropdowns styling.

## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

closes #1379 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
