### PR TITLE
[Publisher] Remove Disabled Metric Message and Show Warning in Alerts When Showing Supervision Sheet Errors

### DIFF
--- a/publisher/src/components/DataUpload/DataUpload.tsx
+++ b/publisher/src/components/DataUpload/DataUpload.tsx
@@ -171,7 +171,10 @@ export const DataUpload: React.FC = observer(() => {
       });
 
       /** Errors and/or Warnings Encountered During Upload -- Show Interstitial instead of Confirmation Page */
-      const errorsWarningsAndMetrics = processUploadResponseBody(data);
+      const errorsWarningsAndMetrics = processUploadResponseBody(
+        data,
+        currentAgency
+      );
       const hasErrorsOrWarnings =
         (errorsWarningsAndMetrics.nonMetricErrors &&
           errorsWarningsAndMetrics.nonMetricErrors.length > 0) ||

--- a/publisher/src/components/DataUpload/ShareUploadErrorWarnings.tsx
+++ b/publisher/src/components/DataUpload/ShareUploadErrorWarnings.tsx
@@ -85,7 +85,10 @@ function ShareUploadErrorWarnings() {
           updatedReports: result.updated_reports || [],
           unchangedReports: result.unchanged_reports || [],
         });
-        const errorsWarningsAndMetrics = processUploadResponseBody(result);
+        const errorsWarningsAndMetrics = processUploadResponseBody(
+          result,
+          currentAgency
+        );
         const hasErrorsOrWarnings =
           (errorsWarningsAndMetrics.nonMetricErrors &&
             errorsWarningsAndMetrics.nonMetricErrors.length > 0) ||
@@ -99,7 +102,7 @@ function ShareUploadErrorWarnings() {
       }
     };
     initialize();
-  }, [reportStore, spreadsheetId]);
+  }, [reportStore, spreadsheetId, currentAgency]);
 
   if (reportStore.loadingSpreadsheetReviewData) {
     return (


### PR DESCRIPTION
## Description of the change

When testing out the new WorkbookStandardizer code, I noticed a message that reads `This metric is disabled. If you would like to enable it, visit the Metric Configuration page.` for supervision metrics. Though this may be true, the Supervision Combined metric is disabled because the agency is reporting by supervision sub-system, it's confusing because there are still sheet errors that the user needs to address. We cannot group these errors by supervision subsystem because they are sheet wide and none of the data can be ingested.

<img width="985" alt="Screenshot 2024-09-03 at 1 14 57 PM" src="https://github.com/user-attachments/assets/3cc3ed23-08f8-4ba7-bdee-c171f5122c23">

 I've added some logic to remove that message when displaying sheet metrics for supervision uploads _if there are errors._ 
 
<img width="933" alt="Screenshot 2024-09-03 at 1 14 03 PM" src="https://github.com/user-attachments/assets/ee962a94-5ed8-4e3f-a81f-5c37d77d4eba">

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
