### PR TITLE
[Publisher] Require completion of free text description when enabling "Other" breakdown

### DIFF
--- a/common/components/CheckboxOptions/CheckboxOptions.tsx
+++ b/common/components/CheckboxOptions/CheckboxOptions.tsx
@@ -25,6 +25,8 @@ export type CheckboxOption = {
   checked: boolean;
   disabled?: boolean;
   icon?: string | React.ReactNode;
+  isOtherOption?: boolean;
+  onChangeOtherOption?: () => void;
   onChangeOverride?: () => void;
 };
 
@@ -42,17 +44,29 @@ export const CheckboxOptions: React.FC<CheckboxOptionsProps> = ({
   return (
     <Styled.CheckboxContainer>
       {options.map(
-        ({ key, label, checked, disabled, icon, onChangeOverride }) => (
+        ({
+          key,
+          label,
+          checked,
+          disabled,
+          icon,
+          isOtherOption,
+          onChangeOtherOption,
+          onChangeOverride,
+        }) => (
           <Styled.CheckboxOptionsWrapper key={key}>
             <Styled.Checkbox
               id={key}
               type="checkbox"
               checked={checked}
-              onChange={() =>
-                onChangeOverride
+              onChange={() => {
+                if (isOtherOption && onChangeOtherOption) {
+                  return onChangeOtherOption();
+                }
+                return onChangeOverride
                   ? onChangeOverride()
-                  : onChange({ key, checked })
-              }
+                  : onChange({ key, checked });
+              }}
               disabled={disabled}
             />
             <Styled.CheckboxLabel>

--- a/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
+++ b/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
@@ -67,6 +67,7 @@ function DefinitionModalForm({
     updateContextValue,
     updateMetricIncludesExcludesConfigurationStatus,
     updateDimensionIncludesExcludesConfigurationStatus,
+    updateDimensionEnabledStatus,
   } = metricConfigStore;
 
   // read only check
@@ -392,6 +393,19 @@ function DefinitionModalForm({
     ? metrics[systemMetricKey]?.description
     : currentDimension?.description;
 
+  const handleOtherDimensionUpdate = () => {
+    if (activeDisaggregationKey && activeDimensionKey?.includes("Other")) {
+      const updatedSetting = updateDimensionEnabledStatus(
+        systemSearchParam,
+        metricSearchParam,
+        activeDisaggregationKey,
+        activeDimensionKey,
+        !!currentContexts.ADDITIONAL_CONTEXT.value
+      );
+      saveMetricSettings(updatedSetting, agencyId);
+    }
+  };
+
   return (
     <Styled.Wrapper>
       <Styled.Content>
@@ -513,6 +527,7 @@ function DefinitionModalForm({
               label="Save"
               onClick={() => {
                 handleSaveSettings();
+                handleOtherDimensionUpdate();
                 closeModal();
               }}
               buttonColor="blue"

--- a/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
+++ b/publisher/src/components/MetricsConfiguration/MetricAvailability.tsx
@@ -49,6 +49,7 @@ import {
 } from "../Settings";
 import { ConfigurationStatusButton } from "./ConfigurationStatusButton";
 import { RACE_ETHNICITY_DISAGGREGATION_KEY } from "./constants";
+import DefinitionModalForm from "./DefinitionModalForm";
 import * as Styled from "./MetricAvailability.styled";
 import { RaceEthnicitiesGrid } from "./RaceEthnicitiesGrid";
 import { ReportFrequencyUpdate } from "./types";
@@ -82,9 +83,12 @@ function MetricAvailability({
   } = metricConfigStore;
   const [activeDisaggregationKey, setActiveDisaggregationKey] =
     useState<string>();
+  const [activeDimensionKey, setActiveDimensionKey] = useState<string>();
   // For when a user selects "Other" for Starting Month and has made no dropdown selection
   const [showCustomYearDropdownOverride, setShowCustomYearDropdownOverride] =
     useState<boolean>();
+
+  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false);
 
   const isReadOnly = userStore.isUserReadOnly(agencyId);
   const systemMetricKey = getActiveSystemMetricKey(settingsSearchParams);
@@ -639,6 +643,15 @@ function MetricAvailability({
         </Styled.SettingsContainer>
 
         {/* Metric Breakdowns */}
+        {isSettingsModalOpen && (
+          // This modal only opens if we check/uncheck "other" breakdown
+          <DefinitionModalForm
+            activeDisaggregationKey={activeDisaggregationKey}
+            activeDimensionKey={activeDimensionKey}
+            closeModal={() => setIsSettingsModalOpen(false)}
+            systemMetricKey={systemMetricKey}
+          />
+        )}
         {hasDisaggregations && (
           <Styled.BreakdownsSection disabled={false}>
             <Styled.BreakdownsSectionTitle>
@@ -732,11 +745,24 @@ function MetricAvailability({
                         <CheckboxOptions
                           options={[
                             ...Object.values(currentDimensions).map(
-                              (dimension) => ({
-                                key: dimension.key as string,
-                                label: dimension.label as string,
-                                checked: Boolean(dimension.enabled),
-                              })
+                              (dimension) => {
+                                const isOtherDimension =
+                                  dimension.key?.includes("Other");
+
+                                return {
+                                  key: dimension.key as string,
+                                  label: dimension.label as string,
+                                  checked: Boolean(dimension.enabled),
+                                  isOtherOption: isOtherDimension,
+                                  onChangeOtherOption: () => {
+                                    setActiveDisaggregationKey(
+                                      disaggregationKey
+                                    );
+                                    setActiveDimensionKey(dimension.key);
+                                    setIsSettingsModalOpen(true);
+                                  },
+                                };
+                              }
                             ),
                             {
                               key: "select-all",


### PR DESCRIPTION
## Description of the change

Require "Other" breakdown description in order to enable it

## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

closes #1426 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
