### PR TITLE
[Publisher] Don't filter out 0 values in `Review Data` page

### DIFF
--- a/publisher/src/components/DataUpload/SpreadsheetReview.tsx
+++ b/publisher/src/components/DataUpload/SpreadsheetReview.tsx
@@ -127,7 +127,7 @@ export function SpreadsheetReview({
   ) => {
     const allDatapoints = metrics
       .flatMap((metric) => metric.datapoints)
-      .filter((dp) => dp.value);
+      .filter((dp) => dp.value || dp.value === 0); // Filter out null values
     const datapointsByMetricNameByAgencyName = allDatapoints.reduce(
       (acc, dp) => {
         if (!dp.agency_name || !dp.metric_display_name) return acc;

--- a/publisher/src/stores/ReportStore.ts
+++ b/publisher/src/stores/ReportStore.ts
@@ -302,7 +302,7 @@ class ReportStore {
 
       const filteredDatapoints =
         combinedFilteredDatapointsFromAllReports.filter(
-          (dp) => dp.value !== null
+          (dp) => dp.value || dp.value === 0 // Filter out null values
         );
 
       const datapointsByMetric =


### PR DESCRIPTION
## Description of the change

**Context**: Matt reported that when uploading 0 values in a sheet via Bulk Upload, these values were not displayed on the Review Data page. Instead, the system acted as if no data had been supplied. 

BEFORE
![image](https://github.com/user-attachments/assets/fe161276-1035-430c-b019-9e3c889b16ca)

**Investigation**: After investigating, I confirmed that while the backend correctly saved the 0 values, the frontend was filtering them out. The frontend logic treated 0 values as if they were missing or undefined, leading to them being excluded from display.

**Fix**: I updated the frontend filtering logic to ensure that only undefined values are filtered out. This allows 0 values to be displayed properly on the Review Data page, as they are valid data points. I tested locally by creating the super/ child agencies in my local environment and tested with the sheet Matt supplied. 

AFTER
<img width="1667" alt="Screenshot 2024-09-16 at 8 01 52 PM" src="https://github.com/user-attachments/assets/506ded8a-bb31-4dd4-b952-39096fbc480d">

@mxosman  I didn't realize that this was already assigned to Ilya! It was a quick fix and I wanted to confirm that it wasn't a result of my refactor changes so I went and knocked it out. 

## Related issues

Closes #1499

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [x] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
