### PR TITLE
[Publisher] Fix Download Data downloading blank CSVs in Explore Data page

### DIFF
--- a/common/utils/downloadHelpers.ts
+++ b/common/utils/downloadHelpers.ts
@@ -22,8 +22,8 @@ export const downloadFeedData = async (
   system: string,
   agencyId: number | string,
   filename: string,
-  filenameWithAgencyName: string,
-  isPublic: boolean
+  isPublic: boolean,
+  filenameWithAgencyName?: string
 ) => {
   const a = document.createElement("a");
   let url = `/feed/${agencyId}?system=${system}&metric=${filename}`;
@@ -37,7 +37,7 @@ export const downloadFeedData = async (
     url = `/api${url}`;
   }
   a.href = url;
-  a.setAttribute("download", `${filenameWithAgencyName}.csv`);
+  a.setAttribute("download", `${filenameWithAgencyName ?? filename}.csv`);
   a.click();
   a.remove();
 };
@@ -58,8 +58,8 @@ export const downloadMetricData = (
         metric.system.key,
         agencyId,
         fileName,
-        filenameWithAgencyName,
-        isPublic
+        isPublic,
+        filenameWithAgencyName
       );
     });
   }

--- a/common/utils/downloadHelpers.ts
+++ b/common/utils/downloadHelpers.ts
@@ -52,7 +52,7 @@ export const downloadMetricData = (
     metric.filenames.forEach((fileName) => {
       const filenameWithAgencyName = agencyName
         ? `${fileName}_${snakeCase(agencyName)}`
-        : fileName;
+        : undefined;
 
       downloadFeedData(
         metric.system.key,

--- a/common/utils/downloadHelpers.ts
+++ b/common/utils/downloadHelpers.ts
@@ -22,6 +22,7 @@ export const downloadFeedData = async (
   system: string,
   agencyId: number | string,
   filename: string,
+  filenameWithAgencyName: string,
   isPublic: boolean
 ) => {
   const a = document.createElement("a");
@@ -36,7 +37,7 @@ export const downloadFeedData = async (
     url = `/api${url}`;
   }
   a.href = url;
-  a.setAttribute("download", `${filename}.csv`);
+  a.setAttribute("download", `${filenameWithAgencyName}.csv`);
   a.click();
   a.remove();
 };
@@ -56,6 +57,7 @@ export const downloadMetricData = (
       downloadFeedData(
         metric.system.key,
         agencyId,
+        fileName,
         filenameWithAgencyName,
         isPublic
       );


### PR DESCRIPTION
## Description of the change

Excluded `filenameWithAgencyName` from url in `downloadFeedData`

## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

closes #1435 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
