### PR TITLE
[Publisher][Bug] Fix bug where Explore Data page shows first Combined Supervision datapoints when Supervision sector is disaggregated

### DIFF
--- a/publisher/src/components/DataViz/MetricsDataChart.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.tsx
@@ -32,7 +32,6 @@ import {
 } from "@justice-counts/common/components/GlobalStyles";
 import { useWindowWidth } from "@justice-counts/common/hooks";
 import {
-  AgencySystem,
   AgencySystems,
   ReportFrequency,
   SupervisionSubsystems,
@@ -103,7 +102,7 @@ export const MetricsDataChart: React.FC = observer(() => {
   const currentMetric = currentSystem
     ? metricsBySystem[currentSystem]?.find(
         (m) => m.key === (metricSearchParam || enabledMetrics[0]?.key)
-      ) || metricsBySystem[currentSystem]?.[0]
+      ) || enabledMetrics[0]
     : undefined;
   const metricName = currentMetric?.display_name || "";
   const metricFrequency =
@@ -276,11 +275,34 @@ export const MetricsDataChart: React.FC = observer(() => {
               return (
                 <React.Fragment key={system}>
                   {currEnabledMetrics.length > 0 ? (
-                    <Styled.SystemNameContainer isSystemActive>
-                      <Styled.SystemName>
-                        {systemNameOrSystemNameWithSpan}
-                      </Styled.SystemName>
-                    </Styled.SystemNameContainer>
+                    <>
+                      <Styled.SystemNameContainer isSystemActive>
+                        <Styled.SystemName>
+                          {systemNameOrSystemNameWithSpan}
+                        </Styled.SystemName>
+                      </Styled.SystemNameContainer>
+                      <Styled.MetricsItemsContainer
+                        isSystemActive={
+                          system === currentSystem ||
+                          currEnabledMetrics.length > 0
+                        }
+                      >
+                        {currEnabledMetrics.map((metric) => (
+                          <Styled.MetricItem
+                            key={metric.key}
+                            selected={currentMetric.key === metric.key}
+                            onClick={() =>
+                              setSettingsSearchParams({
+                                system: system as AgencySystem,
+                                metric: metric.key,
+                              })
+                            }
+                          >
+                            {metric.display_name}
+                          </Styled.MetricItem>
+                        ))}
+                      </Styled.MetricsItemsContainer>
+                    </>
                   ) : (
                     <Styled.SystemNameContainer isSystemActive>
                       <Styled.SystemName>
@@ -289,27 +311,6 @@ export const MetricsDataChart: React.FC = observer(() => {
                       </Styled.SystemName>
                     </Styled.SystemNameContainer>
                   )}
-
-                  <Styled.MetricsItemsContainer
-                    isSystemActive={
-                      system === currentSystem || currEnabledMetrics.length > 0
-                    }
-                  >
-                    {currEnabledMetrics.map((metric) => (
-                      <Styled.MetricItem
-                        key={metric.key}
-                        selected={currentMetric.key === metric.key}
-                        onClick={() =>
-                          setSettingsSearchParams({
-                            system: system as AgencySystem,
-                            metric: metric.key,
-                          })
-                        }
-                      >
-                        {metric.display_name}
-                      </Styled.MetricItem>
-                    ))}
-                  </Styled.MetricsItemsContainer>
                 </React.Fragment>
               );
             })}

--- a/publisher/src/components/DataViz/MetricsDataChart.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.tsx
@@ -32,6 +32,7 @@ import {
 } from "@justice-counts/common/components/GlobalStyles";
 import { useWindowWidth } from "@justice-counts/common/hooks";
 import {
+  AgencySystem,
   AgencySystems,
   ReportFrequency,
   SupervisionSubsystems,
@@ -214,13 +215,6 @@ export const MetricsDataChart: React.FC = observer(() => {
   if (!systemBelongsToAgency) {
     return <NotFound />;
   }
-  if (isLoading || !currentSystem || !currentMetric) {
-    return <Loading />;
-  }
-  if (loadingError) {
-    return <div>Error: {loadingError}</div>;
-  }
-
   if (enabledMetrics.length === 0) {
     return (
       <Styled.NoEnabledMetricsMessage>
@@ -235,6 +229,12 @@ export const MetricsDataChart: React.FC = observer(() => {
         to enable a metric.
       </Styled.NoEnabledMetricsMessage>
     );
+  }
+  if (isLoading || !currentSystem || !currentMetric) {
+    return <Loading />;
+  }
+  if (loadingError) {
+    return <div>Error: {loadingError}</div>;
   }
 
   return (

--- a/publisher/src/components/DataViz/MetricsDataChart.tsx
+++ b/publisher/src/components/DataViz/MetricsDataChart.tsx
@@ -169,11 +169,11 @@ export const MetricsDataChart: React.FC = observer(() => {
       }
 
       // Initialize the search params with the first enabled system and metric
-      const refreshedEnabledMetrics = Object.values(result)
+      const currentEnabledMetrics = Object.values(result)
         .flatMap((metric) => metric)
         .filter((metric) => metric.enabled);
-      const firstEnabledSystemKey = refreshedEnabledMetrics[0]?.system.key;
-      const firstEnabledMetricKey = refreshedEnabledMetrics[0]?.key;
+      const firstEnabledSystemKey = currentEnabledMetrics[0]?.system.key;
+      const firstEnabledMetricKey = currentEnabledMetrics[0]?.key;
 
       setSettingsSearchParams({
         system: firstEnabledSystemKey,


### PR DESCRIPTION
## Description of the change

Fix bug where Explore Data page shows first Combined Supervision datapoints when Supervision sector is disaggregated. Bug was reported by CSG where an agency that has the Supervision sector disaggregated shows a Supervision Combined Funding metric's datapoints by default when first visiting the Explore Data page. This is caused by the current implementation relying on the `system` param which is `undefined` on load and subsequently gets set as the first agency's system instead of the first system with an enabled metric. 

The change proposed here sets the initial search params after initializing the report settings (our current way to infer the enabled/disabled status of a metric for now), which more accurately displays the charts for the first enabled metric and avoids the issue caused by the assumption that the first system in a user's agency includes an enabled metric. 

This component would benefit greatly from a deeper refactor to avoid future risk of race conditions with how we're retrieving metrics to determine the enabled/disabled status and how we're subsequently setting the search params. For now, this should unblock CSG and consistently produce the expected behavior until we can dedicate more time to exploring a more holistic refactor.

## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

Closes #1629

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
