### PR TITLE
[Publisher][Metric Settings] Update metric definitions to support radio input

### DIFF
--- a/common/components/CheckboxOptions/CheckboxOptions.tsx
+++ b/common/components/CheckboxOptions/CheckboxOptions.tsx
@@ -49,20 +49,9 @@ export const CheckboxOptions: React.FC<CheckboxOptionsProps> = ({
   options,
   onChange,
 }) => {
-  const [radioKey, setRadioKey] = useState<string>("");
   const [otherDescriptionValue, setOtherDescriptionValue] = useState<
     string | null
   >(null);
-
-  const handleChange = (key: string, checked: boolean) => {
-    if (multiselect) {
-      onChange({ key, checked });
-    } else {
-      const newKey = radioKey !== key ? key : "";
-      setRadioKey(newKey);
-      onChange({ key: newKey, checked: true });
-    }
-  };
 
   return (
     <Styled.CheckboxContainer>
@@ -81,11 +70,11 @@ export const CheckboxOptions: React.FC<CheckboxOptionsProps> = ({
               <Styled.Checkbox
                 id={key}
                 type={multiselect ? "checkbox" : "radio"}
-                checked={multiselect || !radioKey ? checked : radioKey === key}
+                checked={checked}
                 onChange={() =>
                   onChangeOverride
                     ? onChangeOverride()
-                    : handleChange(key, checked)
+                    : onChange({ key, checked })
                 }
                 disabled={disabled}
               />

--- a/common/components/CheckboxOptions/CheckboxOptions.tsx
+++ b/common/components/CheckboxOptions/CheckboxOptions.tsx
@@ -39,17 +39,30 @@ export type CheckboxOption = {
 export type CheckboxOnChangeParams = { key: string; checked: boolean };
 
 export type CheckboxOptionsProps = {
+  multiselect?: boolean;
   options: CheckboxOption[];
   onChange: (onChangeParams: CheckboxOnChangeParams) => void;
 };
 
 export const CheckboxOptions: React.FC<CheckboxOptionsProps> = ({
+  multiselect = true,
   options,
   onChange,
 }) => {
+  const [radioKey, setRadioKey] = useState<string>("");
   const [otherDescriptionValue, setOtherDescriptionValue] = useState<
     string | null
   >(null);
+
+  const handleChange = (key: string, checked: boolean) => {
+    if (multiselect) {
+      onChange({ key, checked });
+    } else {
+      const newKey = radioKey !== key ? key : "";
+      setRadioKey(newKey);
+      onChange({ key: newKey, checked: true });
+    }
+  };
 
   return (
     <Styled.CheckboxContainer>
@@ -67,12 +80,12 @@ export const CheckboxOptions: React.FC<CheckboxOptionsProps> = ({
             <Styled.CheckboxOptionsWrapper>
               <Styled.Checkbox
                 id={key}
-                type="checkbox"
-                checked={checked}
+                type={multiselect ? "checkbox" : "radio"}
+                checked={multiselect || !radioKey ? checked : radioKey === key}
                 onChange={() =>
                   onChangeOverride
                     ? onChangeOverride()
-                    : onChange({ key, checked })
+                    : handleChange(key, checked)
                 }
                 disabled={disabled}
               />

--- a/common/types.ts
+++ b/common/types.ts
@@ -220,6 +220,7 @@ export interface Metric {
 }
 
 export interface MetricIncludesExcludes {
+  multiselect: boolean;
   description: string;
   settings: MetricConfigurationSettings[];
 }

--- a/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
+++ b/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
@@ -164,17 +164,18 @@ function DefinitionModalForm({
   // handlers
   const handleChooseDefaults = () => {
     const defaultSettings = Object.entries(currentSettings).reduce(
-      (acc, [includesExcludesKey, { settings }]) => {
+      (acc, [includesExcludesKey, { multiselect, settings }]) => {
         return {
           ...acc,
           [includesExcludesKey]: {
+            multiselect,
             settings: Object.entries(settings).reduce(
               (innerAcc, [settingKey, setting]) => {
                 return {
                   ...innerAcc,
                   [settingKey]: {
                     ...setting,
-                    included: setting.default,
+                    included: multiselect ? setting.default : "No",
                   },
                 };
               },
@@ -193,25 +194,46 @@ function DefinitionModalForm({
 
   const handleChangeDefinitionIncluded = (
     includesExcludesKey: string,
-    settingKey: string
+    settingKey: string,
+    multiselect?: boolean
   ) => {
-    setCurrentSettings({
-      ...currentSettings,
-      [includesExcludesKey]: {
-        ...currentSettings[includesExcludesKey],
-        settings: {
-          ...currentSettings[includesExcludesKey].settings,
-          [settingKey]: {
-            ...currentSettings[includesExcludesKey].settings[settingKey],
-            included:
-              currentSettings[includesExcludesKey].settings[settingKey]
-                .included === "Yes"
-                ? "No"
-                : "Yes",
+    if (!multiselect) {
+      setCurrentSettings({
+        ...currentSettings,
+        [includesExcludesKey]: {
+          ...currentSettings[includesExcludesKey],
+          settings: Object.fromEntries(
+            Object.entries(currentSettings[includesExcludesKey].settings).map(
+              ([key, setting]) => [
+                key,
+                {
+                  ...setting,
+                  included: key === settingKey ? "Yes" : "No",
+                },
+              ]
+            )
+          ),
+        },
+      });
+    } else {
+      setCurrentSettings({
+        ...currentSettings,
+        [includesExcludesKey]: {
+          ...currentSettings[includesExcludesKey],
+          settings: {
+            ...currentSettings[includesExcludesKey].settings,
+            [settingKey]: {
+              ...currentSettings[includesExcludesKey].settings[settingKey],
+              included:
+                currentSettings[includesExcludesKey].settings[settingKey]
+                  .included === "Yes"
+                  ? "No"
+                  : "Yes",
+            },
           },
         },
-      },
-    });
+      });
+    }
   };
 
   const handleContextValueChange = (
@@ -470,6 +492,7 @@ function DefinitionModalForm({
                           includesExcludesKey}
                       </p>
                       <CheckboxOptions
+                        multiselect={value.multiselect}
                         options={Object.entries(value.settings).map(
                           ([settingKey, setting]) => {
                             return {
@@ -482,7 +505,8 @@ function DefinitionModalForm({
                         onChange={({ key }) =>
                           handleChangeDefinitionIncluded(
                             includesExcludesKey,
-                            key
+                            key,
+                            value.multiselect
                           )
                         }
                       />

--- a/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
+++ b/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
@@ -175,7 +175,7 @@ function DefinitionModalForm({
                   ...innerAcc,
                   [settingKey]: {
                     ...setting,
-                    included: multiselect ? setting.default : "No",
+                    included: setting.default,
                   },
                 };
               },

--- a/publisher/src/components/MetricsConfiguration/types.ts
+++ b/publisher/src/components/MetricsConfiguration/types.ts
@@ -68,6 +68,7 @@ export type ReportFrequencyUpdate = {
 
 export type SettingsByIncludesExcludesKey = {
   [includesExcludesKey: string]: {
+    multiselect: boolean;
     description?: string;
     settings: {
       [settingKey: string]: Partial<MetricConfigurationSettings>;

--- a/publisher/src/mocks/HomeMocksHelpers.ts
+++ b/publisher/src/mocks/HomeMocksHelpers.ts
@@ -334,6 +334,7 @@ export const LAW_ENFORCEMENT_LATEST_RECORDS_METRICS: LatestRecordsAgencyMetrics 
         frequency: "MONTHLY",
         includes_excludes: [
           {
+            multiselect: true,
             description: "",
             settings: [],
           },
@@ -377,6 +378,7 @@ export const LAW_ENFORCEMENT_LATEST_RECORDS_METRICS: LatestRecordsAgencyMetrics 
         frequency: "ANNUAL",
         includes_excludes: [
           {
+            multiselect: true,
             description: "",
             settings: [],
           },
@@ -420,6 +422,7 @@ export const LAW_ENFORCEMENT_LATEST_RECORDS_METRICS: LatestRecordsAgencyMetrics 
         frequency: "ANNUAL",
         includes_excludes: [
           {
+            multiselect: true,
             description: "",
             settings: [],
           },

--- a/publisher/src/stores/MetricConfigStore.tsx
+++ b/publisher/src/stores/MetricConfigStore.tsx
@@ -61,6 +61,7 @@ class MetricConfigStore {
   metricDefinitionSettings: {
     [systemMetricKey: string]: {
       [includesExcludesKey: string]: {
+        multiselect: boolean;
         description?: string;
         settings: {
           [settingKey: string]: Partial<MetricConfigurationSettings>;
@@ -122,6 +123,7 @@ class MetricConfigStore {
       [disaggregationKey: string]: {
         [dimensionKey: string]: {
           [includesExcludesKey: string]: {
+            multiselect: boolean;
             description?: string;
             settings: {
               [settingKey: string]: Partial<MetricConfigurationSettings>;
@@ -259,6 +261,7 @@ class MetricConfigStore {
             this.initializeMetricDefinitionSetting(
               metric.system.key,
               metric.key,
+              includesExcludes.multiselect,
               includesExcludes.description || "NO_DESCRIPTION",
               includesExcludes.settings
             );
@@ -328,6 +331,7 @@ class MetricConfigStore {
                   metric.key,
                   disaggregation.key,
                   dimension.key,
+                  includesExcludes.multiselect,
                   includesExcludes.description || "NO_DESCRIPTION",
                   includesExcludes.settings
                 );
@@ -368,6 +372,7 @@ class MetricConfigStore {
   initializeMetricDefinitionSetting = (
     system: AgencySystem,
     metricKey: string,
+    multiselect: boolean,
     includesExcludesKey: string,
     metricDefinitionSettings: MetricConfigurationSettings[]
   ) => {
@@ -382,6 +387,7 @@ class MetricConfigStore {
     }
     if (!this.metricDefinitionSettings[systemMetricKey][includesExcludesKey]) {
       this.metricDefinitionSettings[systemMetricKey][includesExcludesKey] = {
+        multiselect,
         description: includesExcludesKey,
         settings: {},
       };
@@ -479,6 +485,7 @@ class MetricConfigStore {
     metricKey: string,
     disaggregationKey: string,
     dimensionKey: string,
+    multiselect: boolean,
     includesExcludesKey: string,
     dimensionDefinitionSettings: MetricConfigurationSettings[]
   ) => {
@@ -512,6 +519,7 @@ class MetricConfigStore {
       this.dimensionDefinitionSettings[systemMetricKey][disaggregationKey][
         dimensionKey
       ][includesExcludesKey] = {
+        multiselect,
         description: includesExcludesKey,
         settings: {},
       };


### PR DESCRIPTION
## Description of the change

Updated metric definitions and checkbox group logic to support radio input

## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

closes #1602 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
