### PR TITLE
[Agency Dashboard] Remove slug from published data url for agency dashboards

### DIFF
--- a/agency-dashboard/src/Protected/Protected.tsx
+++ b/agency-dashboard/src/Protected/Protected.tsx
@@ -30,7 +30,7 @@ export const Protected: React.FC<PropsWithChildren> = observer(
   ({ children }) => {
     const navigate = useNavigate();
     const { agencyDataStore, api } = useStore();
-    const { agencyId, slug } = useParams();
+    const { agencyId } = useParams();
     const isProductionEnv = api.environment === environment.PRODUCTION;
     const isDenied =
       (agencyDataStore.agency &&
@@ -48,21 +48,18 @@ export const Protected: React.FC<PropsWithChildren> = observer(
             timeout: 4000,
           });
         } else {
-          await agencyDataStore.fetchAgencyData(
-            parseInt(agencyId),
-            slug as string
-          );
+          await agencyDataStore.fetchAgencyData(parseInt(agencyId));
           setLoading(false);
         }
       } catch (error) {
         navigate("/404");
         showToast({
-          message: `No agency found with path ${agencyId}/${slug}.`,
+          message: `No agency found with path ${agencyId}.`,
           color: "red",
           timeout: 4000,
         });
       }
-    }, [agencyId, slug]);
+    }, [agencyId]);
 
     if (loading) {
       return <Loading />;

--- a/agency-dashboard/src/stores/AgencyDataStore.ts
+++ b/agency-dashboard/src/stores/AgencyDataStore.ts
@@ -196,18 +196,13 @@ class AgencyDataStore {
     return result;
   }
 
-  async fetchAgencyData(
-    agencyId: number,
-    agencySlug: string
-  ): Promise<void | Error> {
+  async fetchAgencyData(agencyId: number): Promise<void | Error> {
     try {
       runInAction(() => {
         this.loading = true;
       });
       const response = (await API.request({
-        path: `/api/agencies/${agencyId}/${encodeURIComponent(
-          agencySlug
-        )}/published_data`,
+        path: `/api/agencies/${agencyId}/published_data`,
         method: "GET",
       })) as Response;
       if (response.status === 200) {


### PR DESCRIPTION
## Description of the change

Updates URL for published_data so that the FE an correctly fetch data to render the dashboard pages. I tested this manually by deploying the changes to staging with the BE changes and visiting the dashboard for various agencies. 

## Related issues

Closes #1444

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
