### PR TITLE
[Publisher] Fix "Other" checking and unchecking behavior in Metric Settings

### DIFF
--- a/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
+++ b/publisher/src/components/MetricsConfiguration/DefinitionModalForm.tsx
@@ -419,7 +419,7 @@ function DefinitionModalForm({
     ? metrics[systemMetricKey]?.description
     : currentDimension?.description;
 
-  const handleOtherDimensionUpdate = () => {
+  const handleOtherDimensionUpdate = async () => {
     const otherDimensionKey =
       currentDimensions && getOtherDimensonKey(currentDimensions);
 
@@ -435,12 +435,11 @@ function DefinitionModalForm({
         otherDimensionKey,
         !!currentContexts.ADDITIONAL_CONTEXT.value
       );
-      saveMetricSettings(updatedSetting, agencyId);
+      await saveMetricSettings(updatedSetting, agencyId);
     }
   };
 
   const handleCloseModal = () => {
-    handleOtherDimensionUpdate();
     closeModal();
   };
 
@@ -567,7 +566,8 @@ function DefinitionModalForm({
           {!isReadOnly && !hasNoSettingsAndNoContext && (
             <Button
               label="Save"
-              onClick={() => {
+              onClick={async () => {
+                await handleOtherDimensionUpdate();
                 handleSaveSettings();
                 handleCloseModal();
               }}


### PR DESCRIPTION
## Description of the change

Fixed "Other" checking and unchecking behavior in Metric Settings page

## Type of change

> All pull requests must have at least one of the following labels applied (otherwise the PR will fail):

| Label                       	| Description                                                                                               	|
|-----------------------------	|-----------------------------------------------------------------------------------------------------------	|
| Type: Bug                   	| non-breaking change that fixes an issue                                                                   	|
| Type: Feature               	| non-breaking change that adds functionality                                                               	|
| Type: Breaking Change       	| fix or feature that would cause existing functionality to not work as expected                            	|
| Type: Non-breaking refactor 	| change addresses some tech debt item or prepares for a later change, but does not change functionality    	|
| Type: Configuration Change  	| adjusts configuration to achieve some end related to functionality, development, performance, or security 	|
| Type: Dependency Upgrade      | upgrades a project dependency - these changes are not included in release notes                             |

## Related issues

closes #1621 

## Checklists

### Development

**This box MUST be checked by the submitter prior to merging**:
- [ ] **Double- and triple-checked that there is no Personally Identifiable Information (PII) being mistakenly added in this pull request**

These boxes should be checked by the submitter prior to merging:
- [ ] Tests have been written to cover the code changed/added as part of this pull request

### Code review

These boxes should be checked by reviewers prior to merging:

- [ ] This pull request has a descriptive title and information useful to a reviewer
- [ ] This pull request has been moved out of a Draft state, has no "Work In Progress" label, and has assigned reviewers
- [ ] Potential security implications or infrastructural changes have been considered, if relevant
