### PR TITLE
[Publisher] Fix enabled dimension leaking from another sectors

### DIFF
--- a/common/components/DataViz/utils.ts
+++ b/common/components/DataViz/utils.ts
@@ -739,13 +739,15 @@ export const datapointMatchingEnabledDimension = (
   metrics: Metric[]
 ) => {
   if (dp.dimension_display_name) {
-    return metrics.find((metric) =>
-      metric.disaggregations.find((disaggregation) =>
-        disaggregation.dimensions
-          .filter((dimension) => dimension.enabled)
-          .map((dimension) => dimension.key)
-          .includes(dp.dimension_display_name as string)
-      )
+    return metrics.find(
+      (metric) =>
+        dp.metric_definition_key === metric.key &&
+        metric.disaggregations.find((disaggregation) => {
+          return disaggregation.dimensions
+            .filter((dimension) => dimension.enabled)
+            .map((dimension) => dimension.key)
+            .includes(dp.dimension_display_name as string);
+        })
     );
   }
 


### PR DESCRIPTION
## Description of the change

Fixed enabled dimension leaking from another sectors, creating a problem when enabling dimension from sector lead to display the same but disabled dimension from another sector as enabled.

## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

closes #1622 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
