### PR TITLE
[Bug Bash][Common] Fix react/no-unstable-nested-components lint errors 

### DIFF
--- a/common/components/DataViz/BarChart.tsx
+++ b/common/components/DataViz/BarChart.tsx
@@ -114,6 +114,15 @@ const ResponsiveBarChart = forwardRef<never, ResponsiveBarChartProps>(
           height: 500,
         };
 
+    const renderCustomYAxisTick = (props: TickProps) => (
+      <CustomYAxisTick
+        y={props.y}
+        payload={props.payload}
+        percentageView={!!percentageView}
+        styles={tickStyle}
+      />
+    );
+
     return (
       <ChartContainer>
         <ResponsiveContainer {...responsiveContainerProps}>
@@ -157,16 +166,7 @@ const ResponsiveBarChart = forwardRef<never, ResponsiveBarChartProps>(
             />
             <YAxis
               allowDecimals={percentageView}
-              // TODO(#803): Fix lint error and remove the `eslint-disable-next-line`
-              // eslint-disable-next-line react/no-unstable-nested-components
-              tick={(props: TickProps) => (
-                <CustomYAxisTick
-                  y={props.y}
-                  payload={props.payload}
-                  percentageView={!!percentageView}
-                  styles={tickStyle}
-                />
-              )}
+              tick={renderCustomYAxisTick}
               tickLine={false}
               tickCount={percentageView ? 5 : 12}
               domain={percentageView ? ["dataMin", "dataMax"] : undefined}

--- a/common/components/DataViz/MetricsCategoryBarChart.tsx
+++ b/common/components/DataViz/MetricsCategoryBarChart.tsx
@@ -102,6 +102,18 @@ const MetricsCategoryBarChart = forwardRef<never, ResponsiveBarChartProps>(
       );
       return barDefinitions;
     };
+
+    const renderCustomYAxisTick = (props: TickProps) => (
+      <CustomYAxisTick
+        y={props.y}
+        payload={props.payload}
+        percentageView={false}
+        styles={tickStyle}
+        metric={metric}
+        rightAligned
+      />
+    );
+
     return (
       <>
         <ResponsiveContainer width={width} height="100%">
@@ -142,17 +154,7 @@ const MetricsCategoryBarChart = forwardRef<never, ResponsiveBarChartProps>(
             />
             {data.length !== 0 && (
               <YAxis
-                // eslint-disable-next-line react/no-unstable-nested-components
-                tick={(props: TickProps) => (
-                  <CustomYAxisTick
-                    y={props.y}
-                    payload={props.payload}
-                    percentageView={false}
-                    styles={tickStyle}
-                    metric={metric}
-                    rightAligned
-                  />
-                )}
+                tick={renderCustomYAxisTick}
                 tickLine={false}
                 tickCount={5}
                 axisLine={false}


### PR DESCRIPTION
## Description of the change

Fix react/no-unstable-nested-components (Do not define components during render...) lint errors by defining the `CustomYAxisTick` component outside of the main component render.

## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Closes #803 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
